### PR TITLE
meson: only do whole-archive in pkg-config when SPDK is enabled

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -123,11 +123,13 @@ xnvmelib_bundle = custom_target(
 # although they currently link "directly" to the regular static library
 xnvmelib_bundle_dep = declare_dependency(
   dependencies: xnvmelib_deps,
-  link_args: [
-    '-Wl,--whole-archive', '-Wl,--no-as-needed',
+  link_args: conf_data.get('XNVME_BE_SPDK_ENABLED') ? [
+    '-Wl,--whole-archive',
+    '-Wl,--no-as-needed',
     '-lxnvme',
-    '-Wl,--no-whole-archive', '-Wl,--as-needed'
-  ]
+    '-Wl,--no-whole-archive',
+    '-Wl,--as-needed',
+  ] : [ '-lxnvme' ]
 )
 
 # pkg-config -- describing how to consume the xNVMe library


### PR DESCRIPTION
meson: only do whole-archive in pkg-config when SPDK is enabled
    
The generated pkg-config produces linker-args for whole-archive-linking.
This is needed by the __attribute__((destructor)) used by SPDK to load
modules. E.g. the SPDK NVMe driver is registered via such as
constructor.

In some environments/toolchains this is causing issues, those same
environments do not support SPDK. Thus, this change restricts the
addition of these flags to when the xNVMe SPDK backend is enabled.

Signed-off-by: Simon A. F. Lund <simon.lund@samsung.com>