### PR TITLE
Misc. fixes and preps for Python language bindings

### DIFF
--- a/include/libxnvme_adm.h
+++ b/include/libxnvme_adm.h
@@ -1,5 +1,6 @@
 #ifndef __LIBXNVME_ADM_H
 #define __LIBXNVME_ADM_H
+#include <libxnvme.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/libxnvme_be.h
+++ b/include/libxnvme_be.h
@@ -8,6 +8,7 @@
  */
 #ifndef __LIBXNVME_BE_H
 #define __LIBXNVME_BE_H
+#include <libxnvme.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/libxnvme_buf.h
+++ b/include/libxnvme_buf.h
@@ -8,6 +8,7 @@
  */
 #ifndef __LIBXNVME_BUF_H
 #define __LIBXNVME_BUF_H
+#include <libxnvme.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/libxnvme_buf.h
+++ b/include/libxnvme_buf.h
@@ -4,7 +4,7 @@
  * Copyright (C) Simon A. F. Lund <simon.lund@samsung.com>
  * SPDX-License-Identifier: Apache-2.0
  *
- * @file libxnvme_be.h
+ * @file libxnvme_buf.h
  */
 #ifndef __LIBXNVME_BUF_H
 #define __LIBXNVME_BUF_H

--- a/include/libxnvme_dev.h
+++ b/include/libxnvme_dev.h
@@ -1,5 +1,6 @@
 #ifndef __LIBXNVME_DEV_H
 #define __LIBXNVME_DEV_H
+#include <libxnvme.h>
 
 /**
  * Opaque device handle.

--- a/include/libxnvme_lba.h
+++ b/include/libxnvme_lba.h
@@ -12,6 +12,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#include <libxnvme.h>
 
 /**
  * Representation of a range of logical-block-addresses aka LBAs

--- a/include/libxnvme_pp.h
+++ b/include/libxnvme_pp.h
@@ -230,6 +230,17 @@ xnvme_geo_pr(const struct xnvme_geo *geo, int opts);
 void
 xnvme_cmd_ctx_pr(const struct xnvme_cmd_ctx *ctx, int UNUSED_opts);
 
+/**
+ * Prints a humanly readable representation of the given ::xnvme_opts
+ *
+ * @param opts Pointer to the #xnvme_opts to print
+ * @param pr_opts printer options, see ::xnvme_pr
+ *
+ * @return On success, the number of characters printed is returned.
+ */
+int
+xnvme_opts_pr(const struct xnvme_opts *opts, int pr_opts);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/libxnvme_sgl.h
+++ b/include/libxnvme_sgl.h
@@ -9,6 +9,7 @@
  */
 #ifndef __LIBXNVME_SGL_H
 #define __LIBXNVME_SGL_H
+#include <libxnvme.h>
 
 /**
  * Opaque handle for Scatter Gather List (SGL).

--- a/include/libxnvme_ver.h
+++ b/include/libxnvme_ver.h
@@ -1,5 +1,6 @@
 #ifndef __LIBXNVME_VER_H
 #define __LIBXNVME_VER_H
+#include <libxnvme.h>
 
 /**
  * Produces the "major" version of the library

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -45,6 +45,7 @@ xnvmelib_source = [
   'xnvme_libconf.c',
   'xnvme_libconf_entries.c',
   'xnvme_nvm.c',
+  'xnvme_opts.c',
   'xnvme_queue.c',
   'xnvme_req.c',
   'xnvme_sgl.c',

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -40,6 +40,7 @@ xnvmelib_source = [
   'xnvme_dev.c',
   'xnvme_file.c',
   'xnvme_geo.c',
+  'xnvme_ident.c',
   'xnvme_lba.c',
   'xnvme_libconf.c',
   'xnvme_libconf_entries.c',

--- a/lib/xnvme_be.c
+++ b/lib/xnvme_be.c
@@ -18,7 +18,8 @@
 #include <xnvme_dev.h>
 
 static struct xnvme_be *g_xnvme_be_registry[] = {
-	&xnvme_be_spdk, &xnvme_be_linux, &xnvme_be_fbsd, &xnvme_be_posix, &xnvme_be_windows, NULL};
+	&xnvme_be_spdk, &xnvme_be_linux, &xnvme_be_fbsd, &xnvme_be_posix, &xnvme_be_windows, NULL,
+};
 static int g_xnvme_be_count = sizeof g_xnvme_be_registry / sizeof *g_xnvme_be_registry - 1;
 
 int

--- a/lib/xnvme_be.c
+++ b/lib/xnvme_be.c
@@ -723,17 +723,3 @@ xnvme_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enumerate_cb
 
 	return 0;
 }
-
-
-struct xnvme_opts
-xnvme_opts_default(void)
-{
-	struct xnvme_opts opts = {0};
-
-	opts.rdwr = 1;
-
-	// Value is only applicable if the user also sets opts.create = 1
-	opts.create_mode = S_IRUSR | S_IWUSR;
-
-	return opts;
-}

--- a/lib/xnvme_be.c
+++ b/lib/xnvme_be.c
@@ -557,61 +557,6 @@ exit:
 	return err;
 }
 
-int
-xnvme_ident_yaml(FILE *stream, const struct xnvme_ident *ident, int indent, const char *sep,
-		 int head)
-{
-	int wrtn = 0;
-
-	if (head) {
-		wrtn += fprintf(stream, "%*sxnvme_ident:", indent, "");
-		indent += 2;
-	}
-
-	if (!ident) {
-		wrtn += fprintf(stream, " ~");
-		return wrtn;
-	}
-
-	if (head) {
-		wrtn += fprintf(stream, "\n");
-	}
-
-	wrtn += fprintf(stream, "%*suri: '%s'%s", indent, "", ident->uri, sep);
-	wrtn += fprintf(stream, "%*sdtype: 0x%x%s", indent, "", ident->dtype, sep);
-	wrtn += fprintf(stream, "%*snsid: 0x%x%s", indent, "", ident->nsid, sep);
-	wrtn += fprintf(stream, "%*scsi: 0x%x", indent, "", ident->csi);
-
-	return wrtn;
-}
-
-int
-xnvme_ident_fpr(FILE *stream, const struct xnvme_ident *ident, int opts)
-{
-	int wrtn = 0;
-
-	switch (opts) {
-	case XNVME_PR_TERSE:
-		wrtn += fprintf(stream, "# ENOSYS: opts(%x)", opts);
-		return wrtn;
-
-	case XNVME_PR_DEF:
-	case XNVME_PR_YAML:
-		break;
-	}
-
-	wrtn += xnvme_ident_yaml(stream, ident, 0, "\n", 1);
-	wrtn += fprintf(stream, "\n");
-
-	return wrtn;
-}
-
-int
-xnvme_ident_pr(const struct xnvme_ident *ident, int opts)
-{
-	return xnvme_ident_fpr(stdout, ident, opts);
-}
-
 /**
  * Set up mixin of 'be' of the given 'mtype' and matching 'opts' when provided
  */
@@ -779,22 +724,6 @@ xnvme_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enumerate_cb
 	return 0;
 }
 
-int
-xnvme_ident_from_uri(const char *uri, struct xnvme_ident *ident)
-{
-	if (strlen(uri) >= XNVME_IDENT_URI_LEN) {
-		XNVME_DEBUG("FAILED: strlen(uri) too long");
-		return -EINVAL;
-	}
-
-	memset(ident, 0, sizeof(*ident));
-	strncpy(ident->uri, uri, XNVME_IDENT_URI_LEN - 1);
-	ident->dtype = XNVME_DEV_TYPE_UNKNOWN;
-	ident->nsid = 0xFFFFFFFF;
-	ident->csi = 0xFF;
-
-	return 0;
-}
 
 struct xnvme_opts
 xnvme_opts_default(void)

--- a/lib/xnvme_ident.c
+++ b/lib/xnvme_ident.c
@@ -1,0 +1,79 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <libxnvme.h>
+#include <libxnvme_pp.h>
+#include <xnvme_dev.h>
+
+int
+xnvme_ident_from_uri(const char *uri, struct xnvme_ident *ident)
+{
+	if (strlen(uri) >= XNVME_IDENT_URI_LEN) {
+		XNVME_DEBUG("FAILED: strlen(uri) too long");
+		return -EINVAL;
+	}
+
+	memset(ident, 0, sizeof(*ident));
+	strncpy(ident->uri, uri, XNVME_IDENT_URI_LEN - 1);
+	ident->dtype = XNVME_DEV_TYPE_UNKNOWN;
+	ident->nsid = 0xFFFFFFFF;
+	ident->csi = 0xFF;
+
+	return 0;
+}
+
+int
+xnvme_ident_yaml(FILE *stream, const struct xnvme_ident *ident, int indent, const char *sep,
+		 int head)
+{
+	int wrtn = 0;
+
+	if (head) {
+		wrtn += fprintf(stream, "%*sxnvme_ident:", indent, "");
+		indent += 2;
+	}
+
+	if (!ident) {
+		wrtn += fprintf(stream, " ~");
+		return wrtn;
+	}
+
+	if (head) {
+		wrtn += fprintf(stream, "\n");
+	}
+
+	wrtn += fprintf(stream, "%*suri: '%s'%s", indent, "", ident->uri, sep);
+	wrtn += fprintf(stream, "%*sdtype: 0x%x%s", indent, "", ident->dtype, sep);
+	wrtn += fprintf(stream, "%*snsid: 0x%x%s", indent, "", ident->nsid, sep);
+	wrtn += fprintf(stream, "%*scsi: 0x%x", indent, "", ident->csi);
+
+	return wrtn;
+}
+
+int
+xnvme_ident_fpr(FILE *stream, const struct xnvme_ident *ident, int opts)
+{
+	int wrtn = 0;
+
+	switch (opts) {
+	case XNVME_PR_TERSE:
+		wrtn += fprintf(stream, "# ENOSYS: opts(%x)", opts);
+		return wrtn;
+
+	case XNVME_PR_DEF:
+	case XNVME_PR_YAML:
+		break;
+	}
+
+	wrtn += xnvme_ident_yaml(stream, ident, 0, "\n", 1);
+	wrtn += fprintf(stream, "\n");
+
+	return wrtn;
+}
+
+int
+xnvme_ident_pr(const struct xnvme_ident *ident, int opts)
+{
+	return xnvme_ident_fpr(stdout, ident, opts);
+}

--- a/lib/xnvme_opts.c
+++ b/lib/xnvme_opts.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <libxnvme.h>
+#include <libxnvme_pp.h>
+
+struct xnvme_opts
+xnvme_opts_default(void)
+{
+	struct xnvme_opts opts = {0};
+
+	opts.rdwr = 1;
+
+	// Value is only applicable if the user also sets opts.create = 1
+	opts.create_mode = S_IRUSR | S_IWUSR;
+
+	return opts;
+}

--- a/lib/xnvme_opts.c
+++ b/lib/xnvme_opts.c
@@ -17,3 +17,89 @@ xnvme_opts_default(void)
 
 	return opts;
 }
+
+int
+xnvme_opts_yaml(FILE *stream, const struct xnvme_opts *opts, int indent, const char *sep, int head)
+{
+	int wrtn = 0;
+
+	if (head) {
+		wrtn += fprintf(stream, "%*sxnvme_opts:", indent, "");
+		indent += 2;
+	}
+	if (!opts) {
+		wrtn += fprintf(stream, " ~");
+		return wrtn;
+	}
+	if (head) {
+		wrtn += fprintf(stream, "\n");
+	}
+
+	wrtn += fprintf(stream, "\n");
+
+	wrtn += fprintf(stream, "%*sbe: '%s'%s", indent, "", opts->be, sep);
+	wrtn += fprintf(stream, "%*sdev: '%s'%s", indent, "", opts->dev, sep);
+	wrtn += fprintf(stream, "%*smem: '%s'%s", indent, "", opts->mem, sep);
+	wrtn += fprintf(stream, "%*ssync: '%s'%s", indent, "", opts->sync, sep);
+	wrtn += fprintf(stream, "%*sasync: '%s'%s", indent, "", opts->async, sep);
+	wrtn += fprintf(stream, "%*sadmin: '%s'%s", indent, "", opts->admin, sep);
+
+	wrtn += fprintf(stream, "%*snsid: 0x%x%s", indent, "", opts->nsid, sep);
+
+	wrtn += fprintf(stream, "%*soflags: 0x%x%s", indent, "", opts->oflags, sep);
+	wrtn += fprintf(stream, "%*srdonly: %d%s", indent, "", opts->rdonly, sep);
+	wrtn += fprintf(stream, "%*swronly: %d%s", indent, "", opts->wronly, sep);
+	wrtn += fprintf(stream, "%*srdwr: %d%s", indent, "", opts->rdwr, sep);
+	wrtn += fprintf(stream, "%*screate: %d%s", indent, "", opts->create, sep);
+	wrtn += fprintf(stream, "%*struncate: %d%s", indent, "", opts->truncate, sep);
+	wrtn += fprintf(stream, "%*sdirect: %d%s", indent, "", opts->direct, sep);
+
+	wrtn += fprintf(stream, "%*screate_mode: 0x%x%s", indent, "", opts->create_mode, sep);
+
+	wrtn += fprintf(stream, "%*spoll_io: %d%s", indent, "", opts->poll_io, sep);
+	wrtn += fprintf(stream, "%*spoll_sq: %d%s", indent, "", opts->poll_sq, sep);
+	wrtn += fprintf(stream, "%*sregister_files: %d%s", indent, "", opts->register_files, sep);
+	wrtn += fprintf(stream, "%*sregister_buffers: %d%s", indent, "", opts->register_buffers,
+			sep);
+
+	wrtn += fprintf(stream, "%*scss.given: %d%s", indent, "", opts->css.given, sep);
+	wrtn += fprintf(stream, "%*scss.value: 0x%x%s", indent, "", opts->css.value, sep);
+
+	wrtn += fprintf(stream, "%*suse_cmb_sqs: 0x%x%s", indent, "", opts->use_cmb_sqs, sep);
+	wrtn += fprintf(stream, "%*sshm_id: 0x%x%s", indent, "", opts->shm_id, sep);
+	wrtn += fprintf(stream, "%*smain_core: 0x%x%s", indent, "", opts->main_core, sep);
+
+	wrtn += fprintf(stream, "%*score_mask: '%s'%s", indent, "", opts->core_mask, sep);
+	wrtn += fprintf(stream, "%*sadrfam: '%s'%s", indent, "", opts->adrfam, sep);
+
+	wrtn += fprintf(stream, "%*sspdk_fabrics: 0x%x%s", indent, "", opts->spdk_fabrics, sep);
+
+	return wrtn;
+}
+
+int
+xnvme_opts_fpr(FILE *stream, const struct xnvme_opts *opts, enum xnvme_pr pr_opts)
+{
+	int wrtn = 0;
+
+	switch (pr_opts) {
+	case XNVME_PR_TERSE:
+		wrtn += fprintf(stream, "# ENOSYS: pr_opts(%x)", pr_opts);
+		return wrtn;
+
+	case XNVME_PR_DEF:
+	case XNVME_PR_YAML:
+		break;
+	}
+
+	wrtn += xnvme_opts_yaml(stream, opts, 2, "\n", 1);
+	wrtn += fprintf(stream, "\n");
+
+	return wrtn;
+}
+
+int
+xnvme_opts_pr(const struct xnvme_opts *opts, int pr_opts)
+{
+	return xnvme_opts_fpr(stdout, opts, pr_opts);
+}


### PR DESCRIPTION
Changes done in preparation for Python language bindings.
The main thing is the addition of ``xnvme_opts_pr()`` as it is used to check the Python bindings.
That is, that the visually inspect that the misc assignments of **const char pointer**, bitfields and numerical values carry over correctly from Python to C.