### PR TITLE
feat:scripts: add spectract #wip

### DIFF
--- a/scripts/spectract/README.rst
+++ b/scripts/spectract/README.rst
@@ -1,0 +1,50 @@
+Spectract
+=========
+
+Spectract consists of python scripts to extract and parse tables
+from NVMe specification documents to yaml.
+
+The entrypoint is the script::
+
+  spectract.py
+  
+This supports the command::
+
+  spectract.py extract [-h] file
+
+Where ``file`` is a yaml file formatted like the example below::
+
+   - input: nvme-document.pdf
+     pages: 103-104
+     tables: 0-1
+     name: xnvme_spec_cmd_cdw0
+   - input: nvme-document.pdf
+     pages: 104-106
+     tables: 1-3
+     name: xnvme_spec_cmd_common
+   - input: nvme-document.pdf
+     pages: 106
+     tables: 1
+     name: xnvme_spec_cmd_common_admin
+
+Below is the definition of the keys: 
+
+input
+  The file to extract the table from
+
+  string
+  
+pages
+  The pages to extract the table from
+
+  string with format 1 or 1-3
+
+tables
+  The indices of the desired tables in the page range
+
+  string with format 0 or 0-3
+
+name
+  The name of the generated struct, enumerator, etc.
+
+  string with no spaces

--- a/scripts/spectract/requirements.txt
+++ b/scripts/spectract/requirements.txt
@@ -1,0 +1,3 @@
+"camelot-py[cv]"
+pandas
+pyyaml

--- a/scripts/spectract/spectract.py
+++ b/scripts/spectract/spectract.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""
+Extract content of NVMe specification table and convert it to yaml
+"""
+import argparse
+import os
+import sys
+
+import spectract_scheduler
+import spectract_parser
+
+
+def expand_path(path):
+    """Expands variables from the given path and turns it into absolute path"""
+
+    return os.path.abspath(os.path.expanduser(os.path.expandvars(path)))
+
+
+def process_parser_args(args):
+    """Process the arguments and enforce defaults if values are undefined"""
+    input_file = expand_path(args.input)
+    pages = args.pages
+    if args.output is None:
+        filename = os.path.splitext(os.path.basename(args.input))[0]
+        output_file = f'{filename}_{args.pages}_{args.tables}.yaml'
+    else:
+        output_file = args.output
+    table_indices = [int(i) for i in args.tables.split('-')]
+    return input_file, pages, table_indices, output_file
+
+
+def parser(args):
+    input_file, pages, table_indices, output_file = process_parser_args(args)
+    spectract_parser.main(input_file, pages, table_indices, output_file)
+
+
+def scheduler(args):
+    spectract_scheduler.main(expand_path(args.file))
+
+
+def main():
+    """Parse command-line arguments and call relevant function"""
+    prsr = argparse.ArgumentParser(
+        description='Extract content from NVMe specification and convert it to yaml',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    subprsrs = prsr.add_subparsers()
+
+    subprsr_scheduler = subprsrs.add_parser('multiple',
+                                            help='Extract multiple tables by defining targets in a yaml file')
+    subprsr_scheduler.add_argument(
+        'file',
+        help='The yaml file containing the targets to extract from',
+    )
+
+    subprsr_scheduler.set_defaults(func=scheduler)
+
+    subprsr_parser = subprsrs.add_parser('single',
+                                         help='Extract a single table with command line arguments')
+    subprsr_parser.add_argument(
+        '--input', '-i',
+        help='The file to extract the table from',
+        required=True
+    )
+    subprsr_parser.add_argument(
+        '--pages', '-p',
+        help='The pages to extract the table from, input a string with format 1 or 1-3',
+        required=True
+    )
+    subprsr_parser.add_argument(
+        '--tables', '-t',
+        help='The indices of the desired tables in the page range, input a string with format 0 or 0-3',
+        required=True
+    )
+
+    subprsr_parser.add_argument(
+        '--output', '-o',
+        help='The file to write the result to, defaults to <input filename>_<pages>_<tables>.yaml',
+        required=False,
+    )
+
+    subprsr_parser.set_defaults(func=parser)
+
+    args = prsr.parse_args()
+
+    args.func(args)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/spectract/spectract.py
+++ b/scripts/spectract/spectract.py
@@ -7,31 +7,12 @@ import os
 import sys
 
 import spectract_scheduler
-import spectract_parser
 
 
 def expand_path(path):
     """Expands variables from the given path and turns it into absolute path"""
 
     return os.path.abspath(os.path.expanduser(os.path.expandvars(path)))
-
-
-def process_parser_args(args):
-    """Process the arguments and enforce defaults if values are undefined"""
-    input_file = expand_path(args.input)
-    pages = args.pages
-    if args.output is None:
-        filename = os.path.splitext(os.path.basename(args.input))[0]
-        output_file = f'{filename}_{args.pages}_{args.tables}.yaml'
-    else:
-        output_file = args.output
-    table_indices = [int(i) for i in args.tables.split('-')]
-    return input_file, pages, table_indices, output_file
-
-
-def parser(args):
-    input_file, pages, table_indices, output_file = process_parser_args(args)
-    spectract_parser.main(input_file, pages, table_indices, output_file)
 
 
 def scheduler(args):
@@ -47,40 +28,17 @@ def main():
 
     subprsrs = prsr.add_subparsers()
 
-    subprsr_scheduler = subprsrs.add_parser('multiple',
-                                            help='Extract multiple tables by defining targets in a yaml file')
+    subprsr_scheduler = subprsrs.add_parser(
+        'extract',
+        help='Extract tables by defining targets in a yaml file'
+    )
+
     subprsr_scheduler.add_argument(
         'file',
-        help='The yaml file containing the targets to extract from',
+        help='The yaml file containing the targets to extract',
     )
 
     subprsr_scheduler.set_defaults(func=scheduler)
-
-    subprsr_parser = subprsrs.add_parser('single',
-                                         help='Extract a single table with command line arguments')
-    subprsr_parser.add_argument(
-        '--input', '-i',
-        help='The file to extract the table from',
-        required=True
-    )
-    subprsr_parser.add_argument(
-        '--pages', '-p',
-        help='The pages to extract the table from, input a string with format 1 or 1-3',
-        required=True
-    )
-    subprsr_parser.add_argument(
-        '--tables', '-t',
-        help='The indices of the desired tables in the page range, input a string with format 0 or 0-3',
-        required=True
-    )
-
-    subprsr_parser.add_argument(
-        '--output', '-o',
-        help='The file to write the result to, defaults to <input filename>_<pages>_<tables>.yaml',
-        required=False,
-    )
-
-    subprsr_parser.set_defaults(func=parser)
 
     args = prsr.parse_args()
 

--- a/scripts/spectract/spectract.py
+++ b/scripts/spectract/spectract.py
@@ -22,20 +22,19 @@ def scheduler(args):
 def main():
     """Parse command-line arguments and call relevant function"""
     prsr = argparse.ArgumentParser(
-        description='Extract content from NVMe specification and convert it to yaml',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        description="Extract content from NVMe specification and convert it to yaml",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
     subprsrs = prsr.add_subparsers()
 
     subprsr_scheduler = subprsrs.add_parser(
-        'extract',
-        help='Extract tables by defining targets in a yaml file'
+        "extract", help="Extract tables by defining targets in a yaml file"
     )
 
     subprsr_scheduler.add_argument(
-        'file',
-        help='The yaml file containing the targets to extract',
+        "file",
+        help="The yaml file containing the targets to extract",
     )
 
     subprsr_scheduler.set_defaults(func=scheduler)
@@ -45,5 +44,5 @@ def main():
     args.func(args)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/spectract/spectract.py
+++ b/scripts/spectract/spectract.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """
-Extract content of NVMe specification table and convert it to yaml
+Extract content of NVMe specification tables and generate C header
 """
 import argparse
 import os
 import sys
 
+import spectract_generator
 import spectract_scheduler
 
 
@@ -19,10 +20,14 @@ def scheduler(args):
     spectract_scheduler.main(expand_path(args.file))
 
 
+def generator(args):
+    spectract_generator.main(expand_path(args.file))
+
+
 def main():
     """Parse command-line arguments and call relevant function"""
     prsr = argparse.ArgumentParser(
-        description="Extract content from NVMe specification and convert it to yaml",
+        description="Extract content from NVMe specification and generate C header",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
@@ -38,6 +43,17 @@ def main():
     )
 
     subprsr_scheduler.set_defaults(func=scheduler)
+
+    subprsr_generator = subprsrs.add_parser(
+        "generate", help="Generate C headers from a yaml file"
+    )
+
+    subprsr_generator.add_argument(
+        "file",
+        help="The yaml file containing the tables to generate the headers from",
+    )
+
+    subprsr_generator.set_defaults(func=generator)
 
     args = prsr.parse_args()
 

--- a/scripts/spectract/spectract_captions.py
+++ b/scripts/spectract/spectract_captions.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Extract table captions from a page in the NVMe specification
+"""
+
+from itertools import pairwise
+import subprocess
+import xml.etree.ElementTree as ET
+
+
+def extract_captions(input_file, pages):
+    """Extract captions from page"""
+    page = pages.split("-")[0]
+    xml = subprocess.run(["pdftohtml", "-f", page, "-l", page, "-xml", "-stdout", "-i",input_file], stdout=subprocess.PIPE, text=True)
+    tree = ET.fromstring(xml.stdout)
+    elements = tree.findall(".//text[@font='2'][b]")
+    return list(
+        yield_text(
+            remove_non_figure_text(
+                concat_dashed_elements(
+                    remove_empty_elements(
+                        flatten_bold_elements(elements))))))
+
+
+def flatten_bold_elements(elements):
+    """Make parent include text from a bold child"""
+    for element in elements:
+        child = element.find(".//b")
+        element.text = child.text
+        yield element
+
+
+def remove_empty_elements(elements):
+    """Remove any elements with no text"""
+    for element in elements:
+        if element.text.strip():
+            yield element
+
+
+def remove_non_figure_text(elements):
+    """Remove any elements that doesn't include 'Figure'"""
+    for element in elements:
+        if element.text.startswith("Figure"):
+            yield element
+
+
+def yield_text(elements):
+    """Yield only the text of each element"""
+    for element in elements:
+        yield element.text
+
+
+def concat_dashed_elements(elements):
+    """Remove false linebreaks caused by a dash"""
+    skip = False
+    for first, second in pairwise(elements):
+        second_left = int(second.get("left"))
+        first_right = int(first.get("left")) + int(first.get("width"))
+        if 0 <= second_left - first_right < 3:
+            first.text += second.text
+            skip = True
+            yield first
+        elif not skip:
+            yield first
+        else:
+            skip = False
+
+
+def main(input_file, pages):
+    """Entry point"""
+    try:
+        return extract_captions(input_file, pages)
+    except FileNotFoundError:
+        return {}

--- a/scripts/spectract/spectract_generator.py
+++ b/scripts/spectract/spectract_generator.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Generate C headers from a yaml file
+"""
+import yaml
+
+import spectract_transformer
+
+comment_start = r"/**"
+comment_end = r"*/"
+curly_start = r"{"
+curly_end = r"};"
+
+
+def print_lines(lines):
+    for line in lines:
+        print(line)
+
+
+def gen_doc(table, table_name, table_type):
+    """Generate docstrings from table"""
+    lines = []
+    lines.append(comment_start)
+    for row in table:
+        row_name = row["name"]
+        row_description = row["description"]
+        lines.append(f"* @var {row_name} {row_description}")
+
+    lines.append(f"* @{table_type} {table_name}")
+    lines.append(comment_end)
+    return lines
+
+
+def gen_enum(table_name, table):
+    """Generate an enum from table"""
+    doc = gen_doc(table, table_name, "enum")
+
+    code = []
+    code.append(f"enum {table_name} " + curly_start)
+    for row in table:
+        row_name = row["name"]
+        row_value = row["value"]
+        code.append(f"{row_name} = {row_value},")
+    code.append(curly_end)
+    return doc + code
+
+
+def generate(tables):
+    """Generate C headers from tables"""
+    for table_name, table in tables.items():
+        yield gen_enum(table_name, table)
+
+
+def write_header(tables):
+    """Write to header file"""
+    with open("header.h", "w") as file:
+        file.write("%s\n" % comment_start)
+        file.write("* @headerfile header.h\n")
+        file.write("%s\n" % comment_end)
+        for table in generate(tables):
+            for line in table:
+                file.write("%s\n" % line)
+
+
+def main(yaml_file):
+    """Entry point"""
+    try:
+        with open(yaml_file, 'r') as stream:
+            try:
+                tables = spectract_transformer.main(yaml.safe_load(stream))
+            except yaml.YAMLError as err:
+                print(err)
+                return 1
+        write_header(tables)
+    except FileNotFoundError:
+        return 1
+
+    return 0

--- a/scripts/spectract/spectract_parser.py
+++ b/scripts/spectract/spectract_parser.py
@@ -2,16 +2,23 @@
 """
 Extract content of NVMe specification table and convert it to yaml
 """
+
 import re
 
 import camelot
 import pandas
+
+import spectract_captions
 
 
 def extract_table(input_file, pages, table_indices):
     """Read tables, remove first row of each and concatenate"""
 
     tables = camelot.read_pdf(input_file, pages, line_scale=35)
+    captions = spectract_captions.main(input_file, pages)
+    assert(len(tables) == len(captions))
+
+    caption = captions[table_indices[0]]
     headings = extract_headings(tables[table_indices[0]].df.head(1).to_numpy()[0])
 
     if len(table_indices) == 1:
@@ -20,7 +27,7 @@ def extract_table(input_file, pages, table_indices):
         table = pandas.concat(
             [t.df.drop(0) for t in tables[table_indices[0] : table_indices[1] + 1]]
         ).reset_index(drop=True)
-    return extract_content(headings, table)
+    return {caption: extract_content(headings, table)}
 
 
 def extract_headings(row):

--- a/scripts/spectract/spectract_parser.py
+++ b/scripts/spectract/spectract_parser.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Extract content of NVMe specification table and convert it to yaml
+"""
+import camelot
+import pandas
+import yaml
+import re
+import argparse
+import os
+import sys
+
+
+def expand_path(path):
+    """Expands variables from the given path and turns it into absolute path"""
+
+    return os.path.abspath(os.path.expanduser(os.path.expandvars(path)))
+
+
+def process_args(args):
+    """Process the arguments and enforce defaults if values are undefined"""
+    args.input = expand_path(args.input)
+    if args.output is None:
+        filename = os.path.splitext(os.path.basename(args.input))[0]
+        args.output = f'{filename}_{args.pages}_{args.tables}.yaml'
+
+    args.tables = [int(i) for i in args.tables.split('-')]
+    return args
+
+
+def setup():
+    """Parse command-line arguments"""
+
+    prsr = argparse.ArgumentParser(
+        description='Extract content of NVMe specification table and convert to yaml',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    prsr.add_argument(
+        '--input', '-i',
+        help='The file to extract the table from',
+        required=True
+    )
+    prsr.add_argument(
+        '--pages', '-p',
+        help='The pages to extract the table from, input a string with format 1 or 1-3',
+        required=True
+    )
+    prsr.add_argument(
+        '--tables', '-t',
+        help='The indices of the desired tables in the page range, input a string with format 0 or 0-3',
+        required=True
+    )
+
+    prsr.add_argument(
+        '--output', '-o',
+        help='The file to write the result to, defaults to <input filename>_<pages>_<tables>.yaml',
+        required=False,
+    )
+    args = prsr.parse_args()
+    args = process_args(args)
+    return args
+
+
+def extract_table(args):
+    """Read tables, remove first row of each and concatenate"""
+
+    tables = camelot.read_pdf(args.input, args.pages)
+    args.headings = extract_headings(tables[args.tables[0]].df)
+
+    if len(args.tables) == 1:
+        args.table = tables[args.tables[0]].df.drop(0).reset_index(drop=True)
+    else:
+        args.table = pandas.concat([t.df.drop(0)
+                                    for t in
+                                    tables[args.tables[0]:args.tables[1]+1]]).reset_index(drop=True)
+    return args
+
+
+def extract_headings(table):
+    """Extract headings from first row of table given as a dataframe"""
+
+    return [h.lower().replace('\n', '')
+            for row in table.head(1).to_numpy()
+            for h in row
+            if h not in [None, '']]
+
+
+def extract_row(row, headings, start_index):
+    """Extract content from row given as a tuple"""
+    content = {'children': []}
+
+    name_brief_verbose_regex = re.compile('(?P<brief>.+?)\((?P<name>.+?)\):(?P<verbose>.+)')
+    brief_verbose_regex = re.compile('(?P<brief>.+?):(?P<verbose>.+)')
+
+    for i, h in enumerate(headings):
+        if h in ['bits', 'bytes']:
+            content[h] = [int(b) for b in row[start_index+i].split(':')]
+
+        elif match := name_brief_verbose_regex.match(row[start_index + i].replace('\n', '')):
+            content['name'] = match.group('name').strip().lower()
+            content['brief'] = match.group('brief').strip()
+            content['verbose'] = match.group('verbose').strip()
+
+        elif match := brief_verbose_regex.match(row[start_index + i].replace('\n', '')):
+            content['brief'] = match.group('brief').strip()
+            content['verbose'] = match.group('verbose').strip()
+
+        else:
+            content[h] = row[start_index+i]
+
+    return content
+
+
+def extract_content(args):
+    """Extract content from table"""
+    output = []
+    subheadings = None
+    for row in args.table.itertuples(index=False, name=None):
+        if row[0] != '':
+            output.append(extract_row(row, args.headings, 0))
+
+            # reset subheadings
+            subheadings = None
+
+        # Extract from nested tables
+        elif row[len(args.headings)] != '':
+            if subheadings is None and row[len(args.headings)].lower() in ['bits','bytes','value','code']:
+                subheadings = [h.lower().replace('\n', '')
+                               for h in row
+                               if h not in [None, '']]
+            elif subheadings:
+                output[-1]['children'].append(extract_row(row, subheadings, len(args.headings)))
+            else:
+                output[-1]['children'].append(extract_row(row, args.headings, len(args.headings)))
+
+    return output
+
+
+def write_to_yaml(output, filename):
+    """Write output to yaml"""
+    with open(filename, 'w') as file:
+        yaml.dump(output, file, default_flow_style=None)
+
+
+def main(args):
+    """Entry point"""
+    try:
+        write_to_yaml(extract_content(extract_table(args)), args.output)
+    except FileNotFoundError:
+        return 1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(setup()))

--- a/scripts/spectract/spectract_parser.py
+++ b/scripts/spectract/spectract_parser.py
@@ -4,7 +4,6 @@ Extract content of NVMe specification table and convert it to yaml
 """
 import camelot
 import pandas
-import yaml
 import re
 
 
@@ -83,17 +82,9 @@ def extract_content(headings, table):
     return output
 
 
-def write_to_yaml(output, filename):
-    """Write output to yaml"""
-    with open(filename, 'w') as file:
-        yaml.dump(output, file, default_flow_style=None)
-
-
-def main(input_file, pages, table_indices, output_file):
+def main(input_file, pages, table_indices):
     """Entry point"""
     try:
-        write_to_yaml(extract_table(input_file, pages, table_indices), output_file)
+        return extract_table(input_file, pages, table_indices)
     except FileNotFoundError:
-        return 1
-
-    return 0
+        return {}

--- a/scripts/spectract/spectract_parser.py
+++ b/scripts/spectract/spectract_parser.py
@@ -85,10 +85,12 @@ def extract_content(headings, table):
                 "code",
             ]:
                 subheadings = extract_headings(row)
-        elif subheadings:
-            output[-1]["children"].append(extract_row(row, subheadings, len(headings)))
-        else:
-            output[-1]["children"].append(extract_row(row, headings, len(headings)))
+            elif subheadings:
+                output[-1]["children"].append(
+                    extract_row(row, subheadings, len(headings))
+                )
+            else:
+                output[-1]["children"].append(extract_row(row, headings, len(headings)))
 
     return output
 

--- a/scripts/spectract/spectract_parser.py
+++ b/scripts/spectract/spectract_parser.py
@@ -11,7 +11,7 @@ import pandas
 def extract_table(input_file, pages, table_indices):
     """Read tables, remove first row of each and concatenate"""
 
-    tables = camelot.read_pdf(input_file, pages)
+    tables = camelot.read_pdf(input_file, pages, line_scale=35)
     headings = extract_headings(tables[table_indices[0]].df.head(1).to_numpy()[0])
 
     if len(table_indices) == 1:

--- a/scripts/spectract/spectract_parser.py
+++ b/scripts/spectract/spectract_parser.py
@@ -6,74 +6,21 @@ import camelot
 import pandas
 import yaml
 import re
-import argparse
-import os
-import sys
 
 
-def expand_path(path):
-    """Expands variables from the given path and turns it into absolute path"""
-
-    return os.path.abspath(os.path.expanduser(os.path.expandvars(path)))
-
-
-def process_args(args):
-    """Process the arguments and enforce defaults if values are undefined"""
-    args.input = expand_path(args.input)
-    if args.output is None:
-        filename = os.path.splitext(os.path.basename(args.input))[0]
-        args.output = f'{filename}_{args.pages}_{args.tables}.yaml'
-
-    args.tables = [int(i) for i in args.tables.split('-')]
-    return args
-
-
-def setup():
-    """Parse command-line arguments"""
-
-    prsr = argparse.ArgumentParser(
-        description='Extract content of NVMe specification table and convert to yaml',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
-    )
-    prsr.add_argument(
-        '--input', '-i',
-        help='The file to extract the table from',
-        required=True
-    )
-    prsr.add_argument(
-        '--pages', '-p',
-        help='The pages to extract the table from, input a string with format 1 or 1-3',
-        required=True
-    )
-    prsr.add_argument(
-        '--tables', '-t',
-        help='The indices of the desired tables in the page range, input a string with format 0 or 0-3',
-        required=True
-    )
-
-    prsr.add_argument(
-        '--output', '-o',
-        help='The file to write the result to, defaults to <input filename>_<pages>_<tables>.yaml',
-        required=False,
-    )
-    args = prsr.parse_args()
-    args = process_args(args)
-    return args
-
-
-def extract_table(args):
+def extract_table(input_file, pages, table_indices):
     """Read tables, remove first row of each and concatenate"""
 
-    tables = camelot.read_pdf(args.input, args.pages)
-    args.headings = extract_headings(tables[args.tables[0]].df)
+    tables = camelot.read_pdf(input_file, pages)
+    headings = extract_headings(tables[table_indices[0]].df)
 
-    if len(args.tables) == 1:
-        args.table = tables[args.tables[0]].df.drop(0).reset_index(drop=True)
+    if len(table_indices) == 1:
+        table = tables[table_indices[0]].df.drop(0).reset_index(drop=True)
     else:
-        args.table = pandas.concat([t.df.drop(0)
-                                    for t in
-                                    tables[args.tables[0]:args.tables[1]+1]]).reset_index(drop=True)
-    return args
+        table = pandas.concat([t.df.drop(0)
+                               for t in
+                               tables[table_indices[0]:table_indices[1]+1]]).reset_index(drop=True)
+    return extract_content(headings, table)
 
 
 def extract_headings(table):
@@ -111,27 +58,27 @@ def extract_row(row, headings, start_index):
     return content
 
 
-def extract_content(args):
+def extract_content(headings, table):
     """Extract content from table"""
     output = []
     subheadings = None
-    for row in args.table.itertuples(index=False, name=None):
+    for row in table.itertuples(index=False, name=None):
         if row[0] != '':
-            output.append(extract_row(row, args.headings, 0))
+            output.append(extract_row(row, headings, 0))
 
             # reset subheadings
             subheadings = None
 
         # Extract from nested tables
-        elif row[len(args.headings)] != '':
-            if subheadings is None and row[len(args.headings)].lower() in ['bits','bytes','value','code']:
+        elif row[len(headings)] != '':
+            if subheadings is None and row[len(headings)].lower() in ['bits','bytes','value','code']:
                 subheadings = [h.lower().replace('\n', '')
                                for h in row
                                if h not in [None, '']]
             elif subheadings:
-                output[-1]['children'].append(extract_row(row, subheadings, len(args.headings)))
+                output[-1]['children'].append(extract_row(row, subheadings, len(headings)))
             else:
-                output[-1]['children'].append(extract_row(row, args.headings, len(args.headings)))
+                output[-1]['children'].append(extract_row(row, headings, len(headings)))
 
     return output
 
@@ -142,15 +89,11 @@ def write_to_yaml(output, filename):
         yaml.dump(output, file, default_flow_style=None)
 
 
-def main(args):
+def main(input_file, pages, table_indices, output_file):
     """Entry point"""
     try:
-        write_to_yaml(extract_content(extract_table(args)), args.output)
+        write_to_yaml(extract_table(input_file, pages, table_indices), output_file)
     except FileNotFoundError:
         return 1
 
     return 0
-
-
-if __name__ == '__main__':
-    sys.exit(main(setup()))

--- a/scripts/spectract/spectract_scheduler.py
+++ b/scripts/spectract/spectract_scheduler.py
@@ -26,9 +26,12 @@ def process_target(target):
 
 
 def schedule(targets):
-    """Assign each target to a different process"""
+    """Assign each target to a different process and collect results in dict"""
     with concurrent.futures.ProcessPoolExecutor(10) as executor:
-        return list(executor.map(parse, targets))
+        tables = {}
+        for table in executor.map(parse, targets):
+            tables.update(table)
+        return tables
 
 
 def parse(target):

--- a/scripts/spectract/spectract_scheduler.py
+++ b/scripts/spectract/spectract_scheduler.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Schedule multiple instances of the spectract parser from a yaml file
+"""
+import concurrent.futures
+import argparse
+import os
+import sys
+import yaml
+
+import spectract_parser
+
+
+def expand_path(path):
+    """Expands variables from the given path and turns it into absolute path"""
+
+    return os.path.abspath(os.path.expanduser(os.path.expandvars(path)))
+
+
+def setup():
+    """Parse command-line arguments"""
+
+    prsr = argparse.ArgumentParser(
+        description='Schedule multiple instances of the spectract parser from a yaml file',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    prsr.add_argument(
+        'file',
+        help='The yaml file containing the targets to parse',
+    )
+
+    args = prsr.parse_args()
+    args.file = expand_path(args.file)
+
+    return args
+
+
+def process_args(target, args):
+    """Assign the values from the target to args and return args"""
+    args.input = target['input']
+    args.pages = str(target['pages'])
+    args.tables = str(target['tables'])
+    if 'output' not in target:
+        args.output = None
+
+    return spectract_parser.process_args(args)
+
+
+def schedule(targets, args):
+    """Assign each target to a different process"""
+    executor = concurrent.futures.ProcessPoolExecutor(10)
+    futures = [executor.submit(parse, target, args) for target in targets]
+    concurrent.futures.wait(futures)
+
+
+def parse(target, args):
+    """Pass args to the parser"""
+    spectract_parser.main(process_args(target, args))
+
+
+def main(args):
+    """Entry point"""
+
+    try:
+        with open(args.file, 'r') as stream:
+            try:
+                schedule(yaml.safe_load(stream), args)
+            except yaml.YAMLError as err:
+                print(err)
+                return 1
+    except FileNotFoundError:
+        return 1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(setup()))

--- a/scripts/spectract/spectract_scheduler.py
+++ b/scripts/spectract/spectract_scheduler.py
@@ -4,10 +4,10 @@ Schedule multiple instances of the spectract parser from a yaml file
 Collect results and write them to yaml
 """
 import concurrent.futures
-import yaml
 import os
 
 import spectract_parser
+import yaml
 
 
 def expand_path(path):
@@ -18,18 +18,17 @@ def expand_path(path):
 
 def process_target(target):
     """Process the values from the target and return them"""
-    input_file = expand_path(target['input'])
-    pages = str(target['pages'])
-    table_indices = [int(i) for i in str(target['tables']).split('-')]
-    name = target['name']
+    input_file = expand_path(target["input"])
+    pages = str(target["pages"])
+    table_indices = [int(i) for i in str(target["tables"]).split("-")]
+    name = target["name"]
     return input_file, pages, table_indices, name
 
 
 def schedule(targets):
     """Assign each target to a different process"""
-    executor = concurrent.futures.ProcessPoolExecutor(10)
-    results = [result for result in executor.map(parse, targets)]
-    return results
+    with concurrent.futures.ProcessPoolExecutor(10) as executor:
+        return list(executor.map(parse, targets))
 
 
 def parse(target):
@@ -40,14 +39,14 @@ def parse(target):
 
 def write_to_yaml(output):
     """Write output to yaml"""
-    with open('output.yaml', 'w') as file:
+    with open("output.yaml", "w") as file:
         yaml.dump(output, file, default_flow_style=None)
 
 
 def main(yaml_file):
     """Entry point"""
     try:
-        with open(yaml_file, 'r') as stream:
+        with open(yaml_file, "r") as stream:
             try:
                 write_to_yaml(schedule(yaml.safe_load(stream)))
             except yaml.YAMLError as err:

--- a/scripts/spectract/spectract_scheduler.py
+++ b/scripts/spectract/spectract_scheduler.py
@@ -21,8 +21,7 @@ def process_target(target):
     input_file = expand_path(target["input"])
     pages = str(target["pages"])
     table_indices = [int(i) for i in str(target["tables"]).split("-")]
-    name = target["name"]
-    return input_file, pages, table_indices, name
+    return input_file, pages, table_indices
 
 
 def schedule(targets):
@@ -36,8 +35,8 @@ def schedule(targets):
 
 def parse(target):
     """Pass args to the parser"""
-    input_file, pages, table_indices, name = process_target(target)
-    return {name: spectract_parser.main(input_file, pages, table_indices)}
+    input_file, pages, table_indices = process_target(target)
+    return spectract_parser.main(input_file, pages, table_indices)
 
 
 def write_to_yaml(output):

--- a/scripts/spectract/spectract_transformer.py
+++ b/scripts/spectract/spectract_transformer.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Transform and clean up tables
+"""
+
+
+class Table(list):
+
+    def __init__(self, name, content):
+        self.name = name
+        self.content = content
+        self.headings = content[0].keys()
+
+    def print_rows(self):
+        for row in self.content:
+            print(row)
+
+    def remove_value_ranges(self):
+        if "value" in self.headings:
+            self.content = [row for row in self.content if "to" not in row["value"]]
+
+    def remove_empty_children(self):
+        for row in self.content:
+            if not row["children"]:
+                del row["children"]
+
+    def generate_name(self):
+        if "name" not in self.headings:
+            for row in self.content:
+                name = row["definition"] if "definition" in row.keys() else row["description"]
+                row["name"] = name.upper().replace(" ", "_")
+
+    def convert_values_to_hex(self):
+        if "value" in self.headings:
+            for row in self.content:
+                row["value"] = "0x" + row["value"].strip("h")
+
+
+def transform(tables):
+    transformed = {}
+    for name, content in tables.items():
+        table = Table(name, content)
+        table.remove_empty_children()
+        table.remove_value_ranges()
+        table.generate_name()
+        table.convert_values_to_hex()
+        transformed[table.name] = table.content
+
+    return transformed
+
+
+def main(tables):
+    """Entry point"""
+    return transform(tables)


### PR DESCRIPTION
Spectract consists of python scripts to extract and parse tables 
from NVMe specification documents to yaml.

The entry point is `spectract.py`

It works as described below:
```
usage: spectract.py [-h] {extract} ...

Extract content from NVMe specification and convert it to yaml

positional arguments:
  {extract}
    extract   Extract tables by defining targets in a yaml file

options:
  -h, --help  show this help message and exit
```

```
usage: spectract.py extract [-h] file

positional arguments:
  file        The yaml file containing the targets to extract

options:
  -h, --help  show this help message and exit
```

Below is an example of an input yaml file for `spectract.py extract`:
```yaml
- input: nvme-document.pdf
  pages: 103-104
  tables: 0-1
  name: xnvme_spec_cmd_cdw0
- input: nvme-document.pdf
  pages: 104-106
  tables: 1-3
  name: xnvme_spec_cmd_common
- input: nvme-document.pdf
  pages: 106
  tables: 1
  name: xnvme_spec_cmd_common_admin
```

This will extract 3 tables into a single yaml file 

More information can be found in `README.rst`

Signed-off-by: Karl Bonde Torp <k.torp@samsung.com>