### PR TITLE
Docs: fix doxygen includes

### DIFF
--- a/docs/autogen/doxy.cfg
+++ b/docs/autogen/doxy.cfg
@@ -274,7 +274,7 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = ../../include/libxnvme.h \
-	../../include/libxnvme_3p.h \
+	../../include/libxnvme_libconf.h \
 	../../include/libxnvme_pp.h \
 	../../include/libxnvme_ident.h \
 	../../include/libxnvme_util.h \
@@ -287,7 +287,7 @@ INPUT                  = ../../include/libxnvme.h \
 	../../include/libxnvme_nvm.h \
 	../../include/libxnvme_sgl.h \
 	../../include/libxnvme_spec.h \
-	../../include/libxnvme_spec_file.h \
+	../../include/libxnvme_spec_fs.h \
 	../../include/libxnvme_spec_pp.h \
 	../../include/libxnvme_ver.h \
 	../../include/libxnvme_znd.h \


### PR DESCRIPTION
- include libxnvme_libconf instead of libxnvme_3p
- include libxnvme_spec_fs instead of libxnvme_spec_file

Signed-off-by: Karl Bonde Torp <k.torp@samsung.com>