### PR TITLE
be,cmd: Hoist the queue-busy-guard from backends into 'xnvme_cmd'

### DIFF
--- a/lib/xnvme_be_linux_async_libaio.c
+++ b/lib/xnvme_be_linux_async_libaio.c
@@ -106,10 +106,6 @@ _linux_libaio_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes, 
 	struct iocb *iocb = (void *)&ctx->cmd;
 	int err;
 
-	if (queue->base.outstanding == queue->base.capacity) {
-		XNVME_DEBUG("FAILED: queue is full");
-		return -EBUSY;
-	}
 	if (mbuf || mbuf_nbytes) {
 		XNVME_DEBUG("FAILED: mbuf or mbuf_nbytes provided");
 		return -ENOSYS;

--- a/lib/xnvme_be_linux_async_liburing.c
+++ b/lib/xnvme_be_linux_async_liburing.c
@@ -204,11 +204,6 @@ xnvme_be_linux_liburing_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbu
 	int opcode = IORING_OP_NOP;
 	int err = 0;
 
-	if (queue->base.outstanding == queue->base.capacity) {
-		XNVME_DEBUG("FAILED: queue is full");
-		return -EBUSY;
-	}
-
 	if (mbuf || mbuf_nbytes) {
 		XNVME_DEBUG("FAILED: mbuf or mbuf_nbytes provided");
 		return -ENOSYS;

--- a/lib/xnvme_be_linux_async_ucmd.c
+++ b/lib/xnvme_be_linux_async_ucmd.c
@@ -148,11 +148,6 @@ xnvme_be_linux_ucmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes
 	struct io_uring_sqe *sqe = NULL;
 	int err = 0;
 
-	if (queue->base.outstanding == queue->base.capacity) {
-		XNVME_DEBUG("FAILED: queue is full");
-		return -EBUSY;
-	}
-
 	if (mbuf || mbuf_nbytes) {
 		XNVME_DEBUG("FAILED: mbuf or mbuf_nbytes provided");
 		return -ENOSYS;

--- a/lib/xnvme_be_posix_async_aio.c
+++ b/lib/xnvme_be_posix_async_aio.c
@@ -142,10 +142,6 @@ _posix_async_aio_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbyte
 	struct aiocb *aiocb;
 	int err;
 
-	if (queue->base.outstanding == queue->base.capacity) {
-		XNVME_DEBUG("FAILED: queue is full");
-		return -EBUSY;
-	}
 	if (mbuf || mbuf_nbytes) {
 		XNVME_DEBUG("FAILED: mbuf or mbuf_nbytes provided");
 		return -ENOSYS;

--- a/lib/xnvme_be_posix_async_emu.c
+++ b/lib/xnvme_be_posix_async_emu.c
@@ -139,11 +139,6 @@ _posix_async_emu_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbyte
 	struct _emu_qp *qp = queue->qp;
 	struct _emu_entry *entry;
 
-	if (queue->base.outstanding == queue->base.capacity) {
-		XNVME_DEBUG("FAILED: queue is full");
-		return -EBUSY;
-	}
-
 	// Grab entry from rp and push into sq
 	entry = STAILQ_FIRST(&qp->rp);
 	if (!entry) {

--- a/lib/xnvme_be_posix_async_nil.c
+++ b/lib/xnvme_be_posix_async_nil.c
@@ -80,11 +80,6 @@ _posix_nil_cmd_io(struct xnvme_cmd_ctx *ctx, void *XNVME_UNUSED(dbuf),
 {
 	struct xnvme_queue_nil *queue = (void *)ctx->async.queue;
 
-	if (queue->base.outstanding == queue->base.capacity) {
-		XNVME_DEBUG("FAILED: queue is full");
-		return -EBUSY;
-	}
-
 	queue->ctx[queue->base.outstanding++] = ctx;
 
 	return 0;

--- a/lib/xnvme_be_posix_async_thrpool.c
+++ b/lib/xnvme_be_posix_async_thrpool.c
@@ -308,11 +308,6 @@ _posix_async_thrpool_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_n
 	struct _thrpool_entry *entry = NULL;
 	int err;
 
-	if (queue->base.outstanding == queue->base.capacity) {
-		XNVME_DEBUG("FAILED: queue is full");
-		return -EBUSY;
-	}
-
 	entry = STAILQ_FIRST(&qp->rp);
 	STAILQ_REMOVE_HEAD(&qp->rp, link);
 

--- a/lib/xnvme_be_spdk_async.c
+++ b/lib/xnvme_be_spdk_async.c
@@ -126,13 +126,6 @@ xnvme_be_spdk_async_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nb
 	int err;
 
 	// TODO: do something with mbuf?
-
-	// Early exit when queue is full
-	if (queue->base.outstanding == queue->base.capacity) {
-		XNVME_DEBUG("FAILED: queue is full");
-		return -EBUSY;
-	}
-
 	queue->base.outstanding += 1;
 	err = submit_ioc(state->ctrlr, queue->qpair, ctx, dbuf, dbuf_nbytes, mbuf, cmd_async_cb,
 			 ctx);

--- a/lib/xnvme_be_windows_async_iocp.c
+++ b/lib/xnvme_be_windows_async_iocp.c
@@ -144,10 +144,6 @@ _windows_async_iocp_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf,
 	uint64_t slba = ctx->cmd.nvm.slba << ssw;
 	bool ret = 0;
 
-	if (queue->base.outstanding == queue->base.capacity) {
-		XNVME_DEBUG("FAILED: queue is full");
-		return -EBUSY;
-	}
 	if (mbuf || mbuf_nbytes) {
 		XNVME_DEBUG("FAILED: mbuf or mbuf_nbytes provided");
 		return -ENOSYS;

--- a/lib/xnvme_be_windows_async_iocp_th.c
+++ b/lib/xnvme_be_windows_async_iocp_th.c
@@ -242,10 +242,6 @@ _windows_async_iocp_th_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf,
 	bool ret;
 	LPOVERLAPPED ovl;
 
-	if (queue->base.outstanding == queue->base.capacity) {
-		XNVME_DEBUG("FAILED: queue is full");
-		return -EBUSY;
-	}
 	if (mbuf || mbuf_nbytes) {
 		XNVME_DEBUG("FAILED: mbuf or mbuf_nbytes provided");
 		return -ENOSYS;

--- a/lib/xnvme_cmd.c
+++ b/lib/xnvme_cmd.c
@@ -6,6 +6,7 @@
 #include <xnvme_cmd.h>
 #include <xnvme_dev.h>
 #include <xnvme_sgl.h>
+#include <xnvme_queue.h>
 
 /**
  * Calling this requires that opts at least has `XNVME_CMD_SGL_DATA`
@@ -94,6 +95,10 @@ xnvme_cmd_pass(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes, void *
 
 	switch (cmd_opts & XNVME_CMD_MASK_IOMD) {
 	case XNVME_CMD_ASYNC:
+		if (ctx->async.queue->base.outstanding == ctx->async.queue->base.capacity) {
+			XNVME_DEBUG("FAILED: queue is fulll err = -EBUSY");
+			return -EBUSY;
+		}
 		return ctx->dev->be.async.cmd_io(ctx, dbuf, dbuf_nbytes, mbuf, mbuf_nbytes);
 
 	case XNVME_CMD_SYNC:


### PR DESCRIPTION
be,cmd: hoist the queue-busy-guard from backends into 'xnvme_cmd'

On the submission-path in every async-backend implementation a 'BUSY'
guard ensures that the backend-implementation would not proceed but
instead exit early and return '-EBUSY'.
Since all the engines do this, then it can conveniently be handled by
the 'xnvme_cmd'-module instead, upon async-submission. This change does
so.

Signed-off-by: Simon A. F. Lund <simon.lund@samsung.com>