### PR TITLE
be:linux:ucmd: Added Support for 128 byte SQEs and Vectored I/O

### DIFF
--- a/examples/xnvme_io_async.c
+++ b/examples/xnvme_io_async.c
@@ -306,6 +306,7 @@ static struct xnvmec_sub g_subs[] = {
 			{XNVMEC_OPT_BE, XNVMEC_LOPT},
 			{XNVMEC_OPT_ADMIN, XNVMEC_LOPT},
 			{XNVMEC_OPT_ASYNC, XNVMEC_LOPT},
+			{XNVMEC_OPT_DIRECT, XNVMEC_LFLG},
 		},
 	},
 
@@ -325,6 +326,7 @@ static struct xnvmec_sub g_subs[] = {
 			{XNVMEC_OPT_BE, XNVMEC_LOPT},
 			{XNVMEC_OPT_ADMIN, XNVMEC_LOPT},
 			{XNVMEC_OPT_ASYNC, XNVMEC_LOPT},
+			{XNVMEC_OPT_DIRECT, XNVMEC_LFLG},
 		},
 	},
 };

--- a/include/libxnvme.h
+++ b/include/libxnvme.h
@@ -61,6 +61,7 @@ struct xnvme_opts {
 	uint8_t poll_sq;          ///< io_uring: enable sqthread-polling
 	uint8_t register_files;   ///< io_uring: enable file-regirations
 	uint8_t register_buffers; ///< io_uring: enable buffer-registration
+	uint8_t uring_feat;       ///< io_uring: enable 128 byte sqe entries
 	struct {
 		uint32_t value : 31;
 		uint32_t given : 1;

--- a/include/xnvme_be_linux_nvme.h
+++ b/include/xnvme_be_linux_nvme.h
@@ -16,6 +16,6 @@ int
 xnvme_be_linux_nvme_dev_nsid(struct xnvme_dev *dev);
 
 int
-xnvme_be_linux_nvme_map_cpl(struct xnvme_cmd_ctx *ctx, unsigned long ioctl_req);
+xnvme_be_linux_nvme_map_cpl(struct xnvme_cmd_ctx *ctx, unsigned long ioctl_req, int err);
 
 #endif /* __INTERNAL_XNVME_BE_LINUX_NVME_H */

--- a/lib/xnvme_be_linux_async_liburing.c
+++ b/lib/xnvme_be_linux_async_liburing.c
@@ -86,6 +86,10 @@ xnvme_be_linux_liburing_init(struct xnvme_queue *q, int opts)
 		iou_flags |= IORING_SETUP_IOPOLL;
 	}
 
+	if (q->base.dev->opts.uring_feat) {
+		iou_flags |= IORING_SETUP_SQE128;
+	}
+
 	err = io_uring_queue_init(queue->base.capacity, &queue->ring, iou_flags);
 	if (err) {
 		XNVME_DEBUG("FAILED: io_uring_queue_init(), err: %d", err);

--- a/lib/xnvme_be_linux_async_ucmd.c
+++ b/lib/xnvme_be_linux_async_ucmd.c
@@ -197,13 +197,86 @@ xnvme_be_linux_ucmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes
 
 	return 0;
 }
+
+#ifdef NVME_IOCTL_IO64_CMD_VEC
+int
+xnvme_be_linux_ucmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, size_t dvec_cnt,
+			size_t dvec_nbytes, struct iovec *mvec, size_t mvec_cnt,
+			size_t mvec_nbytes)
+{
+	struct xnvme_queue_liburing *queue = (void *)ctx->async.queue;
+	struct xnvme_be_linux_state *state = (void *)queue->base.dev->be.state;
+	struct io_uring_sqe *sqe = NULL;
+	int err = 0;
+
+	if (mvec || mvec_cnt || mvec_nbytes) {
+		XNVME_DEBUG("FAILED: mvec or mvec_cnt or mvec_nbytes provided");
+		return -ENOSYS;
+	}
+
+	sqe = io_uring_get_sqe(&queue->ring);
+	if (!sqe) {
+		return -EAGAIN;
+	}
+
+	sqe->opcode = IORING_OP_URING_CMD;
+	sqe->addr = NVME_PASSTHRU_CMD64_SIZE;
+	sqe->off = NVME_IOCTL_IO64_CMD_VEC;
+	sqe->len = dvec_nbytes;
+	sqe->flags = queue->poll_sq ? IOSQE_FIXED_FILE : 0;
+	sqe->ioprio = 0;
+	// NOTE: we only ever register a single file, the raw device, so the
+	// provided index will always be 0
+	sqe->fd = queue->poll_sq ? 0 : state->fd;
+	sqe->rw_flags = 0;
+	sqe->user_data = (unsigned long)ctx;
+
+	if (queue->poll_io) {
+		ctx->cmd.common.fuse = 1;
+	}
+	ctx->cmd.common.dptr.lnx_ioctl.data = (uint64_t)dvec;
+	ctx->cmd.common.dptr.lnx_ioctl.data_len = dvec_cnt;
+
+	ctx->cmd.common.mptr = (uint64_t)mvec;
+	ctx->cmd.common.dptr.lnx_ioctl.metadata_len = mvec_cnt;
+
+	if (queue->base.dev->opts.uring_feat) {
+		XNVME_DEBUG("In-Line Command");
+		memcpy(&sqe->__pad[0], &ctx->cmd.common, NVME_PASSTHRU_CMD64_SIZE);
+	} else {
+		XNVME_DEBUG("Indirect Command");
+		sqe->__pad[0] = (uint64_t)ctx;
+		sqe->open_flags = IORING_URING_CMD_INDIRECT;
+	}
+
+	err = io_uring_submit(&queue->ring);
+	if (err < 0) {
+		XNVME_DEBUG("io_uring_submit(%d), err: %d", ctx->cmd.common.opcode, err);
+		return err;
+	}
+
+	queue->base.outstanding += 1;
+
+	return 0;
+}
+#else
+int
+xnvme_be_linux_ucmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, size_t dvec_cnt,
+			size_t dvec_nbytes, struct iovec *mvec, size_t mvec_cnt,
+			size_t mvec_nbytes)
+{
+	XNVME_DEBUG("FAILED: not supported, built on system without NVME_IOCTL_IO64_CMD_VEC");
+	return xnvme_be_nosys_queue_cmd_iov(ctx, dvec, dvec_cnt, dvec_nbytes,
+					    mvec, mvec_cnt, mvec_nbytes);
+}
+#endif
 #endif
 
 struct xnvme_be_async g_xnvme_be_linux_async_ucmd = {
 	.id = "io_uring_cmd",
 #ifdef XNVME_BE_LINUX_LIBURING_ENABLED
 	.cmd_io = xnvme_be_linux_ucmd_io,
-	.cmd_iov = xnvme_be_nosys_queue_cmd_iov,
+	.cmd_iov = xnvme_be_linux_ucmd_iov,
 	.poke = xnvme_be_linux_ucmd_poke,
 	.wait = xnvme_be_nosys_queue_wait,
 	.init = xnvme_be_linux_ucmd_init,

--- a/lib/xnvme_be_linux_async_ucmd.c
+++ b/lib/xnvme_be_linux_async_ucmd.c
@@ -18,14 +18,12 @@
 #include <linux/nvme_ioctl.h>
 
 #define IORING_OP_URING_CMD 40
+#define NVME_PASSTHRU_CMD64_SIZE 80
 
-/* This shadows struct io_uring_cmd (40 bytes) */
-struct block_uring_cmd {
-	__u32 ioctl_cmd;
-	__u32 unused1;
-	__u64 unused2[4];
-};
-XNVME_STATIC_ASSERT(sizeof(struct block_uring_cmd) == 40, "Incorrect size");
+/*
+ * sqe->uring_cmd_flags
+ */
+#define IORING_URING_CMD_INDIRECT (1U << 0)
 
 static int g_linux_liburing_optional[] = {
 	IORING_OP_URING_CMD,
@@ -114,7 +112,7 @@ xnvme_be_linux_ucmd_poke(struct xnvme_queue *q, uint32_t max)
 #ifdef NVME_IOCTL_IO64_CMD
 		xnvme_be_linux_nvme_map_cpl(ctx, NVME_IOCTL_IO64_CMD);
 #else
-		xnvme_be_linux_nvme_map_cpl(ctx, NVME_IOCTL_IO_CMD);
+		return -ENOSYS;
 #endif
 		ctx->cpl.result = cqe->res;
 		if (cqe->res < 0) {
@@ -144,7 +142,6 @@ xnvme_be_linux_ucmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes
 {
 	struct xnvme_queue_liburing *queue = (void *)ctx->async.queue;
 	struct xnvme_be_linux_state *state = (void *)queue->base.dev->be.state;
-	struct block_uring_cmd *blk_cmd = NULL;
 	struct io_uring_sqe *sqe = NULL;
 	int err = 0;
 
@@ -159,9 +156,12 @@ xnvme_be_linux_ucmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes
 	}
 
 	sqe->opcode = IORING_OP_URING_CMD;
-	sqe->addr = 4;
-	sqe->len = dbuf_nbytes;
-	sqe->off = (unsigned long)ctx;
+	sqe->addr = NVME_PASSTHRU_CMD64_SIZE;
+#ifdef NVME_IOCTL_IO64_CMD
+	sqe->off = NVME_IOCTL_IO64_CMD;
+#else
+	return -ENOSYS;
+#endif
 	sqe->flags = queue->poll_sq ? IOSQE_FIXED_FILE : 0;
 	sqe->ioprio = 0;
 	// NOTE: we only ever register a single file, the raw device, so the
@@ -169,15 +169,8 @@ xnvme_be_linux_ucmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes
 	sqe->fd = queue->poll_sq ? 0 : state->fd;
 	sqe->rw_flags = 0;
 	sqe->user_data = (unsigned long)ctx;
-	// sqe->__pad2[0] = sqe->__pad2[1] = sqe->__pad2[2] = 0;
-
-	blk_cmd = (void *)&sqe->len;
-#ifdef NVME_IOCTL_IO64_CMD
-	blk_cmd->ioctl_cmd = NVME_IOCTL_IO64_CMD;
-#else
-	blk_cmd->ioctl_cmd = NVME_IOCTL_IO_CMD;
-#endif
-	blk_cmd->unused2[0] = (uint64_t)ctx;
+	sqe->__pad2[0] = (uint64_t)ctx;
+	sqe->open_flags = IORING_URING_CMD_INDIRECT;
 
 	if (queue->poll_io) {
 		ctx->cmd.common.fuse = 1;

--- a/subprojects/liburing.wrap
+++ b/subprojects/liburing.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/axboe/liburing.git
-revision = liburing-2.1
+revision = big-sqe
 patch_directory = liburing
 
 [provide]

--- a/tools/fio-engine/xnvme_fioe.c
+++ b/tools/fio-engine/xnvme_fioe.c
@@ -165,6 +165,7 @@ struct xnvme_fioe_options {
 	unsigned int sqpoll_thread;
 	unsigned int xnvme_dev_nsid;
 	unsigned int xnvme_iovec;
+	unsigned int uring_feat;
 	char *xnvme_be;
 	char *xnvme_async;
 	char *xnvme_sync;
@@ -244,7 +245,15 @@ static struct fio_option options[] = {
 		.category = FIO_OPT_C_ENGINE,
 		.group = FIO_OPT_G_INVALID,
 	},
-
+	{
+		.name = "uring_feat",
+		.lname = "xNVMe io_uring 128 byte sqe entries",
+		.type = FIO_OPT_STR_SET,
+		.off1 = offsetof(struct xnvme_fioe_options, uring_feat),
+		.help = "Use 128 byte sqe entries",
+		.category = FIO_OPT_C_ENGINE,
+		.group = FIO_OPT_G_INVALID,
+	},
 	{
 		.name = NULL,
 	},
@@ -278,6 +287,7 @@ static struct xnvme_opts xnvme_opts_from_fioe(struct thread_data *td)
 
 	opts.poll_io = o->hipri;
 	opts.poll_sq = o->sqpoll_thread;
+	opts.uring_feat = o->uring_feat;
 
 	opts.direct = td->o.odirect;
 


### PR DESCRIPTION
1. Added a new option "uring_feat" for the 128 byte SQE entries
2. Supports Regular I/O with 128 byte SQE entries
3. Supports Vectored I/O with regular SQE entries
4. Supports Vectored I/O with 128 byte SQE entries

**Sample Commands :**

- _fio ./tools/fio-engine/xnvme-verify.fio --section=default --ioengine=external:./builddir/tools/fio-engine/libxnvme-fio-engine.so --filename=/dev/ng0n1 --xnvme_async=io_uring_cmd_

- _fio ./tools/fio-engine/xnvme-verify.fio --section=default --ioengine=external:./builddir/tools/fio-engine/libxnvme-fio-engine.so --filename=/dev/ng0n1 --xnvme_async=io_uring_cmd --xnvme_iovec=1_

- _fio ./tools/fio-engine/xnvme-verify.fio --section=default --ioengine=external:./builddir/tools/fio-engine/libxnvme-fio-engine.so --filename=/dev/ng0n1 --xnvme_async=io_uring_cmd --uring_feat=1_

- _fio ./tools/fio-engine/xnvme-verify.fio --section=default --ioengine=external:./builddir/tools/fio-engine/libxnvme-fio-engine.so --filename=/dev/ng0n1 --xnvme_async=io_uring_cmd --xnvme_iovec=1 --uring_feat=1_