### PR TITLE
Fixes to potential issues found by Coverity

### DIFF
--- a/tools/fio-engine/xnvme_fioe.c
+++ b/tools/fio-engine/xnvme_fioe.c
@@ -553,9 +553,12 @@ static enum fio_q_status xnvme_fioe_queue(struct thread_data *td, struct io_u *i
 
 	default:
 		log_err("ioeng->queue(): ENOSYS: %u\n", io_u->ddir);
-		err = -1;
+
+		xnvme_queue_put_cmd_ctx(ctx->async.queue, ctx);
+
+		io_ur->err = ENOSYS;
 		assert(false);
-		break;
+		return FIO_Q_COMPLETED;
 	}
 
 	if (vectored_io) {

--- a/tools/fio-engine/xnvme_fioe.c
+++ b/tools/fio-engine/xnvme_fioe.c
@@ -362,12 +362,15 @@ static int xnvme_fioe_init(struct thread_data *td)
 
 	xd->iocq = calloc(td->o.iodepth, sizeof(struct io_u *));
 	if (!xd->iocq) {
+		free(xd);
 		log_err("ioeng->init(): !calloc(), err(%d)\n", errno);
 		return 1;
 	}
 
 	xd->iovec = calloc(td->o.iodepth, sizeof(*xd->iovec));
 	if (!xd->iovec) {
+		free(xd->iovec);
+		free(xd);
 		log_err("ioeng->init(): !calloc(xd->iovec), err(%d)\n", errno);
 		return 1;
 	}


### PR DESCRIPTION
The xNVMe fio IO engine had two issues, which are fixed here:

* A resource-leak in _init() when memory-allocation failed
* Poor error-handling for non-supported data-direction