### PR TITLE
mk: fix 'git-setup' error when using src-archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ endef
 git-setup:
 	@echo "## xNVMe:: git-setup"
 	$(GIT) config core.hooksPath .githooks || true
-	$(GIT) config blame.ignoreRevsFile .git-blame-ignore-revs
+	$(GIT) config blame.ignoreRevsFile .git-blame-ignore-revs || true
 	@echo "## xNVMe:: git-setup [DONE]"
 
 define info-help

--- a/scripts/pkgs/opensuse-tumbleweed-latest.sh
+++ b/scripts/pkgs/opensuse-tumbleweed-latest.sh
@@ -7,5 +7,5 @@ ldd --version || true
 
 zypper --non-interactive refresh
 
-# Install packages via dnf
-zypper --non-interactive install -y $(cat "scripts/pkgs/opensuse-tumbleweed-latest.txt")
+# Install packages via zypper
+zypper --non-interactive install -y --allow-downgrade $(cat "scripts/pkgs/opensuse-tumbleweed-latest.txt")


### PR DESCRIPTION
The Makefile-helper 'make git-setup' is invoked via the default
make-target thereby providing an implicit setup of git-hooks and
git-blame-ignore-files. Which is convenient. However, the build using
Makefile might be building from source-archive instead. Thus, this fix
to ignore the git-setup error.

Signed-off-by: Simon A. F. Lund <simon.lund@samsung.com>