### PR TITLE
be:psync,macos: unify pread/pwrite across Unix-like platforms

### DIFF
--- a/include/xnvme_be_macos.h
+++ b/include/xnvme_be_macos.h
@@ -1,0 +1,18 @@
+// Copyright (C) Simon A. F. Lund <simon.lund@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#ifndef __INTERNAL_XNVME_BE_MACOS_H
+#define __INTERNAL_XNVME_BE_MACOS_H
+
+/**
+ * Internal representation of XNVME_BE_MACOS state
+ */
+struct xnvme_be_macos_state {
+	int fd;
+
+	uint8_t _rsvd[124];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_be_macos_state) == XNVME_BE_STATE_NBYTES, "Incorrect size")
+
+extern struct xnvme_be_sync g_xnvme_be_macos_sync_psync;
+
+#endif /* __INTERNAL_XNVME_BE_MACOS */

--- a/include/xnvme_be_psync.h
+++ b/include/xnvme_be_psync.h
@@ -1,0 +1,14 @@
+// Copyright (C) Mads Ynddal <m.ynddal@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#ifndef __INTERNAL_XNVME_BE_PSYNC_H
+#define __INTERNAL_XNVME_BE_PSYNC_H
+
+int
+_xnvme_be_psync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes,
+		       void *XNVME_UNUSED(mbuf), size_t XNVME_UNUSED(mbuf_nbytes), int fd);
+int
+_xnvme_be_psync_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, size_t dvec_cnt,
+			size_t XNVME_UNUSED(dvec_nbytes), struct iovec *XNVME_UNUSED(mvec),
+			size_t XNVME_UNUSED(mvec_cnt), size_t XNVME_UNUSED(mvec_nbytes), int fd);
+
+#endif /* __INTERNAL_XNVME_BE_PSYNC_H */

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -22,6 +22,7 @@ xnvmelib_source = [
   'xnvme_be_posix_dev.c',
   'xnvme_be_posix_mem.c',
   'xnvme_be_posix_sync.c',
+  'xnvme_be_psync.c',
   'xnvme_be_spdk.c',
   'xnvme_be_spdk_admin.c',
   'xnvme_be_spdk_async.c',

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -12,6 +12,8 @@ xnvmelib_source = [
   'xnvme_be_linux_block.c',
   'xnvme_be_linux_dev.c',
   'xnvme_be_linux_nvme.c',
+  'xnvme_be_macos.c',
+  'xnvme_be_macos_sync.c',
   'xnvme_be_nosys.c',
   'xnvme_be_posix.c',
   'xnvme_be_posix_admin.c',

--- a/lib/xnvme_be_fbsd_sync.c
+++ b/lib/xnvme_be_fbsd_sync.c
@@ -15,102 +15,26 @@
 #include <libxnvme_spec_fs.h>
 #include <xnvme_dev.h>
 #include <xnvme_be_fbsd.h>
+#include <xnvme_be_psync.h>
 
 int
-xnvme_be_fbsd_sync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes,
-			  void *XNVME_UNUSED(mbuf), size_t XNVME_UNUSED(mbuf_nbytes))
+xnvme_be_fbsd_sync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes, void *mbuf,
+			  size_t mbuf_nbytes)
 {
 	struct xnvme_be_fbsd_state *state = (void *)ctx->dev->be.state;
-	const uint64_t ssw = ctx->dev->geo.ssw;
-	ssize_t res;
 
-	///< NOTE: opcode-dispatch (io)
-	switch (ctx->cmd.common.opcode) {
-	case XNVME_SPEC_NVM_OPC_WRITE:
-		res = pwrite(state->fd.ns, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba << ssw);
-		break;
-
-	case XNVME_SPEC_NVM_OPC_READ:
-		res = pread(state->fd.ns, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba << ssw);
-		break;
-
-	case XNVME_SPEC_FS_OPC_WRITE:
-		res = pwrite(state->fd.ns, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba);
-		break;
-
-	case XNVME_SPEC_FS_OPC_READ:
-		res = pread(state->fd.ns, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba);
-		break;
-
-	case XNVME_SPEC_NVM_OPC_FLUSH:
-	case XNVME_SPEC_FS_OPC_FLUSH:
-		res = fsync(state->fd.ns);
-		break;
-
-	default:
-		XNVME_DEBUG("FAILED: nosys opcode: %d", ctx->cmd.common.opcode);
-		return -ENOSYS;
-	}
-
-	ctx->cpl.result = res;
-	if (res < 0) {
-		XNVME_DEBUG("FAILED: {pread,pwrite,fsync}(), errno: %d", errno);
-		ctx->cpl.result = 0;
-		ctx->cpl.status.sc = errno;
-		ctx->cpl.status.sct = XNVME_STATUS_CODE_TYPE_VENDOR;
-		return -errno;
-	}
-
-	return 0;
+	return _xnvme_be_psync_cmd_io(ctx, dbuf, dbuf_nbytes, mbuf, mbuf_nbytes, state->fd.ns);
 }
 
 int
 xnvme_be_fbsd_sync_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, size_t dvec_cnt,
-			   size_t XNVME_UNUSED(dvec_nbytes), struct iovec *XNVME_UNUSED(mvec),
-			   size_t XNVME_UNUSED(mvec_cnt), size_t XNVME_UNUSED(mvec_nbytes))
+			   size_t dvec_nbytes, struct iovec *mvec, size_t mvec_cnt,
+			   size_t mvec_nbytes)
 {
 	struct xnvme_be_fbsd_state *state = (void *)ctx->dev->be.state;
-	const uint64_t ssw = ctx->dev->geo.ssw;
-	ssize_t res;
 
-	///< NOTE: opcode-dispatch (io)
-	switch (ctx->cmd.common.opcode) {
-	case XNVME_SPEC_NVM_OPC_WRITE:
-		res = pwritev(state->fd.ns, dvec, dvec_cnt, ctx->cmd.nvm.slba << ssw);
-		break;
-
-	case XNVME_SPEC_NVM_OPC_READ:
-		res = preadv(state->fd.ns, dvec, dvec_cnt, ctx->cmd.nvm.slba << ssw);
-		break;
-
-	case XNVME_SPEC_FS_OPC_WRITE:
-		res = pwritev(state->fd.ns, dvec, dvec_cnt, ctx->cmd.nvm.slba);
-		break;
-
-	case XNVME_SPEC_FS_OPC_READ:
-		res = preadv(state->fd.ns, dvec, dvec_cnt, ctx->cmd.nvm.slba);
-		break;
-
-	case XNVME_SPEC_NVM_OPC_FLUSH:
-	case XNVME_SPEC_FS_OPC_FLUSH:
-		res = fsync(state->fd.ns);
-		break;
-
-	default:
-		XNVME_DEBUG("FAILED: nosys opcode: %d", ctx->cmd.common.opcode);
-		return -ENOSYS;
-	}
-
-	ctx->cpl.result = res;
-	if (res < 0) {
-		XNVME_DEBUG("FAILED: {pread,pwrite,fsync}(), errno: %d", errno);
-		ctx->cpl.result = 0;
-		ctx->cpl.status.sc = errno;
-		ctx->cpl.status.sct = XNVME_STATUS_CODE_TYPE_VENDOR;
-		return -errno;
-	}
-
-	return 0;
+	return _xnvme_be_psync_cmd_iov(ctx, dvec, dvec_cnt, dvec_nbytes, mvec, mvec_cnt,
+				       mvec_nbytes, state->fd.ns);
 }
 #endif
 

--- a/lib/xnvme_be_linux.c
+++ b/lib/xnvme_be_linux.c
@@ -153,7 +153,8 @@ static struct xnvme_be_mixin g_xnvme_be_mixin_linux[] = {
 	{
 		.mtype = XNVME_BE_SYNC,
 		.name = "block",
-		.descr = "Use Linux Block Layer ioctl() and pread()/pwrite() for I/O",
+		.descr = "Use Linux Block Layer ioctl() and pread()/write()/preadv()/pwritev() "
+			 "for I/O",
 		.sync = &g_xnvme_be_linux_sync_block,
 		.check_support = xnvme_be_supported,
 	},

--- a/lib/xnvme_be_macos.c
+++ b/lib/xnvme_be_macos.c
@@ -1,0 +1,80 @@
+// Copyright (C) Mads Ynddal <m.ynddal@samsung.com>
+// Copyright (C) Simon A. F. Lund <simon.lund@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 700
+#endif
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_MACOS_ENABLED
+#include <xnvme_be_posix.h>
+#include <xnvme_be_macos.h>
+
+static struct xnvme_be_mixin g_xnvme_be_mixin_macos[] = {
+	{
+		.mtype = XNVME_BE_MEM,
+		.name = "posix",
+		.descr = "Use C11 lib malloc/free with sysconf for alignment",
+		.mem = &g_xnvme_be_posix_mem,
+		.check_support = xnvme_be_supported,
+	},
+
+	{
+		.mtype = XNVME_BE_ASYNC,
+		.name = "thrpool",
+		.descr = "Use thread pool for Asynchronous I/O",
+		.async = &g_xnvme_be_posix_async_thrpool,
+		.check_support = xnvme_be_supported,
+	},
+	{
+		.mtype = XNVME_BE_ASYNC,
+		.name = "posix",
+		.descr = "Use POSIX aio for Asynchronous I/O",
+		.async = &g_xnvme_be_posix_async_aio,
+		.check_support = xnvme_be_supported,
+	},
+
+	{
+		.mtype = XNVME_BE_SYNC,
+		.name = "psync",
+		.descr = "Use pread()/write() for synchronous I/O and preadv()/pwritev()",
+		.sync = &g_xnvme_be_macos_sync_psync,
+		.check_support = xnvme_be_supported,
+	},
+
+	{
+		.mtype = XNVME_BE_ADMIN,
+		.name = "file_as_ns",
+		.descr = "Use file-stat as to construct NVMe idfy responses",
+		.admin = &g_xnvme_be_posix_admin_shim,
+		.check_support = xnvme_be_supported,
+	},
+
+	{
+		.mtype = XNVME_BE_DEV,
+		.name = "posix",
+		.descr = "Use POSIX file/dev handles and no device enumeration",
+		.dev = &g_xnvme_be_posix_dev,
+		.check_support = xnvme_be_supported,
+	},
+};
+#endif
+
+struct xnvme_be xnvme_be_macos = {
+	.admin = XNVME_BE_NOSYS_ADMIN,
+	.async = XNVME_BE_NOSYS_QUEUE,
+	.dev = XNVME_BE_NOSYS_DEV,
+	.mem = XNVME_BE_NOSYS_MEM,
+	.sync = XNVME_BE_NOSYS_SYNC,
+	.attr =
+		{
+#ifdef XNVME_BE_MACOS_ENABLED
+			.enabled = 1,
+#endif
+			.name = "macos",
+		},
+#ifdef XNVME_BE_MACOS_ENABLED
+	.nobjs = sizeof g_xnvme_be_mixin_macos / sizeof *g_xnvme_be_mixin_macos,
+	.objs = g_xnvme_be_mixin_macos,
+#endif
+};

--- a/lib/xnvme_be_macos_sync.c
+++ b/lib/xnvme_be_macos_sync.c
@@ -1,0 +1,46 @@
+// Copyright (C) Simon A. F. Lund <simon.lund@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#ifndef _BSD_SOURCE
+#define _BSD_SOURCE
+#endif
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#endif
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_MACOS_ENABLED
+#include <xnvme_dev.h>
+#include <xnvme_be_macos.h>
+#include <xnvme_be_psync.h>
+
+int
+xnvme_be_macos_sync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes, void *mbuf,
+			   size_t mbuf_nbytes)
+{
+	struct xnvme_be_macos_state *state = (void *)ctx->dev->be.state;
+
+	return _xnvme_be_psync_cmd_io(ctx, dbuf, dbuf_nbytes, mbuf, mbuf_nbytes, state->fd);
+}
+
+int
+xnvme_be_macos_sync_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, size_t dvec_cnt,
+			    size_t dvec_nbytes, struct iovec *mvec, size_t mvec_cnt,
+			    size_t mvec_nbytes)
+{
+	struct xnvme_be_macos_state *state = (void *)ctx->dev->be.state;
+
+	return _xnvme_be_psync_cmd_iov(ctx, dvec, dvec_cnt, dvec_nbytes, mvec, mvec_cnt,
+				       mvec_nbytes, state->fd);
+}
+#endif
+
+struct xnvme_be_sync g_xnvme_be_macos_sync_psync = {
+	.id = "psync",
+#ifdef XNVME_BE_MACOS_ENABLED
+	.cmd_io = xnvme_be_macos_sync_cmd_io,
+	.cmd_iov = xnvme_be_macos_sync_cmd_iov,
+#else
+	.cmd_io = xnvme_be_nosys_sync_cmd_io,
+	.cmd_iov = xnvme_be_nosys_sync_cmd_iov,
+#endif
+};

--- a/lib/xnvme_be_psync.c
+++ b/lib/xnvme_be_psync.c
@@ -1,0 +1,123 @@
+// Copyright (C) Mads Ynddal <m.ynddal@samsung.com>
+// Copyright (C) Simon A. F. Lund <simon.lund@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#ifndef _BSD_SOURCE
+#define _BSD_SOURCE
+#endif
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#endif
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+
+#if defined(XNVME_BE_FBSD_ENABLED) || defined(XNVME_BE_MACOS_ENABLED) || \
+	defined(XNVME_BE_POSIX_ENABLED) || defined(XNVME_BE_LINUX_BLOCK_ENABLED)
+#include <errno.h>
+#include <unistd.h>
+#include <libxnvme_spec_fs.h>
+#include <xnvme_dev.h>
+
+#ifdef XNVME_BE_FBSD_ENABLED
+#include <sys/uio.h>
+#endif
+
+int
+_xnvme_be_psync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes,
+		       void *XNVME_UNUSED(mbuf), size_t XNVME_UNUSED(mbuf_nbytes), int fd)
+{
+	const uint64_t ssw = ctx->dev->geo.ssw;
+	ssize_t res;
+
+	///< NOTE: opcode-dispatch (io)
+	switch (ctx->cmd.common.opcode) {
+	case XNVME_SPEC_NVM_OPC_WRITE:
+		res = pwrite(fd, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba << ssw);
+		break;
+
+	case XNVME_SPEC_NVM_OPC_READ:
+		res = pread(fd, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba << ssw);
+		break;
+
+	case XNVME_SPEC_FS_OPC_WRITE:
+		res = pwrite(fd, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba);
+		break;
+
+	case XNVME_SPEC_FS_OPC_READ:
+		res = pread(fd, dbuf, dbuf_nbytes, ctx->cmd.nvm.slba);
+		break;
+
+	case XNVME_SPEC_NVM_OPC_FLUSH:
+	case XNVME_SPEC_FS_OPC_FLUSH:
+		res = fsync(fd);
+		break;
+
+	default:
+		XNVME_DEBUG("FAILED: nosys opcode: %d", ctx->cmd.common.opcode);
+		return -ENOSYS;
+	}
+
+	ctx->cpl.result = res;
+	if (res < 0) {
+		XNVME_DEBUG("FAILED: {pread,pwrite,fsync}(), errno: %d", errno);
+		ctx->cpl.result = 0;
+		ctx->cpl.status.sc = errno;
+		ctx->cpl.status.sct = XNVME_STATUS_CODE_TYPE_VENDOR;
+		return -errno;
+	}
+
+	return 0;
+}
+
+// NOTE: preadv/pwritev is not strictly POSIX-compliant, but we use it for FreeBSD, macOS and Linux
+// backends. This is not used in the POSIX backend.
+#if defined(XNVME_BE_FBSD_ENABLED) || defined(XNVME_BE_MACOS_ENABLED) || \
+	defined(XNVME_BE_LINUX_BLOCK_ENABLED)
+int
+_xnvme_be_psync_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, size_t dvec_cnt,
+			size_t XNVME_UNUSED(dvec_nbytes), struct iovec *XNVME_UNUSED(mvec),
+			size_t XNVME_UNUSED(mvec_cnt), size_t XNVME_UNUSED(mvec_nbytes), int fd)
+{
+	const uint64_t ssw = ctx->dev->geo.ssw;
+	ssize_t res;
+
+	///< NOTE: opcode-dispatch (io)
+	switch (ctx->cmd.common.opcode) {
+	case XNVME_SPEC_NVM_OPC_WRITE:
+		res = pwritev(fd, dvec, dvec_cnt, ctx->cmd.nvm.slba << ssw);
+		break;
+
+	case XNVME_SPEC_NVM_OPC_READ:
+		res = preadv(fd, dvec, dvec_cnt, ctx->cmd.nvm.slba << ssw);
+		break;
+
+	case XNVME_SPEC_FS_OPC_WRITE:
+		res = pwritev(fd, dvec, dvec_cnt, ctx->cmd.nvm.slba);
+		break;
+
+	case XNVME_SPEC_FS_OPC_READ:
+		res = preadv(fd, dvec, dvec_cnt, ctx->cmd.nvm.slba);
+		break;
+
+	case XNVME_SPEC_NVM_OPC_FLUSH:
+	case XNVME_SPEC_FS_OPC_FLUSH:
+		res = fsync(fd);
+		break;
+
+	default:
+		XNVME_DEBUG("FAILED: nosys opcode: %d", ctx->cmd.common.opcode);
+		return -ENOSYS;
+	}
+
+	ctx->cpl.result = res;
+	if (res < 0) {
+		XNVME_DEBUG("FAILED: {pread,pwrite,fsync}(), errno: %d", errno);
+		ctx->cpl.result = 0;
+		ctx->cpl.status.sc = errno;
+		ctx->cpl.status.sct = XNVME_STATUS_CODE_TYPE_VENDOR;
+		return -errno;
+	}
+
+	return 0;
+}
+#endif
+#endif


### PR DESCRIPTION
Merge the identical code for sync backends for FreeBSD, Linux and macOS.
By unifying the code, we eliminate redundancy, and make the code more
concise.

With the unified code, a trivial macOS backend is added. This can be
used as the foundation for more platform-specific features.

Signed-off-by: Mads Ynddal <m.ynddal@samsung.com>