### PR TITLE
be:linux:ucmd: add Support for Big-SQE / Big-CQEs

### DIFF
--- a/include/xnvme_be_linux_liburing.h
+++ b/include/xnvme_be_linux_liburing.h
@@ -5,6 +5,7 @@
 #include <liburing.h>
 
 #define XNVME_QUEUE_IOU_CQE_BATCH_MAX 8
+#define XNVME_QUEUE_IOU_BIGSQE        (0x1 << 2)
 
 struct xnvme_queue_liburing {
 	struct xnvme_queue_base base;

--- a/lib/xnvme_be_linux_async_liburing.c
+++ b/lib/xnvme_be_linux_async_liburing.c
@@ -86,6 +86,11 @@ xnvme_be_linux_liburing_init(struct xnvme_queue *q, int opts)
 		iou_flags |= IORING_SETUP_IOPOLL;
 	}
 
+	if (opts & XNVME_QUEUE_IOU_BIGSQE) {
+		iou_flags |= IORING_SETUP_SQE128;
+		iou_flags |= IORING_SETUP_CQE32;
+	}
+
 	err = io_uring_queue_init(queue->base.capacity, &queue->ring, iou_flags);
 	if (err) {
 		XNVME_DEBUG("FAILED: io_uring_queue_init(), err: %d", err);

--- a/lib/xnvme_be_linux_nvme.c
+++ b/lib/xnvme_be_linux_nvme.c
@@ -39,6 +39,14 @@ ioctl_request_to_str(unsigned long req)
 	case NVME_IOCTL_IO64_CMD_VEC:
 		return "NVME_IOCTL_IO64_CMD_VEC";
 #endif
+#ifdef NVME_URING_CMD_IO
+	case NVME_URING_CMD_IO:
+		return "NVME_URING_CMD_IO";
+#endif
+#ifdef NVME_URING_CMD_IO_VEC
+	case NVME_URING_CMD_IO_VEC:
+		return "NVME_URING_CMD_IO_VEC";
+#endif
 	case NVME_IOCTL_RESET:
 		return "NVME_IOCTL_RESET";
 	case NVME_IOCTL_SUBSYS_RESET:
@@ -92,6 +100,14 @@ xnvme_be_linux_nvme_map_cpl(struct xnvme_cmd_ctx *ctx, unsigned long ioctl_req, 
 #ifdef NVME_IOCTL_ADMIN64_CMD
 	case NVME_IOCTL_ADMIN64_CMD:
 		ctx->cpl.result = kcpl->res64.result;
+		break;
+#endif
+#ifdef NVME_URING_CMD_IO
+	case NVME_URING_CMD_IO:
+		break;
+#endif
+#ifdef NVME_URING_CMD_IO_VEC
+	case NVME_URING_CMD_IO_VEC:
 		break;
 #endif
 	default:

--- a/subprojects/liburing.wrap
+++ b/subprojects/liburing.wrap
@@ -1,7 +1,7 @@
 [wrap-git]
 url = https://github.com/axboe/liburing.git
-revision = liburing-2.1
 patch_directory = liburing
+revision = master
 
 [provide]
 uring = uring


### PR DESCRIPTION
_Supports Regular & Vectored I/O with 128 byte SQEs and 32 byte CQEs_

**Sample Commands :**

**Regular I/O :**
_fio ./tools/fio-engine/xnvme-verify.fio --section=default --ioengine=external:./builddir/tools/fio-engine/libxnvme-fio-engine.so --filename=/dev/ng0n1 --xnvme_async=io_uring_cmd_

**Vectored I/O :**
_fio ./tools/fio-engine/xnvme-verify.fio --section=default --ioengine=external:./builddir/tools/fio-engine/libxnvme-fio-engine.so --filename=/dev/ng0n1 --xnvme_async=io_uring_cmd --xnvme_iovec=1_