### PR TITLE
be:linux:async:ucmd: modify uring command interface according to 5.17…

### DIFF
--- a/lib/xnvme_be_linux_async_ucmd.c
+++ b/lib/xnvme_be_linux_async_ucmd.c
@@ -18,14 +18,12 @@
 #include <linux/nvme_ioctl.h>
 
 #define IORING_OP_URING_CMD 40
+#define NVME_PASSTHRU_CMD64_SIZE 80
 
-/* This shadows struct io_uring_cmd (40 bytes) */
-struct block_uring_cmd {
-	__u32 ioctl_cmd;
-	__u32 unused1;
-	__u64 unused2[4];
-};
-XNVME_STATIC_ASSERT(sizeof(struct block_uring_cmd) == 40, "Incorrect size");
+/*
+ * sqe->uring_cmd_flags
+ */
+#define IORING_URING_CMD_INDIRECT (1U << 0)
 
 static int g_linux_liburing_optional[] = {
 	IORING_OP_URING_CMD,
@@ -114,7 +112,7 @@ xnvme_be_linux_ucmd_poke(struct xnvme_queue *q, uint32_t max)
 #ifdef NVME_IOCTL_IO64_CMD
 		xnvme_be_linux_nvme_map_cpl(ctx, NVME_IOCTL_IO64_CMD);
 #else
-		xnvme_be_linux_nvme_map_cpl(ctx, NVME_IOCTL_IO_CMD);
+		return -ENOSYS;
 #endif
 		ctx->cpl.result = cqe->res;
 		if (cqe->res < 0) {
@@ -144,7 +142,6 @@ xnvme_be_linux_ucmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes
 {
 	struct xnvme_queue_liburing *queue = (void *)ctx->async.queue;
 	struct xnvme_be_linux_state *state = (void *)queue->base.dev->be.state;
-	struct block_uring_cmd *blk_cmd = NULL;
 	struct io_uring_sqe *sqe = NULL;
 	int err = 0;
 
@@ -159,9 +156,12 @@ xnvme_be_linux_ucmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes
 	}
 
 	sqe->opcode = IORING_OP_URING_CMD;
-	sqe->addr = 4;
-	sqe->len = dbuf_nbytes;
-	sqe->off = (unsigned long)ctx;
+	sqe->addr = NVME_PASSTHRU_CMD64_SIZE;
+#ifdef NVME_IOCTL_IO64_CMD
+	sqe->off = NVME_IOCTL_IO64_CMD;
+#else
+	return -ENOSYS;
+#endif
 	sqe->flags = queue->poll_sq ? IOSQE_FIXED_FILE : 0;
 	sqe->ioprio = 0;
 	// NOTE: we only ever register a single file, the raw device, so the
@@ -169,15 +169,8 @@ xnvme_be_linux_ucmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes
 	sqe->fd = queue->poll_sq ? 0 : state->fd;
 	sqe->rw_flags = 0;
 	sqe->user_data = (unsigned long)ctx;
-	// sqe->__pad2[0] = sqe->__pad2[1] = sqe->__pad2[2] = 0;
-
-	blk_cmd = (void *)&sqe->len;
-#ifdef NVME_IOCTL_IO64_CMD
-	blk_cmd->ioctl_cmd = NVME_IOCTL_IO64_CMD;
-#else
-	blk_cmd->ioctl_cmd = NVME_IOCTL_IO_CMD;
-#endif
-	blk_cmd->unused2[0] = (uint64_t)ctx;
+	sqe->__pad2[0] = (uint64_t)ctx;
+	sqe->open_flags = IORING_URING_CMD_INDIRECT;
 
 	if (queue->poll_io) {
 		ctx->cmd.common.fuse = 1;


### PR DESCRIPTION
… kernel

Remove unsupported ioctl for io_uring_cmd

Signed-off-by: Ankit Kumar <ankit.kumar@samsung.com>