### PR TITLE
Refreshing ``io_uring_cmd`` backend

### DIFF
--- a/examples/xnvme_io_async.c
+++ b/examples/xnvme_io_async.c
@@ -306,6 +306,7 @@ static struct xnvmec_sub g_subs[] = {
 			{XNVMEC_OPT_BE, XNVMEC_LOPT},
 			{XNVMEC_OPT_ADMIN, XNVMEC_LOPT},
 			{XNVMEC_OPT_ASYNC, XNVMEC_LOPT},
+			{XNVMEC_OPT_DIRECT, XNVMEC_LFLG},
 		},
 	},
 
@@ -325,6 +326,7 @@ static struct xnvmec_sub g_subs[] = {
 			{XNVMEC_OPT_BE, XNVMEC_LOPT},
 			{XNVMEC_OPT_ADMIN, XNVMEC_LOPT},
 			{XNVMEC_OPT_ASYNC, XNVMEC_LOPT},
+			{XNVMEC_OPT_DIRECT, XNVMEC_LFLG},
 		},
 	},
 };

--- a/include/xnvme_be_linux_nvme.h
+++ b/include/xnvme_be_linux_nvme.h
@@ -16,6 +16,6 @@ int
 xnvme_be_linux_nvme_dev_nsid(struct xnvme_dev *dev);
 
 int
-xnvme_be_linux_nvme_map_cpl(struct xnvme_cmd_ctx *ctx, unsigned long ioctl_req);
+xnvme_be_linux_nvme_map_cpl(struct xnvme_cmd_ctx *ctx, unsigned long ioctl_req, int err);
 
 #endif /* __INTERNAL_XNVME_BE_LINUX_NVME_H */

--- a/lib/xnvme_be_linux_async_ucmd.c
+++ b/lib/xnvme_be_linux_async_ucmd.c
@@ -78,22 +78,22 @@ xnvme_be_linux_ucmd_poke(struct xnvme_queue *q, uint32_t max)
 	max = max > XNVME_QUEUE_IOU_CQE_BATCH_MAX ? XNVME_QUEUE_IOU_CQE_BATCH_MAX : max;
 
 	if (queue->poll_io) {
-		int ret;
+		int err;
 
-		ret = io_uring_wait_cqe(&queue->ring, &cqes[0]);
-		if (ret) {
-			XNVME_DEBUG("FAILED: io_uring_wait_cqe(), err: %d", ret);
-			return ret;
+		err = io_uring_wait_cqe(&queue->ring, &cqes[0]);
+		if (err) {
+			XNVME_DEBUG("FAILED: io_uring_wait_cqe(), err: %d", err);
+			return err;
 		}
 		completed = 1;
 	} else {
 		if (!queue->poll_sq) {
-			int ret;
+			int err;
 
-			ret = io_uring_wait_cqe_nr(&queue->ring, cqes, max);
-			if (ret) {
+			err = io_uring_wait_cqe_nr(&queue->ring, cqes, max);
+			if (err) {
 				XNVME_DEBUG("FAILED: io_uring_wait_cqe_nr(), err: %d", err);
-				return ret;
+				return err;
 			}
 		}
 		completed = io_uring_peek_batch_cqe(&queue->ring, cqes, max);

--- a/lib/xnvme_be_linux_async_ucmd.c
+++ b/lib/xnvme_be_linux_async_ucmd.c
@@ -82,7 +82,7 @@ xnvme_be_linux_ucmd_poke(struct xnvme_queue *q, uint32_t max)
 
 		ret = io_uring_wait_cqe(&queue->ring, &cqes[0]);
 		if (ret) {
-			XNVME_DEBUG("FAILED: foo");
+			XNVME_DEBUG("FAILED: io_uring_wait_cqe(), err: %d", ret);
 			return ret;
 		}
 		completed = 1;
@@ -92,7 +92,7 @@ xnvme_be_linux_ucmd_poke(struct xnvme_queue *q, uint32_t max)
 
 			ret = io_uring_wait_cqe_nr(&queue->ring, cqes, max);
 			if (ret) {
-				XNVME_DEBUG("FAILED: foo");
+				XNVME_DEBUG("FAILED: io_uring_wait_cqe_nr(), err: %d", err);
 				return ret;
 			}
 		}

--- a/lib/xnvme_be_linux_nvme.c
+++ b/lib/xnvme_be_linux_nvme.c
@@ -145,7 +145,13 @@ xnvme_be_linux_nvme_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nb
 {
 	int err;
 
-	///< NOTE: opcode-dispatch (io)
+	/**
+	 * NOTE: For the pseudo-spec encapsulating file-system operations in NVMe-commands aka
+	 * SPEC_FS, then the slba aka "offset" is given in units of bytes, this is converted here
+	 * to an NVM-io command by shifting to obtain a unit of blocks. This of course requires
+	 * that the SPEC_FS operation is aligned to the the block-width, if it is not, then it will
+	 * silently write to "truncated" address.
+	 */
 	switch (ctx->cmd.common.opcode) {
 	case XNVME_SPEC_FS_OPC_READ:
 		ctx->cmd.nvm.slba = ctx->cmd.nvm.slba >> ctx->dev->geo.ssw;

--- a/lib/xnvme_be_linux_nvme.c
+++ b/lib/xnvme_be_linux_nvme.c
@@ -23,10 +23,22 @@ ioctl_request_to_str(unsigned long req)
 		return "NVME_IOCTL_ID";
 	case NVME_IOCTL_ADMIN_CMD:
 		return "NVME_IOCTL_ADMIN_CMD";
+#ifdef NVME_IOCTL_ADMIN64_CMD
+	case NVME_IOCTL_ADMIN64_CMD:
+		return "NVME_IOCTL_ADMIN64_CMD";
+#endif
 	case NVME_IOCTL_SUBMIT_IO:
 		return "NVME_IOCTL_SUBMIT_IO";
 	case NVME_IOCTL_IO_CMD:
 		return "NVME_IOCTL_IO_CMD";
+#ifdef NVME_IOCTL_IO64_CMD
+	case NVME_IOCTL_IO64_CMD:
+		return "NVME_IOCTL_IO64_CMD";
+#endif
+#ifdef NVME_IOCTL_IO64_CMD_VEC
+	case NVME_IOCTL_IO64_CMD_VEC:
+		return "NVME_IOCTL_IO64_CMD_VEC";
+#endif
 	case NVME_IOCTL_RESET:
 		return "NVME_IOCTL_RESET";
 	case NVME_IOCTL_SUBSYS_RESET:

--- a/lib/xnvme_be_linux_nvme.c
+++ b/lib/xnvme_be_linux_nvme.c
@@ -70,39 +70,43 @@ struct _kernel_cpl {
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_cpl) == sizeof(struct _kernel_cpl), "Incorrect size")
 
 int
-xnvme_be_linux_nvme_map_cpl(struct xnvme_cmd_ctx *ctx, unsigned long ioctl_req)
+xnvme_be_linux_nvme_map_cpl(struct xnvme_cmd_ctx *ctx, unsigned long ioctl_req, int res)
 {
 	struct _kernel_cpl *kcpl = (void *)&ctx->cpl;
-	uint64_t cpl_res;
 
-	// Assign the completion-result
 	switch (ioctl_req) {
 	case NVME_IOCTL_ADMIN_CMD:
 	case NVME_IOCTL_IO_CMD:
-		cpl_res = kcpl->res32.result;
+		ctx->cpl.result = kcpl->res32.result;
 		break;
 #ifdef NVME_IOCTL_IO64_CMD
 	case NVME_IOCTL_IO64_CMD:
-		cpl_res = kcpl->res64.result;
+		ctx->cpl.result = kcpl->res64.result;
+		break;
+#endif
+#ifdef NVME_IOCTL_IO64_CMD_VEC
+	case NVME_IOCTL_IO64_CMD_VEC:
+		ctx->cpl.result = kcpl->res64.result;
 		break;
 #endif
 #ifdef NVME_IOCTL_ADMIN64_CMD
 	case NVME_IOCTL_ADMIN64_CMD:
-		cpl_res = kcpl->res64.result;
+		ctx->cpl.result = kcpl->res64.result;
 		break;
 #endif
 	default:
-		XNVME_DEBUG("FAILED: ioctl_req: %lu", ioctl_req);
+		XNVME_DEBUG("FAILED: ioctl_req: %lu, res: %d", ioctl_req, res);
 		return -ENOSYS;
 	}
 
-	ctx->cpl.result = cpl_res;
-
-	// Zero-out the remainder of the completion
-	ctx->cpl.status.val = 0;
 	ctx->cpl.sqhd = 0;
 	ctx->cpl.sqid = 0;
 	ctx->cpl.cid = 0;
+	ctx->cpl.status.val = 0;
+	if (res) {
+		ctx->cpl.status.sc = res & 0xFF;
+		ctx->cpl.status.sct = XNVME_STATUS_CODE_TYPE_VENDOR;
+	}
 
 	return 0;
 }
@@ -114,7 +118,7 @@ ioctl_wrap(struct xnvme_dev *dev, unsigned long ioctl_req, struct xnvme_cmd_ctx 
 	int err;
 
 	err = ioctl(state->fd, ioctl_req, ctx);
-	if (xnvme_be_linux_nvme_map_cpl(ctx, ioctl_req)) {
+	if (xnvme_be_linux_nvme_map_cpl(ctx, ioctl_req, err)) {
 		XNVME_DEBUG("FAILED: xnvme_be_linux_map_cpl()");
 		return -ENOSYS;
 	}

--- a/lib/xnvme_be_posix_async_emu.c
+++ b/lib/xnvme_be_posix_async_emu.c
@@ -10,13 +10,22 @@
 #include <xnvme_queue.h>
 #include <xnvme_dev.h>
 
+/**
+ * NOTE: this should be possible to do within a single cache-line... refactor pointers for re-use
+ *       and use a flag to distinguish contig vs. iovec payload
+ */
 struct _emu_entry {
 	struct xnvme_dev *dev;
 	struct xnvme_cmd_ctx *ctx;
-	void *dbuf;
-	size_t dbuf_nbytes;
-	void *mbuf;
-	size_t mbuf_nbytes;
+
+	void *data;
+	void *meta;
+	uint32_t data_nbytes;
+	uint32_t data_vec_cnt;
+	uint32_t meta_nbytes;
+	uint32_t meta_vec_cnt;
+	uint32_t is_vectored;
+
 	STAILQ_ENTRY(_emu_entry) link;
 };
 
@@ -112,8 +121,14 @@ _posix_async_emu_poke(struct xnvme_queue *q, uint32_t max)
 
 		STAILQ_REMOVE_HEAD(&qp->sq, link);
 
-		err = queue->base.dev->be.sync.cmd_io(entry->ctx, entry->dbuf, entry->dbuf_nbytes,
-						      entry->mbuf, entry->mbuf_nbytes);
+		err = entry->is_vectored
+			      ? queue->base.dev->be.sync.cmd_iov(
+					entry->ctx, entry->data, entry->data_vec_cnt,
+					entry->data_nbytes, entry->meta, entry->meta_vec_cnt,
+					entry->meta_nbytes)
+			      : queue->base.dev->be.sync.cmd_io(entry->ctx, entry->data,
+								entry->data_nbytes, entry->meta,
+								entry->meta_nbytes);
 		if (err) {
 			XNVME_DEBUG("FAILED: err: %d", err);
 		}
@@ -147,10 +162,14 @@ _posix_async_emu_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbyte
 
 	entry->dev = ctx->dev;
 	entry->ctx = ctx;
-	entry->dbuf = dbuf;
-	entry->dbuf_nbytes = dbuf_nbytes;
-	entry->mbuf = mbuf;
-	entry->mbuf_nbytes = mbuf_nbytes;
+
+	entry->data = dbuf;
+	entry->data_nbytes = dbuf_nbytes;
+	entry->data_vec_cnt = 0;
+	entry->meta = mbuf;
+	entry->meta_nbytes = mbuf_nbytes;
+	entry->meta_vec_cnt = 0;
+	entry->is_vectored = false;
 
 	STAILQ_INSERT_TAIL(&qp->sq, entry, link);
 
@@ -158,13 +177,49 @@ _posix_async_emu_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbyte
 
 	return 0;
 }
+
+static inline int
+_posix_async_emu_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, size_t dvec_cnt,
+			 size_t dvec_nbytes, struct iovec *mvec, size_t mvec_cnt,
+			 size_t mvec_nbytes)
+{
+	struct xnvme_queue_emu *queue = (void *)ctx->async.queue;
+	struct _emu_qp *qp = queue->qp;
+	struct _emu_entry *entry;
+
+	// Grab entry from rp and push into sq
+	entry = STAILQ_FIRST(&qp->rp);
+	if (!entry) {
+		XNVME_DEBUG("FAILED: should not happen");
+		return -EIO;
+	}
+	STAILQ_REMOVE_HEAD(&qp->rp, link);
+
+	entry->dev = ctx->dev;
+	entry->ctx = ctx;
+
+	entry->data = dvec;
+	entry->data_nbytes = dvec_nbytes;
+	entry->data_vec_cnt = dvec_cnt;
+	entry->meta = mvec;
+	entry->meta_nbytes = mvec_nbytes;
+	entry->meta_vec_cnt = mvec_cnt;
+	entry->is_vectored = true;
+
+	STAILQ_INSERT_TAIL(&qp->sq, entry, link);
+
+	ctx->async.queue->base.outstanding += 1;
+
+	return 0;
+}
+
 #endif
 
 struct xnvme_be_async g_xnvme_be_posix_async_emu = {
 	.id = "emu",
 #ifdef XNVME_BE_ASYNC_EMU_ENABLED
 	.cmd_io = _posix_async_emu_cmd_io,
-	.cmd_iov = xnvme_be_nosys_queue_cmd_iov,
+	.cmd_iov = _posix_async_emu_cmd_iov,
 	.poke = _posix_async_emu_poke,
 	.wait = xnvme_be_nosys_queue_wait,
 	.init = _posix_async_emu_init,

--- a/lib/xnvme_libconf.c
+++ b/lib/xnvme_libconf.c
@@ -4,6 +4,9 @@
 #include <libxnvme_libconf.h>
 #include <xnvme_be_linux.h>
 #include <xnvme_be_windows.h>
+#ifdef XNVME_BE_LINUX_ENABLED
+#include <linux/nvme_ioctl.h>
+#endif
 
 int
 xnvme_libconf_fpr(FILE *stream, enum xnvme_pr opts)
@@ -37,6 +40,17 @@ xnvme_libconf_fpr(FILE *stream, enum xnvme_pr opts)
 	wrtn += xnvme_be_linux_uapi_ver_fpr(stream, XNVME_PR_DEF);
 #endif
 	wrtn += fprintf(stream, "'\n");
+#ifdef XNVME_BE_LINUX_ENABLED
+#ifdef NVME_IOCTL_IO64_CMD
+	wrtn += fprintf(stream, "  - '3p: NVME_IOCTL_IO64_CMD'\n");
+#endif
+#ifdef NVME_IOCTL_IO64_CMD_VEC
+	wrtn += fprintf(stream, "  - '3p: NVME_IOCTL_IO64_CMD_VEC'\n");
+#endif
+#ifdef NVME_IOCTL_ADMIN64_CMD
+	wrtn += fprintf(stream, "  - '3p: NVME_IOCTL_ADMIN64_CMD'\n");
+#endif
+#endif
 
 	return wrtn;
 }

--- a/scripts/cijoe-pkg-xnvme/testplans/xnvme-nvm-linux-ucmd.plan
+++ b/scripts/cijoe-pkg-xnvme/testplans/xnvme-nvm-linux-ucmd.plan
@@ -1,0 +1,62 @@
+---
+descr: Verify mandatory NVM Command-set using a be_linux/io_uring_cmd+nvme-ioctl on /dev/ngXnY
+descr_long: |
+  The io_uring_cmd interfaces ships ioctl() over io_uring, xNVMe uses this to ship NVMe-commands
+  over io_uring. In this test-plan, both the NVMe-ioctl() interface is exercised as well as
+  shipping the same commands over the io_uring interface. This is why there are async=emu, and
+  async=thrpool setups
+hooks: ["sysinf", "xnvme"]
+evars:
+  CMD_PREFIX: " "
+  FIO_NRUNS: "1"
+  FIO_SECTION: "default"
+  FIO_SCRIPT: "xnvme-verify.fio"
+  FIO_IOENG_NAME: "xnvme"
+  NVME_NSTYPE: "lblk"
+  DEV_TYPE: "char"
+  XNVME_BE: "linux"
+  XNVME_ASYNC: "io_uring_cmd"
+  XNVME_ADMIN: "nvme"
+  XNVME_SYNC: "nvme"
+
+testsuites:
+- name: xnvme_core
+  alias: "xNVMe: core library info and default enumeration"
+
+- name: xnvme_nvm
+  alias: "xNVMe: IO contig. using be:linux"
+
+# This uses the NVMe-ioctl
+- name: xnvme_nvm_io
+  alias: "xNVMe: IO contig. using be:linux/async:io_uring_cmd"
+  evars:
+    XNVME_ASYNC: "io_uring_cmd"
+
+- name: xnvme_nvm_io
+  alias: "xNVMe: IO contig. using be:linux/async:thrpool"
+  evars:
+    XNVME_ASYNC: "thrpool"
+
+- name: xnvme_nvm_io
+  alias: "xNVMe: IO contig. using be:linux/async:emu"
+  evars:
+    XNVME_ASYNC: "emu"
+
+# This uses the NVMe-iovec-ioctl
+- name: xnvme_nvm_io
+  alias: "xNVMe: IO iovec using be:linux/async:io_uring_cmd"
+  evars:
+    XNVME_ASYNC: "io_uring_cmd"
+    FIO_AUX: "--xnvme_iovec=1"
+
+- name: xnvme_nvm_io
+  alias: "xNVMe: IO iovec using be:linux/async:thrpool"
+  evars:
+    XNVME_ASYNC: "thrpool"
+    FIO_AUX: "--xnvme_iovec=1"
+
+- name: xnvme_nvm_io
+  alias: "xNVMe: IO iovec using be:linux/async:emu"
+  evars:
+    XNVME_ASYNC: "emu"
+    FIO_AUX: "--xnvme_iovec=1"


### PR DESCRIPTION
This is related to:

- Issue: https://github.com/OpenMPDK/xNVMe/issues/50
- PR: https://github.com/OpenMPDK/xNVMe/pull/43
- PR: https://github.com/OpenMPDK/xNVMe/pull/49

The PR does not address the ``big-sqe``, also the sync. NVMe-ioctl-iovec, definately needs another set of eyes.