### PR TITLE
be:macos: Add simple backend for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ endef
 .PHONY: clean-subprojects
 clean-subprojects:
 	@echo "## xNVMe: make clean-subprojects"
-	@if [ -d "subprojects/spdk" ]; then cd subprojects/spdk &&$(MAKE) clean; fi;
+	@if [ -d "subprojects/spdk" ] && [ ${PLATFORM_ID} != 'Darwin' ]; then cd subprojects/spdk &&$(MAKE) clean; fi;
 	@if [ -d "subprojects/fio" ]; then cd subprojects/fio && $(MAKE) clean; fi;
 	@if [ -d "subprojects/liburing" ]; then cd subprojects/liburing &&$(MAKE) clean; fi;
 	rm -fr $(BUILD_DIR) || true

--- a/include/xnvme_be_macos.h
+++ b/include/xnvme_be_macos.h
@@ -1,0 +1,26 @@
+// Copyright (C) Mads Ynddal <m.ynddal@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#ifndef __INTERNAL_XNVME_BE_MACOS_H
+#define __INTERNAL_XNVME_BE_MACOS_H
+#include <IOKit/IOTypes.h>
+#include <IOKit/storage/nvme/NVMeSMARTLibExternal.h>
+
+/**
+ * Internal representation of XNVME_BE_MACOS state
+ */
+
+struct xnvme_be_macos_state {
+	int fd;
+	io_object_t ioservice_device;
+	IONVMeSMARTInterface **nvme_smart_interface;
+	IOCFPlugInInterface **plugin_interface;
+
+	uint8_t _rsvd[104];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_be_macos_state) == XNVME_BE_STATE_NBYTES, "Incorrect size")
+
+extern struct xnvme_be_admin g_xnvme_be_macos_admin;
+extern struct xnvme_be_sync g_xnvme_be_macos_sync_psync;
+extern struct xnvme_be_dev g_xnvme_be_macos_dev;
+
+#endif /* __INTERNAL_XNVME_BE_MACOS */

--- a/include/xnvme_be_posix.h
+++ b/include/xnvme_be_posix.h
@@ -14,6 +14,10 @@ XNVME_STATIC_ASSERT(sizeof(struct xnvme_be_posix_state) == XNVME_BE_STATE_NBYTES
 int
 xnvme_be_posix_supported(struct xnvme_dev *dev, uint32_t opts);
 
+int
+xnvme_be_posix_sync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes,
+			   void *XNVME_UNUSED(mbuf), size_t XNVME_UNUSED(mbuf_nbytes));
+
 extern struct xnvme_be_admin g_xnvme_be_posix_admin_shim;
 extern struct xnvme_be_sync g_xnvme_be_posix_sync_psync;
 extern struct xnvme_be_async g_xnvme_be_posix_async_nil;

--- a/include/xnvme_be_registry.h
+++ b/include/xnvme_be_registry.h
@@ -6,6 +6,7 @@
 extern struct xnvme_be xnvme_be_spdk;
 extern struct xnvme_be xnvme_be_linux;
 extern struct xnvme_be xnvme_be_fbsd;
+extern struct xnvme_be xnvme_be_macos;
 extern struct xnvme_be xnvme_be_posix;
 extern struct xnvme_be xnvme_be_ramdisk;
 extern struct xnvme_be xnvme_be_windows;

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -12,6 +12,10 @@ xnvmelib_source = [
   'xnvme_be_linux_block.c',
   'xnvme_be_linux_dev.c',
   'xnvme_be_linux_nvme.c',
+  'xnvme_be_macos.c',
+  'xnvme_be_macos_admin.c',
+  'xnvme_be_macos_dev.c',
+  'xnvme_be_macos_sync.c',
   'xnvme_be_nosys.c',
   'xnvme_be_posix.c',
   'xnvme_be_posix_admin.c',
@@ -69,11 +73,13 @@ xnvmelib_deps_shared = [
   execinfo_dep,
   elf_dep,
   aio_dep,
-  setupapi_dep
+  setupapi_dep,
+  corefoundation_dep,
+  iokit_dep
 ]
 
 xnvmelib_deps_static = []
-xnvmelib_deps_static += [spdk_dep, uring_dep]
+xnvmelib_deps_static += [spdk_dep, uring_dep, corefoundation_dep, iokit_dep]
 xnvmelib_deps = xnvmelib_deps_shared + xnvmelib_deps_static
 
 xnvmelib_deps_bundle = [

--- a/lib/xnvme_be.c
+++ b/lib/xnvme_be.c
@@ -17,13 +17,9 @@
 #include <xnvme_be.h>
 #include <xnvme_dev.h>
 
-static struct xnvme_be *g_xnvme_be_registry[] = {&xnvme_be_spdk,
-						 &xnvme_be_linux,
-						 &xnvme_be_fbsd,
-						 &xnvme_be_posix,
-						 &xnvme_be_ramdisk,
-						 &xnvme_be_windows,
-						 NULL};
+static struct xnvme_be *g_xnvme_be_registry[] = {
+	&xnvme_be_spdk,  &xnvme_be_linux,   &xnvme_be_fbsd,    &xnvme_be_posix,
+	&xnvme_be_macos, &xnvme_be_windows, &xnvme_be_ramdisk, NULL};
 static int g_xnvme_be_count = sizeof g_xnvme_be_registry / sizeof *g_xnvme_be_registry - 1;
 
 int

--- a/lib/xnvme_be_macos.c
+++ b/lib/xnvme_be_macos.c
@@ -1,0 +1,77 @@
+// Copyright (C) Mads Ynddal <m.ynddal@samsung.com>
+// Copyright (C) Simon A. F. Lund <simon.lund@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_MACOS_ENABLED
+#include <xnvme_be_posix.h>
+#include <xnvme_be_macos.h>
+
+static struct xnvme_be_mixin g_xnvme_be_mixin_macos[] = {
+	{
+		.mtype = XNVME_BE_MEM,
+		.name = "posix",
+		.descr = "Use C11 lib malloc/free with sysconf for alignment",
+		.mem = &g_xnvme_be_posix_mem,
+		.check_support = xnvme_be_supported,
+	},
+
+	{
+		.mtype = XNVME_BE_ASYNC,
+		.name = "thrpool",
+		.descr = "Use thread pool for Asynchronous I/O",
+		.async = &g_xnvme_be_posix_async_thrpool,
+		.check_support = xnvme_be_supported,
+	},
+	{
+		.mtype = XNVME_BE_ASYNC,
+		.name = "posix",
+		.descr = "Use POSIX aio for Asynchronous I/O",
+		.async = &g_xnvme_be_posix_async_aio,
+		.check_support = xnvme_be_supported,
+	},
+
+	{
+		.mtype = XNVME_BE_SYNC,
+		.name = "macos",
+		.descr = "Use pread()/write() for synchronous I/O",
+		.sync = &g_xnvme_be_macos_sync_psync,
+		.check_support = xnvme_be_supported,
+	},
+
+	{
+		.mtype = XNVME_BE_ADMIN,
+		.name = "macos",
+		.descr = "Use macOS NVMe SMART Interface admin commands",
+		.admin = &g_xnvme_be_macos_admin,
+		.check_support = xnvme_be_supported,
+	},
+
+	{
+		.mtype = XNVME_BE_DEV,
+		.name = "macos",
+		.descr = "Use macOS file/dev handles and enumerate NVMe devices",
+		.dev = &g_xnvme_be_macos_dev,
+		.check_support = xnvme_be_supported,
+	},
+};
+#endif
+
+struct xnvme_be xnvme_be_macos = {
+	.admin = XNVME_BE_NOSYS_ADMIN,
+	.async = XNVME_BE_NOSYS_QUEUE,
+	.dev = XNVME_BE_NOSYS_DEV,
+	.mem = XNVME_BE_NOSYS_MEM,
+	.sync = XNVME_BE_NOSYS_SYNC,
+	.attr =
+		{
+#ifdef XNVME_BE_MACOS_ENABLED
+			.enabled = 1,
+#endif
+			.name = "macos",
+		},
+#ifdef XNVME_BE_MACOS_ENABLED
+	.nobjs = sizeof g_xnvme_be_mixin_macos / sizeof *g_xnvme_be_mixin_macos,
+	.objs = g_xnvme_be_mixin_macos,
+#endif
+};

--- a/lib/xnvme_be_macos_admin.c
+++ b/lib/xnvme_be_macos_admin.c
@@ -22,6 +22,26 @@
 #include <fcntl.h>
 
 int
+_gfeat(struct xnvme_cmd_ctx *ctx, void *XNVME_UNUSED(dbuf))
+{
+	struct xnvme_spec_feat feat = {0};
+
+	switch (ctx->cmd.gfeat.cdw10.fid) {
+	case XNVME_SPEC_FEAT_NQUEUES:
+		feat.nqueues.nsqa = 63;
+		feat.nqueues.ncqa = 63;
+		ctx->cpl.cdw0 = feat.val;
+		break;
+
+	default:
+		XNVME_DEBUG("FAILED: unsupported fid: %d", ctx->cmd.gfeat.cdw10.fid);
+		return -ENOSYS;
+	}
+
+	return 0;
+}
+
+int
 xnvme_be_macos_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes,
 		     void *XNVME_UNUSED(mbuf), size_t XNVME_UNUSED(mbuf_nbytes))
 {
@@ -53,6 +73,8 @@ xnvme_be_macos_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes,
 			return 1;
 		}
 		break;
+	case XNVME_SPEC_ADM_OPC_GFEAT:
+		return _gfeat(ctx, dbuf);
 	default:
 		XNVME_DEBUG("FAILED: ENOSYS opcode: %d", ctx->cmd.common.opcode);
 		return -ENOSYS;

--- a/lib/xnvme_be_macos_admin.c
+++ b/lib/xnvme_be_macos_admin.c
@@ -1,0 +1,73 @@
+// Copyright (C) Mads Ynddal <m.ynddal@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_MACOS_ENABLED
+#include <sys/cdefs.h>
+#include <sys/param.h>
+#include <sys/ioccom.h>
+#include <sys/stat.h>
+
+#include <paths.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <libxnvme_spec_fs.h>
+#include <xnvme_dev.h>
+#include <xnvme_be_macos.h>
+#include <mach/mach_error.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/storage/nvme/NVMeSMARTLibExternal.h>
+#include <sys/syslimits.h>
+#include <fcntl.h>
+
+int
+xnvme_be_macos_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes,
+		     void *XNVME_UNUSED(mbuf), size_t XNVME_UNUSED(mbuf_nbytes))
+{
+	IOReturn err;
+	int nsid;
+	struct xnvme_be_macos_state *state = (void *)ctx->dev->be.state;
+
+	switch (ctx->cmd.common.opcode) {
+	case XNVME_SPEC_ADM_OPC_LOG:
+		err = (*state->nvme_smart_interface)
+			      ->GetLogPage(state->nvme_smart_interface, dbuf, ctx->cmd.log.lid,
+					   dbuf_nbytes / 4 - 1);
+		if (err != kIOReturnSuccess) {
+			XNVME_DEBUG("Error in GetLogPage: %s", (char *)mach_error_string(err));
+			return 1;
+		}
+		break;
+	case XNVME_SPEC_ADM_OPC_IDFY:
+		nsid = 0; // 0 for controller identify data as per Apple docs
+		if (ctx->cmd.idfy.cns == 0) {
+			// If we are providing a namespace id, overwrite with that.
+			nsid = ctx->cmd.common.nsid;
+		}
+		err = (*state->nvme_smart_interface)
+			      ->GetIdentifyData(state->nvme_smart_interface, dbuf, nsid);
+		if (err != kIOReturnSuccess) {
+			XNVME_DEBUG("Error in GetIdentifyData: %s",
+				    (char *)mach_error_string(err));
+			return 1;
+		}
+		break;
+	default:
+		XNVME_DEBUG("FAILED: ENOSYS opcode: %d", ctx->cmd.common.opcode);
+		return -ENOSYS;
+	}
+
+	return 0;
+}
+
+#endif
+
+struct xnvme_be_admin g_xnvme_be_macos_admin = {
+	.id = "nvme",
+#ifdef XNVME_BE_MACOS_ENABLED
+	.cmd_admin = xnvme_be_macos_admin,
+#else
+	.cmd_admin = xnvme_be_nosys_sync_cmd_admin,
+#endif
+};

--- a/lib/xnvme_be_macos_dev.c
+++ b/lib/xnvme_be_macos_dev.c
@@ -1,0 +1,291 @@
+// Copyright (C) Mads Ynddal <m.ynddal@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_MACOS_ENABLED
+#include <errno.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <libxnvme_ident.h>
+#include <libxnvme_file.h>
+#include <libxnvme_spec_fs.h>
+#include <xnvme_dev.h>
+#include <xnvme_be_macos.h>
+#include <xnvme_be_posix.h>
+#include <IOKit/storage/nvme/NVMeSMARTLibExternal.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <mach/mach_error.h>
+#include <libgen.h>
+
+#ifndef _PATH_DEV_DISK
+#define _PATH_DEV_DISK "/dev/"
+#define _DISK_PREFIX "disk"
+#define _RDISK_PREFIX "rdisk"
+#endif
+
+io_object_t
+_get_ioservice_device(char *devname)
+{
+	CFMutableDictionaryRef matching_dictionary;
+	io_object_t ioservice_device;
+
+	matching_dictionary = IOBSDNameMatching(kIOMasterPortDefault, 0, basename(devname));
+	ioservice_device = IOServiceGetMatchingService(kIOMasterPortDefault, matching_dictionary);
+	return ioservice_device;
+}
+
+int
+_get_nvme_smart_interface(io_object_t ioservice_device,
+			  IONVMeSMARTInterface ***nvme_smart_interface,
+			  IOCFPlugInInterface ***plugin_interface)
+{
+	io_object_t device = ioservice_device;
+	io_object_t parent_device;
+	CFBooleanRef is_nvme;
+	SInt32 score;
+	kern_return_t ret;
+
+	// Cannot use IORegistryEntrySearchCFProperty, as it won't return the parent having the key
+	while (true) {
+		is_nvme = IORegistryEntryCreateCFProperty(
+			device, CFSTR(kIOPropertyNVMeSMARTCapableKey), kCFAllocatorDefault, 0);
+		if (is_nvme) {
+			CFRelease(is_nvme);
+			break;
+		}
+
+		IOReturn err =
+			IORegistryEntryGetParentEntry(device, kIOServicePlane, &parent_device);
+		if (device !=
+		    ioservice_device) { // Don't free initial device. We are just borrowing it.
+			IOObjectRelease(device);
+		}
+		if (err) {
+			XNVME_DEBUG("No parent device found");
+			return -1;
+		}
+
+		device = parent_device;
+	}
+
+	ret = IOCreatePlugInInterfaceForService(device, kIONVMeSMARTUserClientTypeID,
+						kIOCFPlugInInterfaceID, plugin_interface, &score);
+	if (ret == kIOReturnSuccess) {
+		(**plugin_interface)
+			->QueryInterface(*plugin_interface,
+					 CFUUIDGetUUIDBytes(kIONVMeSMARTInterfaceID),
+					 nvme_smart_interface);
+	} else {
+		XNVME_DEBUG("IOCreatePlugInInterfaceForService failed: %s",
+			    (char *)mach_error_string(ret));
+		return -1;
+	}
+	return 0;
+}
+
+int
+_get_nvme_ns(io_object_t ioservice_device)
+{
+	CFTypeRef cf_nsid = IORegistryEntrySearchCFProperty(
+		ioservice_device, kIOServicePlane, CFSTR("NamespaceID"), kCFAllocatorDefault,
+		kIORegistryIterateRecursively | kIORegistryIterateParents);
+	if (!cf_nsid) {
+		XNVME_DEBUG("Failed to get namespace id");
+		return 0;
+	}
+	int nsid;
+	if (!CFNumberGetValue(cf_nsid, kCFNumberIntType, &nsid)) {
+		XNVME_DEBUG("Failed to convert namespace id to int");
+		return 0;
+	}
+	return nsid;
+}
+
+int
+_is_disk_nvme(io_object_t ioservice_device)
+{
+	CFBooleanRef is_nvme;
+
+	is_nvme = IORegistryEntrySearchCFProperty(
+		ioservice_device, kIOServicePlane, CFSTR(kIOPropertyNVMeSMARTCapableKey),
+		kCFAllocatorDefault, kIORegistryIterateRecursively | kIORegistryIterateParents);
+
+	if (is_nvme) {
+		CFRelease(is_nvme);
+		return 1;
+	}
+	return 0;
+}
+
+int
+xnvme_be_macos_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enumerate_cb cb_func,
+			 void *cb_args)
+{
+	if (sys_uri) {
+		XNVME_DEBUG("FAILED: sys_uri: %s is not supported", sys_uri);
+		return -ENOSYS;
+	}
+
+	for (int nid = 0; nid < 256; nid++) {
+		char path[128] = {0};
+		char disk_id[128] = {0};
+		char uri[XNVME_IDENT_URI_LEN] = {0};
+		struct xnvme_dev *dev;
+
+		// Enumerate 'disk' devices
+		snprintf(disk_id, 127, "%s%d", _DISK_PREFIX, nid);
+		snprintf(path, 127, "%s%s", _PATH_DEV_DISK, disk_id);
+
+		if (access(path, F_OK)) {
+			continue;
+		}
+
+		snprintf(uri, XNVME_IDENT_URI_LEN - 1, "%s", path);
+
+		dev = xnvme_dev_open(uri, opts);
+		if (!dev) {
+			XNVME_DEBUG("xnvme_dev_open(): %d", errno);
+			continue;
+		}
+		if (cb_func(dev, cb_args)) {
+			xnvme_dev_close(dev);
+		}
+	}
+
+	return 0;
+}
+
+void
+xnvme_be_macos_state_term(struct xnvme_be_macos_state *state)
+{
+	if (!state) {
+		return;
+	}
+
+	if (state->fd >= 0) {
+		close(state->fd);
+	}
+
+	if (state->ioservice_device) {
+		IOObjectRelease(state->ioservice_device);
+	}
+
+	if (state->nvme_smart_interface) {
+		IOObjectRelease(state->nvme_smart_interface);
+	}
+
+	if (state->plugin_interface) {
+		IODestroyPlugInInterface(state->plugin_interface);
+	}
+}
+
+void
+xnvme_be_macos_dev_close(struct xnvme_dev *dev)
+{
+	if (!dev) {
+		return;
+	}
+
+	xnvme_be_macos_state_term((void *)dev->be.state);
+	memset(&dev->be, 0, sizeof(dev->be));
+}
+
+int
+xnvme_file_opts_to_macos(struct xnvme_opts *opts)
+{
+	int flags = 0;
+
+	flags |= opts->create ? O_CREAT : 0x0;
+	flags |= opts->rdonly ? O_RDONLY : 0x0;
+	flags |= opts->wronly ? O_WRONLY : 0x0;
+	flags |= opts->rdwr ? O_RDWR : 0x0;
+	flags |= opts->truncate ? O_TRUNC : 0x0;
+
+	return flags;
+}
+
+int
+xnvme_be_macos_dev_open(struct xnvme_dev *dev)
+{
+	struct xnvme_be_macos_state *state = (void *)dev->be.state;
+	struct xnvme_opts *opts = &dev->opts;
+	int flags = xnvme_file_opts_to_macos(opts);
+	int err;
+	io_object_t ioservice_device;
+	IONVMeSMARTInterface **nvme_smart_interface;
+	IOCFPlugInInterface **plugin_interface;
+
+	ioservice_device = _get_ioservice_device(dev->ident.uri);
+	if (!ioservice_device) {
+		XNVME_DEBUG("No devices found");
+		return -ENOTSUP;
+	}
+
+	if (_get_nvme_smart_interface(ioservice_device, &nvme_smart_interface,
+				      &plugin_interface)) {
+		XNVME_DEBUG("Failed to acquire NVMe SMART interface for %s", dev->ident.uri);
+		return -ENOTSUP;
+	}
+
+	if (_is_disk_nvme(ioservice_device)) {
+		state->fd = open(dev->ident.uri, flags);
+		if (state->fd < 0) {
+			XNVME_DEBUG("FAILED: Unable to open device, errno: %d, %s", errno,
+				    strerror(errno));
+			return -errno;
+		}
+		state->ioservice_device = ioservice_device;
+		state->nvme_smart_interface = nvme_smart_interface;
+		state->plugin_interface = plugin_interface;
+		dev->ident.nsid = _get_nvme_ns(ioservice_device);
+		dev->ident.dtype = XNVME_DEV_TYPE_BLOCK_DEVICE;
+		dev->ident.csi = XNVME_SPEC_CSI_NVM;
+
+		if (!opts->admin) {
+			dev->be.admin = g_xnvme_be_macos_admin;
+		}
+		if (!opts->sync) {
+			dev->be.sync = g_xnvme_be_posix_sync_psync;
+		}
+		if (!opts->async) {
+			dev->be.async = g_xnvme_be_posix_async_emu;
+		}
+	} else {
+		XNVME_DEBUG("non-nvme disks are currently unsupported.");
+		return -ENOTSUP;
+
+		state->fd = open(dev->ident.uri, flags, opts->create_mode);
+		state->ioservice_device = NULL;
+		state->nvme_smart_interface = NULL;
+		dev->ident.nsid = 1;
+		dev->ident.dtype = XNVME_DEV_TYPE_FS_FILE;
+		dev->ident.csi = XNVME_SPEC_CSI_FS;
+	}
+
+	err = xnvme_be_dev_idfy(dev);
+	if (err) {
+		XNVME_DEBUG("FAILED: open() : xnvme_be_dev_idfy");
+		return -EINVAL;
+	}
+	err = xnvme_be_dev_derive_geometry(dev);
+	if (err) {
+		XNVME_DEBUG("FAILED: open() : xnvme_be_dev_derive_geometry()");
+		return err;
+	}
+
+	return 0;
+}
+#endif
+
+struct xnvme_be_dev g_xnvme_be_macos_dev = {
+#ifdef XNVME_BE_MACOS_ENABLED
+	.enumerate = xnvme_be_macos_enumerate,
+	.dev_open = xnvme_be_macos_dev_open,
+	.dev_close = xnvme_be_macos_dev_close,
+#else
+	.enumerate = xnvme_be_nosys_enumerate,
+	.dev_open = xnvme_be_nosys_dev_open,
+	.dev_close = xnvme_be_nosys_dev_close,
+#endif
+};

--- a/lib/xnvme_be_macos_sync.c
+++ b/lib/xnvme_be_macos_sync.c
@@ -1,0 +1,61 @@
+// Copyright (C) Simon A. F. Lund <simon.lund@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_MACOS_ENABLED
+#include <errno.h>
+#include <unistd.h>
+#include <libxnvme_spec_fs.h>
+#include <xnvme_dev.h>
+#include <xnvme_be_posix.h>
+#include <fcntl.h>
+
+int
+xnvme_be_macos_sync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes, void *mbuf,
+			   size_t mbuf_nbytes)
+{
+	struct xnvme_be_posix_state *state = (void *)ctx->dev->be.state;
+	ssize_t res;
+
+	///< NOTE: opcode-dispatch (io)
+	switch (ctx->cmd.common.opcode) {
+	case XNVME_SPEC_NVM_OPC_FLUSH:
+	case XNVME_SPEC_FS_OPC_FLUSH:
+		// NOTE: macOS requires special handling for fsync:
+		// https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fsync.2.html#//apple_ref/doc/man/2/fsync
+		res = fsync(state->fd);
+		ctx->cpl.result = res;
+		if (res < 0) {
+			XNVME_DEBUG("FAILED: {fsync}(), errno: %d", errno);
+			ctx->cpl.result = 0;
+			ctx->cpl.status.sc = errno;
+			ctx->cpl.status.sct = XNVME_STATUS_CODE_TYPE_VENDOR;
+			return -errno;
+		}
+
+		fcntl(state->fd, F_FULLFSYNC);
+		ctx->cpl.result = res;
+		if (res < 0) {
+			XNVME_DEBUG("FAILED: {F_FULLFSYNC}(), errno: %d", errno);
+			ctx->cpl.result = 0;
+			ctx->cpl.status.sc = errno;
+			ctx->cpl.status.sct = XNVME_STATUS_CODE_TYPE_VENDOR;
+			return -errno;
+		}
+		return 0;
+	default:
+		return xnvme_be_posix_sync_cmd_io(ctx, dbuf, dbuf_nbytes, mbuf, mbuf_nbytes);
+	}
+}
+#endif
+
+struct xnvme_be_sync g_xnvme_be_macos_sync_psync = {
+	.id = "macos",
+#ifdef XNVME_BE_MACOS_ENABLED
+	.cmd_io = xnvme_be_macos_sync_cmd_io,
+	.cmd_iov = xnvme_be_nosys_sync_cmd_iov,
+#else
+	.cmd_io = xnvme_be_nosys_sync_cmd_io,
+	.cmd_iov = xnvme_be_nosys_sync_cmd_iov,
+#endif
+};

--- a/lib/xnvmec.c
+++ b/lib/xnvmec.c
@@ -730,7 +730,8 @@ static struct xnvmec_opt_attr xnvmec_opts[] = {
 		.opt = XNVMEC_OPT_BE,
 		.vtype = XNVMEC_OPT_VTYPE_STR,
 		.name = "be",
-		.descr = "xNVMe backend, e.g. 'linux', 'spdk', 'fbsd', 'posix', 'windows'",
+		.descr =
+			"xNVMe backend, e.g. 'linux', 'spdk', 'fbsd', 'macos', 'posix', 'windows'",
 	},
 	{
 		.opt = XNVMEC_OPT_MEM,

--- a/meson.build
+++ b/meson.build
@@ -74,6 +74,7 @@ conf_data.set('XNVME_BE_LINUX_BLOCK_ZONED_ENABLED', is_linux ? cc.has_header('li
 conf_data.set('XNVME_BE_LINUX_LIBAIO_ENABLED', is_linux and get_option('with-libaio'))
 conf_data.set('XNVME_BE_LINUX_LIBURING_ENABLED', is_linux and get_option('with-liburing'))
 
+conf_data.set('XNVME_BE_MACOS_ENABLED', is_darwin)
 conf_data.set('XNVME_BE_FBSD_ENABLED', is_freebsd)
 conf_data.set('XNVME_BE_POSIX_ENABLED', is_linux or is_freebsd or is_darwin)
 
@@ -196,6 +197,16 @@ elf_dep = cc.find_library(
 spdk_dep = dependency(
   'spdk',
   required: conf_data.get('XNVME_BE_SPDK_ENABLED')
+)
+corefoundation_dep = dependency(
+  'appleframeworks',
+  modules: 'CoreFoundation',
+  required: is_darwin
+)
+iokit_dep = dependency(
+  'appleframeworks',
+  modules: 'IOKit',
+  required: is_darwin
 )
 
 # Headers

--- a/toolbox/cijoe-pkg-xnvme/envs/refenv-xnvme.sh
+++ b/toolbox/cijoe-pkg-xnvme/envs/refenv-xnvme.sh
@@ -63,6 +63,8 @@ elif [[ -v XNVME_BE && "${XNVME_BE}" == "linux" ]]; then
   fi
 elif [[ -v XNVME_BE && "$XNVME_BE" == "fbsd" ]]; then
   XNVME_URI="/dev/nvme${NVME_CNTID}ns${NVME_NSID}"; export XNVME_URI
+elif [[ -v XNVME_BE && "$XNVME_BE" == "macos" ]]; then
+  XNVME_URI="/dev/disk4"; export XNVME_URI
 fi
 if [[ -v XNVME_BE ]]; then
   XNVME_DEV_NSID="${NVME_NSID}"; export XNVME_DEV_NSID

--- a/toolbox/cijoe-pkg-xnvme/testcases/examples-xnvme_hello.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/examples-xnvme_hello.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_hello` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/examples-xnvme_io_async_read.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/examples-xnvme_io_async_read.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_io_async read` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/examples-xnvme_io_async_write.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/examples-xnvme_io_async_write.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_io_async write` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/examples-zoned_io_async_append.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/examples-zoned_io_async_append.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `zoned_io_async append` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/examples-zoned_io_async_read.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/examples-zoned_io_async_read.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `zoned_io_async read` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/examples-zoned_io_async_write.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/examples-zoned_io_async_write.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `zoned_io_async write` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/examples-zoned_io_sync_append.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/examples-zoned_io_sync_append.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `zoned_io_sync append` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/examples-zoned_io_sync_read.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/examples-zoned_io_sync_read.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `zoned_io_sync read` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/examples-zoned_io_sync_write.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/examples-zoned_io_sync_write.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `zoned_io_sync write` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/lblk_enum.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/lblk_enum.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that the CLI `lblk enum` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/lblk_idfy.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/lblk_idfy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that the CLI `lblk idfy` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/lblk_info.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/lblk_info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that the CLI `lblk info` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/lblk_read.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/lblk_read.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `lblk read` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_enum.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_enum.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that the `xnvme enum` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_enum_fabrics.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_enum_fabrics.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that the `xnvme enum` runs without error using '--uri' for Fabrics
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_feature_get.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_feature_get.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that the TEST `xnvme feature-get` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_feature_set.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_feature_set.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that the TEST `xnvme feature-set` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_file_copy_sync.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_file_copy_sync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Produce a file of 1GB then copy it in a tmpfs
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_fioe.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_fioe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Compares xNVMe using fio, the Flexible I/O Tester.
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_format.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that the CLI `xnvme format` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_idfy.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_idfy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that the CLI `xnvme idfy` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_idfy_ctrlr.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_idfy_ctrlr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that the CLI `xnvme idfy-ctrlr` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_idfy_ns.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_idfy_ns.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that the CLI `xnvme idfy-ns` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_info.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that the CLI `xnvme info` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_kvs_enum.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_kvs_enum.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `kvs enum` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_kvs_exist.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_kvs_exist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `kvs exist` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_kvs_idfy_ns.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_kvs_idfy_ns.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `kvs idfy-ns` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_kvs_io.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_kvs_io.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that test `xnvme_tests_kvs kvs_io` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_kvs_list.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_kvs_list.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `kvs list` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_kvs_retrieve.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_kvs_retrieve.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `kvs retrieve` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_kvs_store_opt.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_kvs_store_opt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `kvs store` runs without error,
 # while used with additional STORE command options

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_library_info.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_library_info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `xnvme library-info` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_log-erri.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_log-erri.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `xnvme log-erri` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_log-health.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_log-health.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `xnvme log-health` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_log.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_log.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `xnvme log` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_padc.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_padc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `xnvme padc` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_pioc.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_pioc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `xnvme pioc` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_sanitize.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_sanitize.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `xnvme sanitize` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_async_intf01.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_async_intf01.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify initialization and termination of a single xNVMe asynchronous contexts
 # with queue-depth 64

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_async_intf02.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_async_intf02.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify initialization and termination of 4 xNVMe asynchronous contexts with
 # queue-depth 64

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_async_intf03.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_async_intf03.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify initialization and termination of 8 xNVMe asynchronous contexts with
 # queue-depth 64

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_async_intf04.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_async_intf04.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify initialization and termination of [1; 128] xNVMe asynchronous contexts
 # with queue-depth 64

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_enum_multi.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_enum_multi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify xnvme_enumerate() and xnvme_dev_open() / xnvme_dev_close()
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_enum_open.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_enum_open.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify xnvme_enumerate() and xnvme_dev_open() / xnvme_dev_close()
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_lblk_io.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_lblk_io.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_lblk io` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_lblk_scopy.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_lblk_scopy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_lblk scopy` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_lblk_write_uncorrectable.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_lblk_write_uncorrectable.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_lblk write_uncorrectable` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_lblk_zero.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_lblk_zero.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_lblk zero` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_scc_idfy.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_scc_idfy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_scc idfy` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_scc_scopy_async.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_scc_scopy_async.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_scc scopy` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_scc_scopy_msrc_async.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_scc_scopy_msrc_async.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_scc scopy-msrc` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_scc_scopy_msrc_sync.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_scc_scopy_msrc_sync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_scc scopy-msrc --clear` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_scc_scopy_sync.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_scc_scopy_sync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_scc scopy --clear` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_scc_support.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_scc_support.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_scc support` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_append.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_append.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_znd_append verify` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_state.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_state.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_znd_state state` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_zrwa_flush.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_zrwa_flush.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_znd_zrwa commit` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_zrwa_flush_explicit.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_zrwa_flush_explicit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_znd_zrwa commit-explicit` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_zrwa_flush_implicit.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_zrwa_flush_implicit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_znd_zrwa commit-implicit` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_zrwa_idfy.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_zrwa_idfy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_znd_zrwa idfy` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_zrwa_open_with_zrwa.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_zrwa_open_with_zrwa.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_znd_zrwa open-with-zrwa` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_zrwa_open_without_zrwa.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_zrwa_open_without_zrwa.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_znd_zrwa open-without-zrwa` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_zrwa_support.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_znd_zrwa_support.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that `xnvme_tests_znd_zrwa support` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/zoned_append.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/zoned_append.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `zoned append` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/zoned_changes.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/zoned_changes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `zoned changes` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/zoned_enum.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/zoned_enum.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `zoned enum` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/zoned_idfy_ctrlr.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/zoned_idfy_ctrlr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that the CLI `zoned idfy-ctrlr` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/zoned_idfy_ns.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/zoned_idfy_ns.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that the CLI `zoned idfy-ns` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/zoned_info.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/zoned_info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that the CLI `zoned info` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/zoned_mgmt_open.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/zoned_mgmt_open.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `zoned mgmt-open` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/zoned_read.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/zoned_read.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `zoned read` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/zoned_report.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/zoned_report.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `zoned report` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/zoned_report_all.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/zoned_report_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `zoned report` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/zoned_report_one.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/zoned_report_one.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `zoned report` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/zoned_report_some.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/zoned_report_some.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `zoned report` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testcases/zoned_write.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/zoned_write.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Verify that CLI `zoned write` runs without error
 #

--- a/toolbox/cijoe-pkg-xnvme/testplans/xnvme-base-macos.plan
+++ b/toolbox/cijoe-pkg-xnvme/testplans/xnvme-base-macos.plan
@@ -1,0 +1,31 @@
+---
+descr: Verify base xNVMe functionality using the macOS backend
+descr_long: |
+  Exercises 
+  * library-information
+  * device enumeration
+  * admin-commands idfy-ns, idfy-ctrlr, get-log, get/set feature
+  * queue-init/teardown of io_uring/libaio/posix
+  Requires
+  * XNVME_URI points to an NVMe namespace e.g. /dev/disk4
+evars:
+  NVME_NSTYPE: "lblk"
+  DEV_TYPE: "nvme"
+  XNVME_BE: "macos"
+  XNVME_ADMIN: "macos"
+
+
+testsuites:
+- name: xnvme_core
+  alias: "xNVMe: verify base functionality using be:macos"
+
+- name: xnvme_admin_idfy_log
+  alias: "xNVMe: verify base functionality using be:macos"
+
+- name: xnvme_queue
+  alias: "xNVMe: verify base functionality using be:macos/async:posix"
+  evars: {XNVME_ASYNC: "posix"}
+
+- name: xnvme_queue
+  alias: "xNVMe: verify base functionality using be:macos/async:thrpool"
+  evars: {XNVME_ASYNC: "thrpool"}

--- a/toolbox/cijoe-pkg-xnvme/testsuites/xnvme_admin_idfy_log.suite
+++ b/toolbox/cijoe-pkg-xnvme/testsuites/xnvme_admin_idfy_log.suite
@@ -1,0 +1,11 @@
+xnvme_enum.sh
+xnvme_info.sh
+xnvme_idfy_ctrlr.sh
+xnvme_idfy_ns.sh
+xnvme_idfy.sh
+xnvme_log.sh
+xnvme_log-erri.sh
+xnvme_log-health.sh
+examples-xnvme_hello.sh
+xnvme_tests_enum_open.sh
+xnvme_tests_enum_multi.sh


### PR DESCRIPTION
New backend which supports macOS mostly using existing POSIX functionality. Although with the addition to  use the NVMeSMARTLibExternal.h provided by Xcode to query some information from the target disk. This does not enable arbitrary NVMe commands to be sent to a disk, but rather support for Get Log Page and Identify commands.