### PR TITLE
Revive the xNVMe Python language bindings

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -323,6 +323,15 @@ jobs:
     - name: Execute 'xnvme library-info'
       run: xnvme library-info
 
+    - name: Check pkg-config
+      run: |
+        pkg-config xnvme --libs
+        pkg-config xnvme --variable=datadir
+        pkg-config xnvme --variable=includedir
+        pkg-config xnvme --variable=libdir
+        pkg-config xnvme --variable=pcfiledir
+        pkg-config xnvme --variable=prefix
+        ls -lh $(pkg-config xnvme --variable=libdir) | grep xnvme
 
     - name: Check Python, pip, platform, and sysconfig
       run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -323,8 +323,13 @@ jobs:
     - name: Execute 'xnvme library-info'
       run: xnvme library-info
 
-    - name: Check pip
-      run: python3 -m pip --version
+
+    - name: Check Python, pip, platform, and sysconfig
+      run: |
+        python3 --version
+        python3 -m pip --version
+        python3 -c "import platform; print(platform.system()); print(platform.uname())"
+        python3 -c 'import sysconfig; print(sysconfig.get_config_var("SHLIB_SUFFIX"))'
 
   #
   # Build on macOS
@@ -381,8 +386,12 @@ jobs:
         pkg-config xnvme --variable=prefix
         ls -lh $(pkg-config xnvme --variable=libdir) | grep xnvme
 
-    - name: Check pip
-      run: python3 -m pip --version
+    - name: Check Python, pip, platform, and sysconfig
+      run: |
+        python3 --version
+        python3 -m pip --version
+        python3 -c "import platform; print(platform.system()); print(platform.uname())"
+        python3 -c 'import sysconfig; print(sysconfig.get_config_var("SHLIB_SUFFIX"))'
 
   #
   # Build on Windows
@@ -437,8 +446,12 @@ jobs:
         xnvme.exe enum
         xnvme.exe library-info
 
-    - name: Check pip
-      run: python3 -m pip --version
+    - name: Check Python, pip, platform, and sysconfig
+      run: |
+        python3 --version
+        python3 -m pip --version
+        python3 -c "import platform; print(platform.system()); print(platform.uname())"
+        python3 -c 'import sysconfig; print(sysconfig.get_config_var("SHLIB_SUFFIX"))'
 
   #
   # Build on run CIJOE testplans

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -250,10 +250,55 @@ jobs:
       run: docker push refenv/xnvme
 
   #
+  # Build Python-bindings
+  #
+  build-python:
+    needs: source-archive
+    runs-on: ubuntu-latest
+    if: ((github.event_name == 'pull_request') || ((github.event_name == 'workflow_dispatch') && ((github.event.inputs.job
+      == 'all') || contains('build-linux', github.event.inputs.job))))
+    container: refenv/alpine-bash
+
+    steps:
+    - name: Retrieve the source-archive
+      uses: actions/download-artifact@v2
+      with:
+        name: archive-src
+    - name: Extract the full-source-archive
+      run: |
+        tar xzf xnvme*.tar.gz --strip 1
+        rm xnvme*.tar.gz
+
+    - name: Install build-requirements
+      run: |
+        ./toolbox/pkgs/alpine-latest.sh
+
+    - name: Python bindings, system packages
+      run: |
+        apk add clang-libs
+
+    - name: Python bindings, Python packages
+      run: |
+        cd python
+        python3 -m pip install -r requirements.txt
+
+    - name: Python bindings, generate, patch, and build-sdist
+      run: |
+        cd python
+        make build
+        for file in dist/*.tar.gz; do mv $file ${file//xnvme/xnvme-py}; done
+
+    - name: Upload Python package
+      uses: actions/upload-artifact@v2
+      with:
+        name: python-pkg
+        path: python/dist/xnvme-py-*.tar.gz
+
+  #
   # Build on Linux using different Linux distributions
   #
   build-linux:
-    needs: [source-archive, source-format-check]
+    needs: [source-archive, source-format-check, build-python]
     runs-on: ubuntu-latest
     if: ((github.event_name == 'pull_request') || ((github.event_name == 'workflow_dispatch') && ((github.event.inputs.job
       == 'all') || contains('build-linux', github.event.inputs.job))))
@@ -340,11 +385,22 @@ jobs:
         python3 -c "import platform; print(platform.system()); print(platform.uname())"
         python3 -c 'import sysconfig; print(sysconfig.get_config_var("SHLIB_SUFFIX"))'
 
+    - name: Retrieve the xNVMe Python bindings (prebuilt sdist)
+      uses: actions/download-artifact@v2
+      with:
+        name: python-pkg
+
+    - name: Install and test xNVMe Python bindings
+      if: (!contains(matrix.container.ver, 'bookworm'))
+      run: |
+        python3 -m pip install xnvme-py*.tar.gz --user
+        python3 -m pytest --pyargs xnvme
+
   #
   # Build on macOS
   #
   build-macos:
-    needs: [source-archive, source-format-check]
+    needs: [source-archive, source-format-check, build-python]
     runs-on: ${{ matrix.runner.os }}-${{ matrix.runner.ver }}
     if: ((github.event_name == 'pull_request') || ((github.event_name == 'workflow_dispatch') && ((github.event.inputs.job
       == 'all') || contains('build-macos', github.event.inputs.job))))
@@ -401,6 +457,16 @@ jobs:
         python3 -m pip --version
         python3 -c "import platform; print(platform.system()); print(platform.uname())"
         python3 -c 'import sysconfig; print(sysconfig.get_config_var("SHLIB_SUFFIX"))'
+
+    - name: Retrieve the xNVMe Python bindings (prebuilt sdist)
+      uses: actions/download-artifact@v2
+      with:
+        name: python-pkg
+
+    - name: Install and test xNVMe Python bindings
+      run: |
+        python3 -m pip install xnvme-py*.tar.gz --user
+        python3 -m pytest --pyargs xnvme
 
   #
   # Build on Windows

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,6 +86,7 @@ repos:
     args:
     - '--max-line-length=88'
     - '--extend-ignore=E203' # ignore "whitespace before ':'"
+    exclude: (ctypes_mapping\.py)$
 
 # Shell: todo: exclude xnvme-driver.sh
 - repo: https://github.com/jumanjihouse/pre-commit-hooks

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,7 @@ Contents:
    capis/index.rst
    examples/index.rst
    tutorial/index.rst
+   python/index.rst
    contributing/index.rst
 
 Indices and tables

--- a/docs/python/index.rst
+++ b/docs/python/index.rst
@@ -1,0 +1,188 @@
+.. _sec-python:
+
+========
+ Python
+========
+
+**xNVMe** language bindings for Python provide access to the **xNVMe** C API
+via :ref:`sec-python-ctypes` and :ref:`sec-python-Cython`. Two language binding
+interfaces are provided as they serve different use-cases.
+
+* The :ref:`sec-python-ctypes` bindings are intended for interactive usage when
+  experimenting with the **xNVMe** API, as well as integration into
+  adminstrative tools such as Web-UI for managing fabrics
+  :ref:`sec-tutorials-fabrics`.
+
+* The :ref:`sec-python-cython` bindings are intended for Cython applications,
+  that is, to provide Cython bindings readily available such that you don't
+  have to make them in order to use **xNVMe** in your Cython code.
+
+The library bindings are a work-in-progress, provided as a preview of what can
+be done when integrating with Python. See, section :ref:`sec-python-todo` for a
+list of known short-comings and areas to improve. Your input on these are most
+welcome along with pull-requests to improve the interfaces.
+
+Install
+=======
+
+Before installing, then ensure that the following system dependencies are met:
+
+* Python 3.6+
+* **xNVMe** installed on your system
+* ``pkg-config`` installed and able to locate **xNVMe** on your system
+
+See, the :ref:`sec-building` on how to build and install xNVMe. With the above
+then you can go ahead and install the bindings using ``pip``::
+
+  # install: for the current user
+  python3 -m pip install xnvme --user
+
+For a description of building and installing the package from source, then see
+the :ref:`sec-python-development` section.
+
+.. note:: The **xNVMe** Python package comes with pytests, thus, you can verify
+   your installation by running: ``python3 -m pytest --pyargs xnvme``.
+
+.. _sec-python-ctypes:
+
+ctypes
+======
+
+Python ctypes_ comes with CPython_, that is, with the reference implementation
+of the Python intepreter. When using the ctypes_ bindings, the only other
+runtime dependency is pytest_.
+
+Usage examples
+--------------
+
+See the files in ``bin/*``. At the time of writing this, there were three
+examples, two of which require no arguments, these are run like so::
+
+  # Enumerate devices on the system
+  ./bin/xpy_enumerate
+
+  # Print library-information
+  ./bin/xpy_libconf
+
+The third opens and queries a device for information, and thus requires a
+device as well as permissions, on a Linux system, running it could look
+something like this::
+
+  sudo -E ./bin/xpy_dev_open --uri /dev/nvme0n1
+
+.. note:: In the above example ``sudo -E`` is used. The ``sudo`` is there to
+   ensure permission to ``/dev/nvme0n1``, then ``-E`` is there such that the
+   **xNVMe** package installed as ``--user`` is available.
+
+.. _sec-python-cython:
+
+Cython
+======
+
+Python Cython_ ...
+
+.. _sec-python-development:
+
+Development
+===========
+
+The bindings are generated using the ctypeslib2_ tool, patched (injecting an
+extension to the library-loader), and then formatted with black_.
+
+The build-requirements are installable via ``requirements.txt``::
+
+  python3 -m pip install -r requirements.txt --user
+
+Furthermore, ``clang`` is needed on the system::
+
+  # Debian
+  sudo apt-get install libclang-dev
+
+  # Alpine
+  sudo apk add clang-libs
+
+A Makefile is available for common tasks, run::
+
+  make help
+
+To see what it provides / common-tasks during development. For example::
+
+  make build uninstall install test
+
+The above ``make`` invocation will generate the ctypes-mapping via
+``clang2py``, then patch the mappings using the auxilary scripts
+``aux/patch_ctypes_mapping.py``, adjust the style according to the conventions
+of ``black``, create a Python sdist package, install the package, and finally
+run the pytests.
+
+**CAVEAT:** the mappings produced by ``clang2py`` aren't stable. That is, the
+ordering in which classes are emitted can change from each invocation of the
+tool.
+
+.. _sec-python-todo:
+
+TODO
+====
+
+As mentioned earlier, then the Python language bindings are a work in progress,
+the following are mixture of notes for improvment along with things to be aware
+of when using the Python language bindings.
+
+* Explore how to distribute the **xNVMe** source on pypi_
+  - Should provide the source-archive of **xNVMe**
+  - Should provide means of building the library along with the Python package
+  - Should provide a means of making the library available to the Python
+    language bindings
+  - See one approach to explore in the mention on ``mesonpep517``
+
+* Explore using ``mesonpep517`` for the bindings
+  - https://pypi.org/project/mesonpep517/
+  - https://github.com/mesonbuild/meson/issues/7863
+  - https://thiblahute.gitlab.io/mesonpep517/
+
+* Re-consider the API-guard ``capi.guard_unloadable()``.
+
+* The package-readme ``python/README.rst`` is lacking in proper description and
+  pointers to information. This should be improved.
+
+* Currently the Python package does not include the Cython mappings / bindings
+
+  - These should be added
+
+* **testing** The bindings have only been tested on Linux and macOS
+
+  - Add testing on Windows
+  - Add testing on FreeBSD
+
+* **testing:** a CIJOE testplan and testcases are provided, however, it has
+  shortcomings
+
+  - Must be added to the 'build-and-test' workflow-job
+  - Needs fixing for Windows
+
+* **RECONSIDER:** The auto-generated ctypes-mapping has prefixes for e.g.
+  ``union_`` and ``struct_``, the patcher removes these. This works for the
+  xNVMe C API since there are no collisions, however, in the general case it
+  would break. So, reconsider which is the preferable form for a "raw C API
+  mapping".
+
+* **ctypes_mapping:** The bit-fields and nested structs have cumbersome
+  accessors in Python, this could be improved by modifying the ``clang2py`` /
+  ``ctypeslib2``
+
+* **ctypes_mapping:** The generated bindings are **not** stable, that is, the
+  output emitted from ``clang2py`` changes order of the generated items. This
+  would be nice to fix by submitting a PR to the ctypeslib2_.
+
+* **cython_mapping:** add Cython mappings in ``xnvme.cython_mappings``, ideally
+  these would be "duck-type" compatible with the ``xnvme.ctypes_mapping``. Such
+  that library user can switch between them by simply replace ``import
+  xnvme.ctypes_mapping as capi``.
+
+.. _CPython: https://en.wikipedia.org/wiki/CPython
+.. _Cython: https://cython.org/
+.. _black: https://github.com/psf/black
+.. _ctypes: https://docs.python.org/3/library/ctypes.html
+.. _ctypeslib2: https://github.com/trolldbois/ctypeslib/
+.. _pytest: https://pytest.org/
+.. _pypi: https://pypi.org/

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,2 @@
+.eggs
+xnvme/ctypes_mapping.py

--- a/python/LICENSE
+++ b/python/LICENSE
@@ -1,0 +1,212 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 simon.lund@samsung.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+---------------------------------------------------------------------------
+NOTE:
+
+Individual files contain the following tag instead of the full license text.
+
+   SPDX-License-Identifier: Apache-2.0
+
+This enables machine processing of license information based on the SPDX
+License Identifiers that are here available: http://spdx.org/licenses/

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,0 +1,113 @@
+#
+# This Makefile serves as convenient command-line auto-completion when working on Python bindings
+#
+TOOLBOX_DIR?=../toolbox
+PROJECT_NAME=xnvme
+XNVME_CAPI_HEADERS=$(shell ls ../include/libxnvme* | grep -v util | grep -v libxnvmec)
+
+define default-help
+# invoke: 'make uninstall', 'make install'
+endef
+.PHONY: default
+default: build
+	@echo "## py: make default"
+	@echo "## py: make default [DONE]"
+
+define build-help
+# Generate ctypes, patch them, then create a source package
+endef
+.PHONY: build
+build: generate-ctypes patch-ctypes
+	@echo "## py: make build-sdist"
+	@python3 setup.py sdist
+	@echo "## py: make build-sdist [DONE]"
+
+define install-help
+# install for current user
+endef
+.PHONY: install
+install:
+	@echo "## py: make install"
+	@python3 -m pip install dist/xnvme-*.tar.gz --user
+	@echo "## py: make install [DONE]"
+
+define uninstall-help
+# uninstall
+#
+# Prefix with 'sudo' when uninstalling a system-wide installation
+endef
+.PHONY: uninstall
+uninstall:
+	@echo "## py: make uninstall"
+	@python3 -m pip uninstall ${PROJECT_NAME} --yes || echo "Cannot uninstall => That is OK"
+	@echo "## py: make uninstall [DONE]"
+
+define install-system-help
+# install system-wide
+#
+# install system-wide
+endef
+.PHONY: install-system
+install-system:
+	@echo "## py: make install-system"
+	@python3 -m pip install dist/xnvme-*.tar.gz
+	@echo "## py: make install-system [DONE]"
+
+define test-help
+# Run pytest on tests/
+endef
+.PHONY: test
+test:
+	@echo "## py: make test"
+	@python3 -m pytest --pyargs xnvme
+	@echo "## py: make test [DONE]"
+
+define generate-ctypes-help
+# Generate definitions (xnvme_ctypes.header) from xNVMe public C API headers
+endef
+.PHONY: generate-ctypes
+generate-ctypes:
+	@echo "## py: gen"
+	@echo "## py:headers: ${XNVME_CAPI_HEADERS}"
+	@clang2py ${XNVME_CAPI_HEADERS} --clang-args="-I../include" > xnvme/ctypes_mapping.py
+	@echo "## Remember to also call 'make patch-ctypes' to fix format"
+	@echo "## py: gen [DONE]"
+
+define patch-ctypes-help
+# Patch definitions (xnvme_ctypes.header)
+endef
+.PHONY: patch-ctypes
+patch-ctypes:
+	@echo "## py: gen"
+	@python3 aux/patch_ctypes_mapping.py --path xnvme/ctypes_mapping.py
+	@black xnvme/ctypes_mapping.py || echo "could not fix format"
+	@echo "## py: gen [DONE]"
+
+define clean-help
+# clean the Python build dirs (build, dist)
+endef
+.PHONY: clean
+clean:
+	@echo "## py: clean"
+	@rm -r build || echo "Cannot remove => That is OK"
+	@rm -r dist || echo "Cannot remove => That is OK"
+	@rm -r *.egg-info || echo "Cannot remove => That is OK"
+	@echo "## py: clean [DONE]"
+
+define help-help
+# Print the description of every target
+#
+# Print the description of every target
+endef
+.PHONY: help
+help:
+	@./$(TOOLBOX_DIR)/print_help.py --repos .
+
+define help-verbose-help
+# Print the verbose description of every target
+#
+# Print the verbose description of every target
+endef
+.PHONY: help-verbose
+help-verbose:
+	@./$(TOOLBOX_DIR)/print_help.py --verbose --repos .

--- a/python/README.rst
+++ b/python/README.rst
@@ -1,0 +1,17 @@
+======================================================
+ xNVMe Cython and ctypes language-bindings for Python
+======================================================
+
+This package provides "raw" Python language-bindings to the xNVMe C API.
+
+For documentation consult the following:
+
+* The online docs_ for the latest released version
+* The ``docs/python`` folder on the next_ branch of the repository_ for the
+  upcoming release
+* The ``docs/python/`` folder in the repository_ on any outstanding pull-requests_.
+
+.. _docs: https://xnvme.io/docs/latest/python
+.. _next: https://github.com/OpenMPDK/xNVMe/tree/next
+.. _repository: https://github.com/OpenMPDK/xNVMe
+.. _pull-requests: https://github.com/OpenMPDK/xNVMe/pulls

--- a/python/aux/patch_ctypes_mapping.py
+++ b/python/aux/patch_ctypes_mapping.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+import argparse
+import os
+
+
+def parse_args():
+    """Parse command-line arguments"""
+
+    parser = argparse.ArgumentParser(
+        description="Patch the given xnvme.ctypes_mapping",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--path",
+        help="Path to ctypes_mapping.py",
+        required=True,
+        type=str,
+    )
+
+    return parser.parse_args()
+
+
+SNIPPETS = {
+    "import": ("import ctypes\n" "import sys\n" "\n" "import xnvme.library_loader"),
+    "loader": (
+        "_libraries['xnvme'] = xnvme.library_loader.load()\n"
+        "is_loaded = _libraries['xnvme'] is not None\n"
+        "_libraries['xnvme'] = _libraries['xnvme' ]"
+        " if _libraries['xnvme'] else FunctionFactoryStub()"
+    ),
+    "guard": (
+        "def guard_unloadable():\n"
+        '   """Print error and do sys.exit(1) when library is not loadable"""\n'
+        "\n"
+        "   if is_loaded:\n"
+        "       return\n"
+        "\n"
+        '   print("FAILED: library is not loadable; perhaps install xNVMe?")\n'
+        "   sys.exit(1)\n"
+    ),
+}
+
+
+def main(args):
+    """Patch the given auto-generated ctypes-mapping"""
+
+    path = os.path.abspath(os.path.expandvars(os.path.expanduser(args.path)))
+    with open(path) as ctfile:
+        code = ctfile.read()
+
+    # Vanity, change the "FIXNVME_STUB" to "xnvme", with clang2py, the basename of the
+    # shared library is indented to be used as index since it can map multple library
+    # into the same file of auto-generated mappings. However, since xNVMe provides
+    # everything in a single library then just change this to 'xnvme'
+    code = code.replace("FIXME_STUB", "xnvme")
+
+    # Replace the FactoryStub/direct ctypes.CDLL load with 'xnvme.library_loader' and
+    # provide a variable to probe for state
+    code = code.replace("import ctypes", SNIPPETS["import"])
+    code = code.replace(
+        "_libraries['xnvme'] = FunctionFactoryStub()", SNIPPETS["loader"]
+    )
+
+    # Add a function to invoke in order to exit and provide the samme error-message
+    # where it is attempted
+    code += SNIPPETS["guard"]
+
+    # The following two mapping-changes are a bit controversial, in a general
+    # code-generator case removing the 'struct' and 'union' prefix is likely to cause
+    # namespace collision.  For xNVMe it does not, which allows for a less verbose API
+    # mapping.
+    code = code.replace("struct_xnvme", "xnvme")
+    code = code.replace("union_xnvme", "xnvme")
+
+    # The entities in the 'skiplist' are names of 'static inline' function and thus
+    # unavailable via the shared library, when writing the modified ctypes_mapping to
+    # file we skip writing them.
+    skiplist = ["xnvme_cmd_ctx_set_cb", "xnvme_cmd_ctx_cpl_status"]
+
+    with open(path, "w") as pfile:
+        for line in code.splitlines():
+            if [x for x in skiplist if x in line]:
+                continue
+
+            pfile.write(line)
+            pfile.write("\n")
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/python/bin/xpy_dev_open
+++ b/python/bin/xpy_dev_open
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+
+import xnvme.ctypes_mapping as xnvme
+
+xnvme.guard_unloadable()
+
+
+def parse_args():
+    """Parse command-line arguments"""
+
+    parser = argparse.ArgumentParser(
+        description="Open a device and query it for information",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--uri",
+        help="uri argument to pass to xnvme_dev_open()",
+        required=True,
+        type=str,
+    )
+    parser.add_argument(
+        "--dev-nsid",
+        help="NVMe namespace-identifier",
+        default=0x1,
+        type=lambda x: int(x, 0),
+    )
+
+    return parser.parse_args()
+
+
+def main(args):
+    """Example of xNVMe C API bindings to open a device"""
+
+    opts = xnvme.xnvme_opts()
+    opts.nsid = args.dev_nsid
+
+    dev = xnvme.xnvme_dev_open(args.uri.encode(), opts)
+    if not dev:
+        print(f"FAILED: xnvme_dev_open({args.uri})")
+        return 1
+
+    xnvme.xnvme_dev_pr(dev, xnvme.XNVME_PR_DEF)
+    xnvme.xnvme_dev_close(dev)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(parse_args()))

--- a/python/bin/xpy_enumerate
+++ b/python/bin/xpy_enumerate
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import sys
+from ctypes import POINTER, c_uint32, cast, pointer
+
+import xnvme.ctypes_mapping as xnvme
+
+xnvme.guard_unloadable()
+
+
+def enumerate_callback(dev, callback_args):
+    """Enumerate devices on the system"""
+
+    count = cast(callback_args, POINTER(c_uint32))
+    count.contents.value += 1
+
+    xnvme.xnvme_dev_pr(dev, xnvme.XNVME_PR_DEF)
+
+    return xnvme.XNVME_ENUMERATE_DEV_CLOSE
+
+
+def main():
+    """Enumerate the local-system passing a variable to increment/count"""
+
+    count = c_uint32(0)
+
+    err = xnvme.xnvme_enumerate(
+        None, None, xnvme.xnvme_enumerate_cb(enumerate_callback), pointer(count)
+    )
+    if err:
+        print(f"FAILED: xnvme_enumerate(), err({err})")
+
+    print(f"Found {count.value} device(s)")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/bin/xpy_libconf
+++ b/python/bin/xpy_libconf
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+import sys
+
+import xnvme.ctypes_mapping as xnvme
+
+xnvme.guard_unloadable()
+
+
+def main():
+    """Print xNVMe library information"""
+
+    xnvme.xnvme_libconf_pr(xnvme.XNVME_PR_DEF)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,5 @@
+# For ctypes-bindings
+black
+ctypeslib2
+# All
+pytest

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,43 @@
+import codecs
+import glob
+import os
+
+import setuptools
+
+
+def read(*parts):
+    """Read parts to use a e.g. long_description"""
+
+    here = os.path.abspath(os.path.dirname(__file__))
+
+    # intentionally *not* adding an encoding option to open, See:
+    #   https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
+    with codecs.open(os.path.join(here, *parts), "r") as pfp:
+        return pfp.read()
+
+
+setuptools.setup(
+    name="xnvme",
+    version="0.3.0",
+    author="Simon A. F. Lund",
+    author_email="os@safl.dk",
+    description="xNVMe Cython and ctypes language-bindings for Python",
+    long_description=read("README.rst"),
+    url="https://github.com/OpenMPDK/xNVMe",
+    project_urls={
+        "Bug Tracker": "https://github.com/OpenMPDK/xNVMe/issues",
+    },
+    license="Apache License, Version 2.0",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    data_files=[
+        ("bin", glob.glob("bin/*")),
+    ],
+    package_dir={"": "./"},
+    packages=setuptools.find_packages(where="./"),
+    python_requires=">=3.6",
+    install_requires=["pytest"],
+)

--- a/python/xnvme/library_loader.py
+++ b/python/xnvme/library_loader.py
@@ -1,0 +1,60 @@
+"""
+    The xnvme.library_loader provides a single method to dynamically load the xNVMe
+    shared library. This intent is that the loader is invoked by the
+    'xnvme.ctypes_mapping' on package-initialization, such that the user can directly
+    get a library-handle like so:
+
+        from xnvme.ctypes_mapping import capi
+
+    This is useful since usage of the library handle can have multiple entry points.
+"""
+import ctypes
+import ctypes.util
+import os
+import platform
+import subprocess
+
+SHARED_EXT = {
+    "linux": "so",
+    "windows": "dll",
+    "darwin": "dylib",
+}
+
+
+def search_paths():
+    """Search the system for the shared library emitting paths for ctypes.CDLL()"""
+
+    for search in ["xnvme-shared", "xnvme_shared"]:
+        path = ctypes.util.find_library(search)
+        if path:
+            yield path
+
+    try:
+        proc = subprocess.run(
+            ["pkg-config", "xnvme", "--variable=libdir"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if not proc.returncode:
+            ext = SHARED_EXT.get(platform.system().lower(), "so")
+
+            yield os.path.join(
+                proc.stdout.decode("utf-8").strip(), f"libxnvme-shared.{ext}"
+            )
+    except subprocess.CalledProcessError:
+        pass
+
+
+def load():
+    """Dynamically load the xNVMe shared library"""
+
+    for spath in search_paths():
+        try:
+            lib = ctypes.CDLL(spath)
+            if lib:
+                return lib
+        except OSError:
+            continue
+
+    return None

--- a/python/xnvme/tests/test_loader.py
+++ b/python/xnvme/tests/test_loader.py
@@ -1,0 +1,24 @@
+import xnvme.ctypes_mapping as capi
+
+
+def test_capi_is_loadable():
+    """The 'capi' is loaded upon module access, this checks that it succeeded"""
+
+    assert capi.is_loaded, "C library is not loaded; possibly missing library"
+
+
+def test_capi_has_function():
+    """
+    This verifies that the loaded library actually is the xNVMe library, by checking for
+    the existance of a xNVMe specific funtion.
+    """
+
+    assert capi.xnvme_enumerate, "Function-lookup failed, possibly incompatible library"
+
+
+def test_capi_is_callable():
+    """Verifies that at at least one function is callable"""
+
+    assert capi.xnvme_libconf_pr(
+        capi.XNVME_PR_DEF
+    ), "Function-call failed; possibly missing or incompatible library"

--- a/toolbox/cijoe-pkg-xnvme/testcases/xpy_dev_open.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xpy_dev_open.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Verify that `xpy_dev_open` runs without error
+#
+# When this passes the xNVMe Python bindings loadable and functional.
+#
+# shellcheck disable=SC2119
+#
+CIJ_TEST_NAME=$(basename "${BASH_SOURCE[0]}")
+export CIJ_TEST_NAME
+# shellcheck source=modules/cijoe.sh
+source "$CIJ_ROOT/modules/cijoe.sh"
+test.enter
+
+: "${XNVME_URI:?Must be set and non-empty}"
+
+: "${XNVME_DEV_NSID:?Must be set and non-empty}"
+
+# Instrumentation of the xNVMe runtime
+XNVME_RT_ARGS=""
+XNVME_RT_ARGS="${XNVME_RT_ARGS} --dev-nsid ${XNVME_DEV_NSID}"
+
+if ! cij.cmd "xpy_dev_open --uri ${XNVME_URI} ${XNVME_RT_ARGS}"; then
+  test.fail
+fi
+
+test.pass

--- a/toolbox/cijoe-pkg-xnvme/testcases/xpy_enumerate.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xpy_enumerate.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Verify that `xpy_enumerate` runs without error
+#
+# When this passes the xNVMe Python bindings loadable and functional.
+#
+# shellcheck disable=SC2119
+#
+CIJ_TEST_NAME=$(basename "${BASH_SOURCE[0]}")
+export CIJ_TEST_NAME
+# shellcheck source=modules/cijoe.sh
+source "$CIJ_ROOT/modules/cijoe.sh"
+test.enter
+
+if ! cij.cmd "xpy_enumerate"; then
+  test.fail
+fi
+
+test.pass

--- a/toolbox/cijoe-pkg-xnvme/testcases/xpy_libconf.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xpy_libconf.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Verify that `xpy_libconf` runs without error
+#
+# When this passes the xNVMe Python bindings loadable and functional.
+#
+# shellcheck disable=SC2119
+#
+CIJ_TEST_NAME=$(basename "${BASH_SOURCE[0]}")
+export CIJ_TEST_NAME
+# shellcheck source=modules/cijoe.sh
+source "$CIJ_ROOT/modules/cijoe.sh"
+test.enter
+
+if ! cij.cmd "xpy_libconf"; then
+  test.fail
+fi
+
+test.pass

--- a/toolbox/cijoe-pkg-xnvme/testplans/xnvme-python.plan
+++ b/toolbox/cijoe-pkg-xnvme/testplans/xnvme-python.plan
@@ -1,0 +1,28 @@
+---
+descr: Do minimal verification of Python language bindings
+descr_long: |
+  This will exercise the Python language-bindings, invoking Python
+  examples which will touch the trickier parts of the API, that is,
+  callback-functions, non-primitive data-types, and device handles
+evars:
+  NVME_NSTYPE: "lblk"
+  DEV_TYPE: "nvme"
+
+testsuites:
+- name: xpy_kernel
+  alias: "Using the OS NVMe driver"
+  hooks: ["xnvme"]
+  evars: {XNVME_BE: "linux"}
+  testcases:
+  - xpy_dev_open.sh
+  - xpy_enumerate.sh
+  - xpy_libconf.sh
+
+- name: xpy_userspace
+  alias: "Using the user-space NVMe driver"
+  hooks: ["xnvme"]
+  evars: {XNVME_BE: "spdk"}
+  testcases:
+  - xpy_dev_open.sh
+  - xpy_enumerate.sh
+  - xpy_libconf.sh


### PR DESCRIPTION
xNVMe previously had Python bindings, however, these where manually written wrappers which were not properly tested, thus they became stale and were removed from the repository.

However, recently when providing examples of how to dynamically load xNVMe from C and Python, then it seemed worth-while to explore just how much is possible via ``ctypes``. With a couple of non-intrusive changes to the public C API (adding a couple of includes), then it is possible to auto-generate a complete ctypes-wrapping for the C API. With the essentials auto-generated, then using ``ctypes`` is a breeze.

With this PR a full xNVMe C API mapping is available along with automatic dynamic loading. This module can serve for those wanting to experiment with the API from the comforts of Python. Additionally, as a reference for adding Cython bindings as well, for those going beyond poking at the API.

- [x] Add testcases and testplan for CIJOE invoking and verifying the library
- [x] Add testing to CI
- [x] Add description of the Python module in the docs

Have a look at the ``toolbox/py_xnvme_pkg/README.rst`` for more information. 