### PR TITLE
Fixes to doc-generator and documentation

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -661,12 +661,21 @@ jobs:
         source ${{ steps.cijoe-qemu.outputs.target-env }}
         cij.cmd "meson install -C builddir"
 
+    - name: CIJOE, install fio
+      run: |
+        pushd $(cij_root) && source modules/cijoe.sh && popd
+        source ${{ steps.cijoe-qemu.outputs.target-env }}
+        cij.cmd "cd subprojects/fio && make install"
+
     - name: CIJOE, check binaries are available
       run: |
         pushd $(cij_root) && source modules/cijoe.sh && popd
         source ${{ steps.cijoe-qemu.outputs.target-env }}
         cij.cmd "xnvme enum"
         cij.cmd "xnvme library-info"
+        cij.cmd "pkg-config xnvme --variable=libdir"
+        cij.cmd "pkg-config xnvme --variable=datadir"
+        cij.cmd "pkg-config xnvme --variable=includedir"
 
     - name: CIJOE/QEMU, xnvme-docgen generate command-output
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ scripts/source-format.log*
 build
 builddir
 docs/build
+docs/autogen/enumerate_example
 docs/tutorial/dynamic_loading/enumerate_example
 cscope.out
 tags

--- a/docs/getting_started/200_dmesg.out
+++ b/docs/getting_started/200_dmesg.out
@@ -1,2 +1,2 @@
-[    0.023043] DMAR: IOMMU enabled
+[    0.025384] DMAR: IOMMU enabled
 

--- a/docs/getting_started/xnvme_io_async_read_emu.out
+++ b/docs/getting_started/xnvme_io_async_read_emu.out
@@ -7,6 +7,6 @@ xnvme_lba_range:
   naddrs: 1
   nbytes: 4096
   attr: { is_zones: 0, is_valid: 1}
-wall-clock: {elapsed: 0.0005, mib: 0.00, mib_sec: 7.58}
+wall-clock: {elapsed: 0.0013, mib: 0.00, mib_sec: 2.98}
 # cb_args: {submitted: 1, completed: 1, ecount: 0}
 

--- a/docs/getting_started/xnvme_io_async_read_io_uring.out
+++ b/docs/getting_started/xnvme_io_async_read_io_uring.out
@@ -7,6 +7,6 @@ xnvme_lba_range:
   naddrs: 1
   nbytes: 4096
   attr: { is_zones: 0, is_valid: 1}
-wall-clock: {elapsed: 0.0000, mib: 0.00, mib_sec: 313.23}
+wall-clock: {elapsed: 0.0000, mib: 0.00, mib_sec: 344.13}
 # cb_args: {submitted: 1, completed: 1, ecount: 0}
 

--- a/docs/getting_started/xnvme_io_async_read_libaio.out
+++ b/docs/getting_started/xnvme_io_async_read_libaio.out
@@ -7,6 +7,6 @@ xnvme_lba_range:
   naddrs: 1
   nbytes: 4096
   attr: { is_zones: 0, is_valid: 1}
-wall-clock: {elapsed: 0.0006, mib: 0.00, mib_sec: 6.37}
+wall-clock: {elapsed: 0.0000, mib: 0.00, mib_sec: 269.45}
 # cb_args: {submitted: 1, completed: 1, ecount: 0}
 

--- a/docs/getting_started/xnvme_library-info.out
+++ b/docs/getting_started/xnvme_library-info.out
@@ -1,11 +1,26 @@
 # xNVMe Library Information
-ver: {major: 0, minor: 0, patch: 29}
-xnvme_3p:
-  - 'fio;git-describe:fio-3.28'
-  - 'libnvme;git-rev:master/a458217'
-  - 'liburing;git-describe:liburing-2.0'
-  - 'spdk;git-describe:v21.10;+patches'
-  - 'linux;LINUX_VERSION_CODE-UAPI/330310-5.10.70'
+ver: {major: 0, minor: 3, patch: 0}
+xnvme_libconf:
+  - '3p: fio;git-describe:fio-3.30'
+  - '3p: liburing;git-describe:liburing-2.1-409-gbb756586'
+  - '3p: spdk;git-describe:v21.10;+patches'
+  - 'conf: XNVME_BE_LINUX_ENABLED'
+  - 'conf: XNVME_BE_LINUX_BLOCK_ENABLED'
+  - 'conf: XNVME_BE_LINUX_BLOCK_ZONED_ENABLED'
+  - 'conf: XNVME_BE_LINUX_LIBAIO_ENABLED'
+  - 'conf: XNVME_BE_LINUX_LIBURING_ENABLED'
+  - 'conf: XNVME_BE_POSIX_ENABLED'
+  - 'conf: XNVME_BE_SPDK_ENABLED'
+  - 'conf: XNVME_BE_SPDK_TRANSPORT_PCIE_ENABLED'
+  - 'conf: XNVME_BE_SPDK_TRANSPORT_TCP_ENABLED'
+  - 'conf: XNVME_BE_SPDK_TRANSPORT_RDMA_ENABLED'
+  - 'conf: XNVME_BE_SPDK_TRANSPORT_FC_ENABLED'
+  - 'conf: XNVME_BE_ASYNC_ENABLED'
+  - 'conf: XNVME_BE_ASYNC_EMU_ENABLED'
+  - 'conf: XNVME_BE_ASYNC_THRPOOL_ENABLED'
+  - '3p: linux;LINUX_VERSION_CODE-UAPI/330332-5.10.92'
+  - '3p: NVME_IOCTL_IO64_CMD'
+  - '3p: NVME_IOCTL_ADMIN64_CMD'
 xnvme_be_attr_list:
   count: 5
   capacity: 5

--- a/docs/tools/file/file_usage.out
+++ b/docs/tools/file/file_usage.out
@@ -2,15 +2,17 @@ Usage: xnvme_file <command> [<args>]
 
 Where <command> is one of:
 
-  write-read       | Write and read a file
-  dump-sync        | Write a buffer of 'data-nbytes' to file
-  dump-async       | Write a buffer of 'data-nbytes' to file --data-output
-  load-sync        | Read the entire file into memory
-  load-async       | Read the entire file into memory
-  copy-sync        | Copy file --data-input to --data--output
-  copy-async       | Copy file -- asynchronously
+  write-read        | Write and read a file
+  dump-sync         | Write a buffer of 'data-nbytes' to file
+  dump-sync-iovec   | Write a buffer of 'data-nbytes' to file using vectored ios
+  dump-async        | Write a buffer of 'data-nbytes' to file --data-output
+  dump-async-iovec  | Write a buffer of 'data-nbytes' to file --data-output using vectored ios
+  load-sync         | Read the entire file into memory
+  load-async        | Read the entire file into memory
+  copy-sync         | Copy file --data-input to --data--output
+  copy-async        | Copy file -- asynchronously
 
 See 'xnvme_file <command> --help' for the description of [<args>]
 
-xNVMe file - Exercise the xnvme_file API -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe file - Exercise the xnvme_file API -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/fio/200_fio_compare_os.out
+++ b/docs/tools/fio/200_fio_compare_os.out
@@ -2,28 +2,28 @@ default: (g=0): rw=randread, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096
 fio-3.30
 Starting 1 thread
 
-default: (groupid=0, jobs=1): err= 0: pid=24218: Tue May 17 08:15:30 2022
-  read: IOPS=1208, BW=4834KiB/s (4950kB/s)(33.1MiB/7001msec)
-    slat (nsec): min=300, max=197481, avg=2367.51, stdev=2869.49
-    clat (usec): min=403, max=3830, avg=819.57, stdev=227.72
-     lat (usec): min=405, max=3833, avg=821.93, stdev=228.34
+default: (groupid=0, jobs=1): err= 0: pid=21168: Wed May 18 14:48:09 2022
+  read: IOPS=1468, BW=5872KiB/s (6013kB/s)(40.1MiB/7001msec)
+    slat (nsec): min=200, max=30387, avg=1478.46, stdev=766.92
+    clat (usec): min=359, max=3151, avg=675.27, stdev=131.67
+     lat (usec): min=359, max=3152, avg=676.75, stdev=131.79
     clat percentiles (usec):
-     |  1.00th=[  506],  5.00th=[  578], 10.00th=[  619], 20.00th=[  668],
-     | 30.00th=[  709], 40.00th=[  742], 50.00th=[  783], 60.00th=[  816],
-     | 70.00th=[  857], 80.00th=[  914], 90.00th=[ 1037], 95.00th=[ 1205],
-     | 99.00th=[ 1762], 99.50th=[ 1991], 99.90th=[ 2606], 99.95th=[ 2835],
-     | 99.99th=[ 3818]
-   bw (  KiB/s): min= 4328, max= 5434, per=100.00%, avg=4836.29, stdev=396.71, samples=14
-   iops        : min= 1082, max= 1358, avg=1209.00, stdev=99.07, samples=14
-  lat (usec)   : 500=0.83%, 750=40.80%, 1000=46.57%
-  lat (msec)   : 2=11.32%, 4=0.48%
-  cpu          : usr=3.33%, sys=37.80%, ctx=8326, majf=0, minf=0
+     |  1.00th=[  445],  5.00th=[  519], 10.00th=[  545], 20.00th=[  586],
+     | 30.00th=[  611], 40.00th=[  644], 50.00th=[  668], 60.00th=[  693],
+     | 70.00th=[  717], 80.00th=[  750], 90.00th=[  791], 95.00th=[  840],
+     | 99.00th=[ 1106], 99.50th=[ 1385], 99.90th=[ 1876], 99.95th=[ 2008],
+     | 99.99th=[ 2245]
+   bw (  KiB/s): min= 4632, max= 6244, per=100.00%, avg=5874.43, stdev=390.21, samples=14
+   iops        : min= 1158, max= 1561, avg=1468.50, stdev=97.56, samples=14
+  lat (usec)   : 500=3.52%, 750=77.65%, 1000=17.14%
+  lat (msec)   : 2=1.62%, 4=0.06%
+  cpu          : usr=2.31%, sys=37.31%, ctx=10260, majf=0, minf=0
   IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
      submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
      complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
-     issued rwts: total=8461,0,0,0 short=0,0,0,0 dropped=0,0,0,0
+     issued rwts: total=10278,0,0,0 short=0,0,0,0 dropped=0,0,0,0
      latency   : target=0, window=0, percentile=100.00%, depth=1
 
 Run status group 0 (all jobs):
-   READ: bw=4834KiB/s (4950kB/s), 4834KiB/s-4834KiB/s (4950kB/s-4950kB/s), io=33.1MiB (34.7MB), run=7001-7001msec
+   READ: bw=5872KiB/s (6013kB/s), 5872KiB/s-5872KiB/s (6013kB/s-6013kB/s), io=40.1MiB (42.1MB), run=7001-7001msec
 

--- a/docs/tools/fio/210_fio_compare_os.out
+++ b/docs/tools/fio/210_fio_compare_os.out
@@ -2,30 +2,29 @@ default: (g=0): rw=randread, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096
 fio-3.30
 Starting 1 thread
 
-default: (groupid=0, jobs=1): err= 0: pid=24223: Tue May 17 08:15:40 2022
-  read: IOPS=1225, BW=4903KiB/s (5021kB/s)(33.5MiB/7001msec)
-    slat (usec): min=47, max=1940, avg=136.93, stdev=129.76
-    clat (nsec): min=592, max=2489.5k, avg=673326.59, stdev=196452.07
-     lat (usec): min=414, max=2731, avg=810.26, stdev=184.98
+default: (groupid=0, jobs=1): err= 0: pid=21173: Wed May 18 14:48:19 2022
+  read: IOPS=1458, BW=5833KiB/s (5973kB/s)(39.9MiB/7001msec)
+    slat (usec): min=42, max=1819, avg=99.68, stdev=77.12
+    clat (nsec): min=1432, max=1800.0k, avg=581889.14, stdev=123027.63
+     lat (usec): min=364, max=1934, avg=681.57, stdev=109.92
     clat percentiles (usec):
-     |  1.00th=[    4],  5.00th=[  375], 10.00th=[  478], 20.00th=[  553],
-     | 30.00th=[  603], 40.00th=[  644], 50.00th=[  668], 60.00th=[  701],
-     | 70.00th=[  742], 80.00th=[  783], 90.00th=[  857], 95.00th=[  963],
-     | 99.00th=[ 1303], 99.50th=[ 1467], 99.90th=[ 1811], 99.95th=[ 1926],
-     | 99.99th=[ 2474]
-   bw (  KiB/s): min= 4384, max= 5472, per=100.00%, avg=4905.57, stdev=312.79, samples=14
-   iops        : min= 1096, max= 1368, avg=1226.29, stdev=78.12, samples=14
-  lat (nsec)   : 750=0.05%
-  lat (usec)   : 2=0.12%, 4=1.06%, 10=0.27%, 20=0.03%, 250=0.21%
-  lat (usec)   : 500=10.15%, 750=60.99%, 1000=22.89%
-  lat (msec)   : 2=4.19%, 4=0.05%
-  cpu          : usr=2.23%, sys=38.63%, ctx=8465, majf=0, minf=0
+     |  1.00th=[  269],  5.00th=[  396], 10.00th=[  457], 20.00th=[  502],
+     | 30.00th=[  537], 40.00th=[  562], 50.00th=[  594], 60.00th=[  619],
+     | 70.00th=[  635], 80.00th=[  660], 90.00th=[  693], 95.00th=[  725],
+     | 99.00th=[  914], 99.50th=[ 1123], 99.90th=[ 1369], 99.95th=[ 1549],
+     | 99.99th=[ 1631]
+   bw (  KiB/s): min= 5560, max= 5912, per=100.00%, avg=5835.50, stdev=95.17, samples=14
+   iops        : min= 1390, max= 1478, avg=1458.71, stdev=23.81, samples=14
+  lat (usec)   : 2=0.02%, 4=0.45%, 10=0.10%, 20=0.01%, 100=0.01%
+  lat (usec)   : 250=0.18%, 500=18.68%, 750=76.93%, 1000=2.92%
+  lat (msec)   : 2=0.71%
+  cpu          : usr=1.80%, sys=36.91%, ctx=10157, majf=0, minf=0
   IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
      submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
      complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
-     issued rwts: total=8582,0,0,0 short=0,0,0,0 dropped=0,0,0,0
+     issued rwts: total=10208,0,0,0 short=0,0,0,0 dropped=0,0,0,0
      latency   : target=0, window=0, percentile=100.00%, depth=1
 
 Run status group 0 (all jobs):
-   READ: bw=4903KiB/s (5021kB/s), 4903KiB/s-4903KiB/s (5021kB/s-5021kB/s), io=33.5MiB (35.2MB), run=7001-7001msec
+   READ: bw=5833KiB/s (5973kB/s), 5833KiB/s-5833KiB/s (5973kB/s-5973kB/s), io=39.9MiB (41.8MB), run=7001-7001msec
 

--- a/docs/tools/fio/220_fio_compare_os.out
+++ b/docs/tools/fio/220_fio_compare_os.out
@@ -2,30 +2,30 @@ default: (g=0): rw=randread, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096
 fio-3.30
 Starting 1 thread
 
-default: (groupid=0, jobs=1): err= 0: pid=24230: Tue May 17 08:15:50 2022
-  read: IOPS=1236, BW=4948KiB/s (5067kB/s)(33.8MiB/7001msec)
-    slat (usec): min=44, max=1895, avg=161.10, stdev=144.52
-    clat (nsec): min=861, max=3325.3k, avg=641189.84, stdev=227780.77
-     lat (usec): min=412, max=3413, avg=802.29, stdev=222.50
+default: (groupid=0, jobs=1): err= 0: pid=21180: Wed May 18 14:48:29 2022
+  read: IOPS=1531, BW=6126KiB/s (6273kB/s)(41.9MiB/7001msec)
+    slat (usec): min=42, max=997, avg=122.98, stdev=100.05
+    clat (nsec): min=932, max=5426.2k, avg=525648.03, stdev=128185.93
+     lat (usec): min=398, max=5543, avg=648.62, stdev=109.61
     clat percentiles (usec):
-     |  1.00th=[    6],  5.00th=[  338], 10.00th=[  404], 20.00th=[  502],
-     | 30.00th=[  537], 40.00th=[  586], 50.00th=[  627], 60.00th=[  668],
-     | 70.00th=[  709], 80.00th=[  758], 90.00th=[  873], 95.00th=[ 1012],
-     | 99.00th=[ 1434], 99.50th=[ 1614], 99.90th=[ 1958], 99.95th=[ 2089],
-     | 99.99th=[ 3326]
-   bw (  KiB/s): min= 4280, max= 5568, per=100.00%, avg=4950.07, stdev=433.89, samples=14
-   iops        : min= 1070, max= 1392, avg=1237.43, stdev=108.40, samples=14
-  lat (nsec)   : 1000=0.05%
-  lat (usec)   : 2=0.09%, 4=0.05%, 10=1.42%, 20=0.16%, 50=0.03%
-  lat (usec)   : 250=0.38%, 500=17.32%, 750=58.83%, 1000=16.27%
-  lat (msec)   : 2=5.31%, 4=0.08%
-  cpu          : usr=3.96%, sys=43.29%, ctx=26810, majf=0, minf=0
+     |  1.00th=[  231],  5.00th=[  322], 10.00th=[  359], 20.00th=[  457],
+     | 30.00th=[  482], 40.00th=[  502], 50.00th=[  523], 60.00th=[  545],
+     | 70.00th=[  586], 80.00th=[  627], 90.00th=[  668], 95.00th=[  701],
+     | 99.00th=[  775], 99.50th=[  807], 99.90th=[  922], 99.95th=[  988],
+     | 99.99th=[ 2704]
+   bw (  KiB/s): min= 6008, max= 6264, per=100.00%, avg=6128.29, stdev=74.91, samples=14
+   iops        : min= 1502, max= 1566, avg=1532.07, stdev=18.73, samples=14
+  lat (nsec)   : 1000=0.01%
+  lat (usec)   : 4=0.06%, 10=0.44%, 20=0.01%, 250=0.81%, 500=37.81%
+  lat (usec)   : 750=59.21%, 1000=1.60%
+  lat (msec)   : 2=0.03%, 4=0.01%, 10=0.01%
+  cpu          : usr=3.50%, sys=40.80%, ctx=29382, majf=0, minf=0
   IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
      submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
      complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
-     issued rwts: total=8660,0,0,0 short=0,0,0,0 dropped=0,0,0,0
+     issued rwts: total=10722,0,0,0 short=0,0,0,0 dropped=0,0,0,0
      latency   : target=0, window=0, percentile=100.00%, depth=1
 
 Run status group 0 (all jobs):
-   READ: bw=4948KiB/s (5067kB/s), 4948KiB/s-4948KiB/s (5067kB/s-5067kB/s), io=33.8MiB (35.5MB), run=7001-7001msec
+   READ: bw=6126KiB/s (6273kB/s), 6126KiB/s-6126KiB/s (6273kB/s-6273kB/s), io=41.9MiB (43.9MB), run=7001-7001msec
 

--- a/docs/tools/fio/230_fio_compare_os.out
+++ b/docs/tools/fio/230_fio_compare_os.out
@@ -2,28 +2,28 @@ default: (g=0): rw=randread, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096
 fio-3.30
 Starting 1 thread
 
-default: (groupid=0, jobs=1): err= 0: pid=24235: Tue May 17 08:16:01 2022
-  read: IOPS=1120, BW=4482KiB/s (4589kB/s)(30.6MiB/7001msec)
-    slat (nsec): min=1082, max=1642.9k, avg=8316.27, stdev=22676.21
-    clat (usec): min=9, max=5618, avg=882.50, stdev=226.60
-     lat (usec): min=444, max=5649, avg=890.82, stdev=229.08
+default: (groupid=0, jobs=1): err= 0: pid=21185: Wed May 18 14:48:40 2022
+  read: IOPS=1364, BW=5459KiB/s (5590kB/s)(37.3MiB/7001msec)
+    slat (nsec): min=1012, max=248497, avg=4441.94, stdev=5567.30
+    clat (usec): min=420, max=2810, avg=727.56, stdev=102.76
+     lat (usec): min=423, max=2815, avg=732.00, stdev=103.16
     clat percentiles (usec):
-     |  1.00th=[  537],  5.00th=[  619], 10.00th=[  668], 20.00th=[  725],
-     | 30.00th=[  766], 40.00th=[  807], 50.00th=[  848], 60.00th=[  889],
-     | 70.00th=[  938], 80.00th=[ 1004], 90.00th=[ 1139], 95.00th=[ 1270],
-     | 99.00th=[ 1582], 99.50th=[ 1827], 99.90th=[ 2769], 99.95th=[ 3523],
-     | 99.99th=[ 5604]
-   bw (  KiB/s): min= 3672, max= 5000, per=100.00%, avg=4484.14, stdev=434.26, samples=14
-   iops        : min=  918, max= 1250, avg=1121.00, stdev=108.55, samples=14
-  lat (usec)   : 10=0.01%, 500=0.33%, 750=26.22%, 1000=52.66%
-  lat (msec)   : 2=20.42%, 4=0.33%, 10=0.01%
-  cpu          : usr=99.23%, sys=0.57%, ctx=1693, majf=0, minf=0
+     |  1.00th=[  510],  5.00th=[  578], 10.00th=[  611], 20.00th=[  644],
+     | 30.00th=[  668], 40.00th=[  693], 50.00th=[  725], 60.00th=[  750],
+     | 70.00th=[  775], 80.00th=[  807], 90.00th=[  848], 95.00th=[  889],
+     | 99.00th=[ 1004], 99.50th=[ 1045], 99.90th=[ 1205], 99.95th=[ 1270],
+     | 99.99th=[ 2802]
+   bw (  KiB/s): min= 5330, max= 5544, per=100.00%, avg=5461.00, stdev=63.08, samples=14
+   iops        : min= 1332, max= 1386, avg=1365.14, stdev=15.92, samples=14
+  lat (usec)   : 500=0.77%, 750=58.90%, 1000=39.30%
+  lat (msec)   : 2=1.00%, 4=0.02%
+  cpu          : usr=99.29%, sys=0.57%, ctx=1184, majf=0, minf=0
   IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
      submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
      complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
-     issued rwts: total=7844,0,0,0 short=0,0,0,0 dropped=0,0,0,0
+     issued rwts: total=9555,0,0,0 short=0,0,0,0 dropped=0,0,0,0
      latency   : target=0, window=0, percentile=100.00%, depth=1
 
 Run status group 0 (all jobs):
-   READ: bw=4482KiB/s (4589kB/s), 4482KiB/s-4482KiB/s (4589kB/s-4589kB/s), io=30.6MiB (32.1MB), run=7001-7001msec
+   READ: bw=5459KiB/s (5590kB/s), 5459KiB/s-5459KiB/s (5590kB/s-5590kB/s), io=37.3MiB (39.1MB), run=7001-7001msec
 

--- a/docs/tools/fio/310_fio_compare_uspace.out
+++ b/docs/tools/fio/310_fio_compare_uspace.out
@@ -4,29 +4,29 @@ default: (g=0): rw=randread, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096
 fio-3.30
 Starting 1 thread
 
-default: (groupid=0, jobs=1): err= 0: pid=24664: Tue May 17 08:16:22 2022
-  read: IOPS=1557, BW=6232KiB/s (6381kB/s)(42.6MiB/7001msec)
-    slat (usec): min=40, max=3266, avg=160.57, stdev=150.83
-    clat (usec): min=33, max=4096, avg=477.96, stdev=186.14
-     lat (usec): min=370, max=5228, avg=638.52, stdev=201.88
+default: (groupid=0, jobs=1): err= 0: pid=21614: Wed May 18 14:49:02 2022
+  read: IOPS=1805, BW=7220KiB/s (7393kB/s)(49.4MiB/7001msec)
+    slat (usec): min=36, max=3048, avg=133.60, stdev=116.65
+    clat (usec): min=31, max=5284, avg=418.01, stdev=115.49
+     lat (usec): min=338, max=8145, avg=551.61, stdev=136.81
     clat percentiles (usec):
-     |  1.00th=[   55],  5.00th=[  241], 10.00th=[  297], 20.00th=[  367],
-     | 30.00th=[  404], 40.00th=[  433], 50.00th=[  465], 60.00th=[  498],
-     | 70.00th=[  529], 80.00th=[  578], 90.00th=[  652], 95.00th=[  725],
-     | 99.00th=[ 1045], 99.50th=[ 1303], 99.90th=[ 1975], 99.95th=[ 3130],
-     | 99.99th=[ 3752]
-   bw (  KiB/s): min= 5184, max= 6688, per=99.81%, avg=6220.69, stdev=444.73, samples=13
-   iops        : min= 1296, max= 1672, avg=1555.15, stdev=111.16, samples=13
-  lat (usec)   : 50=0.67%, 100=0.90%, 250=4.02%, 500=54.93%, 750=35.38%
-  lat (usec)   : 1000=2.92%
-  lat (msec)   : 2=1.09%, 4=0.08%, 10=0.01%
-  cpu          : usr=99.40%, sys=0.16%, ctx=718, majf=0, minf=0
+     |  1.00th=[  176],  5.00th=[  249], 10.00th=[  289], 20.00th=[  343],
+     | 30.00th=[  367], 40.00th=[  396], 50.00th=[  420], 60.00th=[  441],
+     | 70.00th=[  469], 80.00th=[  498], 90.00th=[  537], 95.00th=[  578],
+     | 99.00th=[  644], 99.50th=[  685], 99.90th=[  848], 99.95th=[ 1029],
+     | 99.99th=[ 2900]
+   bw (  KiB/s): min= 6736, max= 7576, per=100.00%, avg=7223.00, stdev=244.82, samples=14
+   iops        : min= 1684, max= 1894, avg=1805.64, stdev=61.25, samples=14
+  lat (usec)   : 50=0.18%, 100=0.25%, 250=4.61%, 500=75.98%, 750=18.72%
+  lat (usec)   : 1000=0.20%
+  lat (msec)   : 2=0.02%, 4=0.02%, 10=0.01%
+  cpu          : usr=99.61%, sys=0.03%, ctx=745, majf=0, minf=0
   IO depths    : 1=100.0%, 2=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, >=64=0.0%
      submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
      complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
-     issued rwts: total=10907,0,0,0 short=0,0,0,0 dropped=0,0,0,0
+     issued rwts: total=12637,0,0,0 short=0,0,0,0 dropped=0,0,0,0
      latency   : target=0, window=0, percentile=100.00%, depth=1
 
 Run status group 0 (all jobs):
-   READ: bw=6232KiB/s (6381kB/s), 6232KiB/s-6232KiB/s (6381kB/s-6381kB/s), io=42.6MiB (44.7MB), run=7001-7001msec
+   READ: bw=7220KiB/s (7393kB/s), 7220KiB/s-7220KiB/s (7393kB/s-7393kB/s), io=49.4MiB (51.8MB), run=7001-7001msec
 

--- a/docs/tools/fio/900_prep.cmd
+++ b/docs/tools/fio/900_prep.cmd
@@ -1,0 +1,1 @@
+xnvme-driver reset

--- a/docs/tools/fio/900_prep.out
+++ b/docs/tools/fio/900_prep.out
@@ -1,3 +1,3 @@
-0000:03:00.0 (1b36 0010): Already using the nvme driver
+0000:03:00.0 (1b36 0010): vfio-pci -> nvme
 0000:00:02.0 (1af4 1001): Already using the virtio-pci driver
 

--- a/docs/tools/lblk/lblk_enum_usage.out
+++ b/docs/tools/lblk/lblk_enum_usage.out
@@ -11,5 +11,5 @@ Where <args> include:
 
 See 'lblk --help' for other commands
 
-Logical Block Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Logical Block Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/lblk/lblk_idfy_usage.out
+++ b/docs/tools/lblk/lblk_idfy_usage.out
@@ -14,5 +14,5 @@ Where <args> include:
 
 See 'lblk --help' for other commands
 
-Logical Block Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Logical Block Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/lblk/lblk_read_usage.out
+++ b/docs/tools/lblk/lblk_read_usage.out
@@ -18,5 +18,5 @@ Where <args> include:
 
 See 'lblk --help' for other commands
 
-Logical Block Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Logical Block Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/lblk/lblk_usage.out
+++ b/docs/tools/lblk/lblk_usage.out
@@ -12,5 +12,5 @@ Where <command> is one of:
 
 See 'lblk <command> --help' for the description of [<args>]
 
-Logical Block Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Logical Block Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/lblk/lblk_write_usage.out
+++ b/docs/tools/lblk/lblk_write_usage.out
@@ -18,5 +18,5 @@ Where <args> include:
 
 See 'lblk --help' for other commands
 
-Logical Block Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Logical Block Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xdd/xdd_async_usage.out
+++ b/docs/tools/xdd/xdd_async_usage.out
@@ -10,9 +10,10 @@ Where <args> include:
   [ --iosize NUM ]              ; Use given 'NUM' as bs/iosize
   [ --qdepth NUM ]              ; Use given 'NUM' as queue max capacity
   [ --direct ]                  ; Bypass layers
+  [ --offset NUM ]              ; Use given 'NUM' as offset
   [ --help ]                    ; Show usage / help
 
 See 'xdd --help' for other commands
 
-xNVMe dd - Copy bytes from input to output -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe dd - Copy bytes from input to output -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xdd/xdd_sync_usage.out
+++ b/docs/tools/xdd/xdd_sync_usage.out
@@ -9,9 +9,10 @@ Where <args> include:
   --data-nbytes NUM             ; Data size in bytes
   [ --iosize NUM ]              ; Use given 'NUM' as bs/iosize
   [ --direct ]                  ; Bypass layers
+  [ --offset NUM ]              ; Use given 'NUM' as offset
   [ --help ]                    ; Show usage / help
 
 See 'xdd --help' for other commands
 
-xNVMe dd - Copy bytes from input to output -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe dd - Copy bytes from input to output -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xdd/xdd_usage.out
+++ b/docs/tools/xdd/xdd_usage.out
@@ -7,5 +7,5 @@ Where <command> is one of:
 
 See 'xdd <command> --help' for the description of [<args>]
 
-xNVMe dd - Copy bytes from input to output -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe dd - Copy bytes from input to output -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xnvme/xnvme_enum_usage.out
+++ b/docs/tools/xnvme/xnvme_enum_usage.out
@@ -11,5 +11,5 @@ Where <args> include:
 
 See 'xnvme --help' for other commands
 
-xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xnvme/xnvme_feature_get_usage.out
+++ b/docs/tools/xnvme/xnvme_feature_get_usage.out
@@ -16,5 +16,5 @@ Where <args> include:
 
 See 'xnvme --help' for other commands
 
-xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xnvme/xnvme_feature_set_usage.out
+++ b/docs/tools/xnvme/xnvme_feature_set_usage.out
@@ -17,5 +17,5 @@ Where <args> include:
 
 See 'xnvme --help' for other commands
 
-xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xnvme/xnvme_format_usage.out
+++ b/docs/tools/xnvme/xnvme_format_usage.out
@@ -19,5 +19,5 @@ Where <args> include:
 
 See 'xnvme --help' for other commands
 
-xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xnvme/xnvme_idfy_ctrlr_usage.out
+++ b/docs/tools/xnvme/xnvme_idfy_ctrlr_usage.out
@@ -13,5 +13,5 @@ Where <args> include:
 
 See 'xnvme --help' for other commands
 
-xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xnvme/xnvme_idfy_ns_usage.out
+++ b/docs/tools/xnvme/xnvme_idfy_ns_usage.out
@@ -14,5 +14,5 @@ Where <args> include:
 
 See 'xnvme --help' for other commands
 
-xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xnvme/xnvme_idfy_usage.out
+++ b/docs/tools/xnvme/xnvme_idfy_usage.out
@@ -18,5 +18,5 @@ Where <args> include:
 
 See 'xnvme --help' for other commands
 
-xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xnvme/xnvme_info_usage.out
+++ b/docs/tools/xnvme/xnvme_info_usage.out
@@ -12,5 +12,5 @@ Where <args> include:
 
 See 'xnvme --help' for other commands
 
-xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xnvme/xnvme_library_info.out
+++ b/docs/tools/xnvme/xnvme_library_info.out
@@ -1,11 +1,26 @@
 # xNVMe Library Information
-ver: {major: 0, minor: 0, patch: 29}
-xnvme_3p:
-  - 'fio;git-describe:fio-3.28'
-  - 'libnvme;git-rev:master/a458217'
-  - 'liburing;git-describe:liburing-2.0'
-  - 'spdk;git-describe:v21.10;+patches'
-  - 'linux;LINUX_VERSION_CODE-UAPI/330310-5.10.70'
+ver: {major: 0, minor: 3, patch: 0}
+xnvme_libconf:
+  - '3p: fio;git-describe:fio-3.30'
+  - '3p: liburing;git-describe:liburing-2.1-409-gbb756586'
+  - '3p: spdk;git-describe:v21.10;+patches'
+  - 'conf: XNVME_BE_LINUX_ENABLED'
+  - 'conf: XNVME_BE_LINUX_BLOCK_ENABLED'
+  - 'conf: XNVME_BE_LINUX_BLOCK_ZONED_ENABLED'
+  - 'conf: XNVME_BE_LINUX_LIBAIO_ENABLED'
+  - 'conf: XNVME_BE_LINUX_LIBURING_ENABLED'
+  - 'conf: XNVME_BE_POSIX_ENABLED'
+  - 'conf: XNVME_BE_SPDK_ENABLED'
+  - 'conf: XNVME_BE_SPDK_TRANSPORT_PCIE_ENABLED'
+  - 'conf: XNVME_BE_SPDK_TRANSPORT_TCP_ENABLED'
+  - 'conf: XNVME_BE_SPDK_TRANSPORT_RDMA_ENABLED'
+  - 'conf: XNVME_BE_SPDK_TRANSPORT_FC_ENABLED'
+  - 'conf: XNVME_BE_ASYNC_ENABLED'
+  - 'conf: XNVME_BE_ASYNC_EMU_ENABLED'
+  - 'conf: XNVME_BE_ASYNC_THRPOOL_ENABLED'
+  - '3p: linux;LINUX_VERSION_CODE-UAPI/330332-5.10.92'
+  - '3p: NVME_IOCTL_IO64_CMD'
+  - '3p: NVME_IOCTL_ADMIN64_CMD'
 xnvme_be_attr_list:
   count: 5
   capacity: 5

--- a/docs/tools/xnvme/xnvme_log_erri_usage.out
+++ b/docs/tools/xnvme/xnvme_log_erri_usage.out
@@ -15,5 +15,5 @@ Where <args> include:
 
 See 'xnvme --help' for other commands
 
-xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xnvme/xnvme_log_health_usage.out
+++ b/docs/tools/xnvme/xnvme_log_health_usage.out
@@ -14,5 +14,5 @@ Where <args> include:
 
 See 'xnvme --help' for other commands
 
-xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xnvme/xnvme_log_usage.out
+++ b/docs/tools/xnvme/xnvme_log_usage.out
@@ -19,5 +19,5 @@ Where <args> include:
 
 See 'xnvme --help' for other commands
 
-xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xnvme/xnvme_padc_usage.out
+++ b/docs/tools/xnvme/xnvme_padc_usage.out
@@ -20,5 +20,5 @@ Where <args> include:
 
 See 'xnvme --help' for other commands
 
-xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xnvme/xnvme_pioc_usage.out
+++ b/docs/tools/xnvme/xnvme_pioc_usage.out
@@ -20,5 +20,5 @@ Where <args> include:
 
 See 'xnvme --help' for other commands
 
-xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xnvme/xnvme_sanitize_usage.out
+++ b/docs/tools/xnvme/xnvme_sanitize_usage.out
@@ -12,5 +12,5 @@ Where <args> include:
 
 See 'xnvme --help' for other commands
 
-xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/xnvme/xnvme_usage.out
+++ b/docs/tools/xnvme/xnvme_usage.out
@@ -22,5 +22,5 @@ Where <command> is one of:
 
 See 'xnvme <command> --help' for the description of [<args>]
 
-xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 0, patch: 29}
+xNVMe - Cross-platform NVMe utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/zoned/zoned_append_usage.out
+++ b/docs/tools/zoned/zoned_append_usage.out
@@ -18,5 +18,5 @@ Where <args> include:
 
 See 'zoned --help' for other commands
 
-Zoned Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Zoned Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/zoned/zoned_changes.uone.out
+++ b/docs/tools/zoned/zoned_changes.uone.out
@@ -2,5 +2,4 @@
 # Zoned Changes log page is an optional feature
 # This devices does not support it; expect failure
 
-# ERR: 'xnvme_znd_log_changes_from_dev()': {errno: -5, msg: 'Input/output error'}
-# ERR: 'changes': {errno: -5, msg: 'Input/output error'}
+# ERR: 'xnvme_znd_log_changes_from_dev()': {errno: 0, msg: 'Success'}

--- a/docs/tools/zoned/zoned_changes_usage.out
+++ b/docs/tools/zoned/zoned_changes_usage.out
@@ -13,5 +13,5 @@ Where <args> include:
 
 See 'zoned --help' for other commands
 
-Zoned Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Zoned Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/zoned/zoned_enum_usage.out
+++ b/docs/tools/zoned/zoned_enum_usage.out
@@ -11,5 +11,5 @@ Where <args> include:
 
 See 'zoned --help' for other commands
 
-Zoned Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Zoned Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/zoned/zoned_errors_usage.out
+++ b/docs/tools/zoned/zoned_errors_usage.out
@@ -14,5 +14,5 @@ Where <args> include:
 
 See 'zoned --help' for other commands
 
-Zoned Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Zoned Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/zoned/zoned_info_usage.out
+++ b/docs/tools/zoned/zoned_info_usage.out
@@ -12,5 +12,5 @@ Where <args> include:
 
 See 'zoned --help' for other commands
 
-Zoned Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Zoned Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/zoned/zoned_mgmt_close_usage.out
+++ b/docs/tools/zoned/zoned_mgmt_close_usage.out
@@ -16,5 +16,5 @@ Where <args> include:
 
 See 'zoned --help' for other commands
 
-Zoned Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Zoned Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/zoned/zoned_mgmt_finish_usage.out
+++ b/docs/tools/zoned/zoned_mgmt_finish_usage.out
@@ -16,5 +16,5 @@ Where <args> include:
 
 See 'zoned --help' for other commands
 
-Zoned Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Zoned Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/zoned/zoned_mgmt_open_usage.out
+++ b/docs/tools/zoned/zoned_mgmt_open_usage.out
@@ -16,5 +16,5 @@ Where <args> include:
 
 See 'zoned --help' for other commands
 
-Zoned Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Zoned Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/zoned/zoned_mgmt_usage.out
+++ b/docs/tools/zoned/zoned_mgmt_usage.out
@@ -17,5 +17,5 @@ Where <args> include:
 
 See 'zoned --help' for other commands
 
-Zoned Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Zoned Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/zoned/zoned_read_usage.out
+++ b/docs/tools/zoned/zoned_read_usage.out
@@ -5,7 +5,7 @@ Where <command> is one of:
   enum             | Enumerate Zoned Namespaces on the system
   info             | Retrieve device info
   idfy-ctrlr       | Zoned Command Set specific identify-controller
-  idfy-ns          | Zoned Command Set specific identify-controller
+  idfy-ns          | Zoned Command Set specific identify-namespace
   changes          | Retrieve the Changed Zone list
   errors           | Retrieve the Error-Log
   read             | Execute a Read Command
@@ -20,5 +20,5 @@ Where <command> is one of:
 
 See 'zoned <command> --help' for the description of [<args>]
 
-Zoned Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Zoned Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/zoned/zoned_report_usage.out
+++ b/docs/tools/zoned/zoned_report_usage.out
@@ -16,5 +16,5 @@ Where <args> include:
 
 See 'zoned --help' for other commands
 
-Zoned Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Zoned Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/zoned/zoned_usage.out
+++ b/docs/tools/zoned/zoned_usage.out
@@ -5,7 +5,7 @@ Where <command> is one of:
   enum             | Enumerate Zoned Namespaces on the system
   info             | Retrieve device info
   idfy-ctrlr       | Zoned Command Set specific identify-controller
-  idfy-ns          | Zoned Command Set specific identify-controller
+  idfy-ns          | Zoned Command Set specific identify-namespace
   changes          | Retrieve the Changed Zone list
   errors           | Retrieve the Error-Log
   read             | Execute a Read Command
@@ -20,5 +20,5 @@ Where <command> is one of:
 
 See 'zoned <command> --help' for the description of [<args>]
 
-Zoned Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Zoned Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tools/zoned/zoned_write_usage.out
+++ b/docs/tools/zoned/zoned_write_usage.out
@@ -5,7 +5,7 @@ Where <command> is one of:
   enum             | Enumerate Zoned Namespaces on the system
   info             | Retrieve device info
   idfy-ctrlr       | Zoned Command Set specific identify-controller
-  idfy-ns          | Zoned Command Set specific identify-controller
+  idfy-ns          | Zoned Command Set specific identify-namespace
   changes          | Retrieve the Changed Zone list
   errors           | Retrieve the Error-Log
   read             | Execute a Read Command
@@ -20,5 +20,5 @@ Where <command> is one of:
 
 See 'zoned <command> --help' for the description of [<args>]
 
-Zoned Namespace Utility -- ver: {major: 0, minor: 0, patch: 29}
+Zoned Namespace Utility -- ver: {major: 0, minor: 3, patch: 0}
 

--- a/docs/tutorial/dynamic_loading/000_compile_example.cmd
+++ b/docs/tutorial/dynamic_loading/000_compile_example.cmd
@@ -1,1 +1,1 @@
-gcc ./enumerate_example.c -ldl -o enumerate_example
+gcc ../tutorial/dynamic_loading/enumerate_example.c -ldl -o enumerate_example

--- a/docs/tutorial/dynamic_loading/020_run_python_example.cmd
+++ b/docs/tutorial/dynamic_loading/020_run_python_example.cmd
@@ -1,1 +1,1 @@
-python3 enumerate_example.py
+python3 ../tutorial/dynamic_loading/enumerate_example.py

--- a/docs/tutorial/nvme/100_xnvme_idfy_cs.out
+++ b/docs/tutorial/nvme/100_xnvme_idfy_cs.out
@@ -1,4 +1,3 @@
 xnvme_spec_idfy_cs:
   - { iocsci: 0, val: 0x5, nvm: 1, zns: 1 }
-  - { iocsci: 1, val: 0x1, nvm: 1, zns: 0 }
 


### PR DESCRIPTION
The updated description of fio required fio to be installed on the system, this is fixed in the ``ci:docgen`` commit.
During doc-generation a ``enumerate_example`` binary is generated, this is added to git-ignore in ``git: add ...``
To ensure that the commands in the fio-engine docs does not interfere a command to reset the driver was added in ``docs:tools:fio: ...``
The dynamic-loading example did not work properly when ctypes is unable to locate the library, this is fixed in ``docs:tutorial: fix loader in Python...``
Last, all the command-output is generated in ``docs: update ...``