### PR TITLE
xnvme_fioe_reset_wp() was resetting one too many zone

### DIFF
--- a/tools/fio-engine/xnvme_fioe.c
+++ b/tools/fio-engine/xnvme_fioe.c
@@ -968,7 +968,7 @@ xnvme_fioe_reset_wp(struct thread_data *td, struct fio_file *f, uint64_t offset,
 	last = (((offset + length) >> ssw) / geo->nsect) * geo->nsect;
 	XNVME_DEBUG("INFO: first: 0x%lx, last: 0x%lx", first, last);
 
-	for (uint64_t zslba = first; zslba <= last; zslba += geo->nsect) {
+	for (uint64_t zslba = first; zslba < last; zslba += geo->nsect) {
 		struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
 
 		if (zslba >= (geo->nsect * geo->nzone)) {


### PR DESCRIPTION
Signed-off-by: Pierre Labat <plabat@micron.com>

The problem is exposed when running fio random write on a zns device via xnvme.
Fio, after a while, fills up a number of zones. Then it starts to reset some zones, one at a time.
When fio reset a zone xnvme_fioe_reset_wp() is called. 
xnvme_fioe_reset_wp() resets 2 zones instead of only one as it should. The next one is also reset.
Later, when fio tries to write in the zone reset by mistake (and without fio being aware of it), the zns device returns a write error because fio thinks the WP is A  (with A > zone start) while on the device it the WP is now zone start. The FIO tests fails.

I tested the fix, and with it, the fio test completes without error.
