### PR TITLE
docs:tutorial:fabrics: adjust for multiple devices

### DIFF
--- a/docs/tutorial/fabrics/fabrics_env.sh
+++ b/docs/tutorial/fabrics/fabrics_env.sh
@@ -2,16 +2,18 @@
 #
 # Variables defining the fabrics setup, adjust these to match your setup
 #
-export NVMET_SUBSYS_NQN="nqn.2022-05.io.xnvme:ctrlnode1"
-export NVMET_SUBSYS_NSID="1"
+export NVMET_SUBSYS_NQN="nqn.2022-06.io.xnvme:ctrlnode1"
 
 export NVMET_TRADDR="1.2.3.4"
 export NVMET_TRTYPE="tcp"
 export NVMET_TRSVCID="4420"
 export NVMET_ADRFAM="ipv4"
 
-export EXPORT_DEV_PATH="/dev/nvme0n1"
-export EXPORT_DEV_PCIE="0000:03:00.0"
+# Device names and PCIe identifiers of NVMe devices on the NVMe-over-Fabrics target
+export NVMET_DEVPATHS="/dev/nvme0n1 /dev/nvme1n1"
+export NVMET_PCIE_IDS="0000:02:00.0 0000:04:00.0"
+
+export NVMEI_DEVPATHS="/dev/nvme1n1 /dev/nvme1n2"
 
 # Absolute path to the xNVMe repository
 export XNVME_REPOS="/root/git/xnvme"

--- a/docs/tutorial/fabrics/fabrics_initiator_nvmecli.sh
+++ b/docs/tutorial/fabrics/fabrics_initiator_nvmecli.sh
@@ -21,18 +21,23 @@ nvme connect \
   --trsvcid="${NVMET_TRSVCID}" \
   --nqn="${NVMET_SUBSYS_NQN}"
 
+# Time to settle...
+sleep 2
+
 echo "# Show devices after connecting/mounting"
 xnvme enum
 
-echo "# Inspect it, using xNVMe"
-xnvme info /dev/nvme1n1
+for dev_path in ${NVMEI_DEVPATHS}; do
+  echo "# Inspect dev_path: '${dev_path}' using xNVMe"
+  xnvme info "${dev_path}"
 
-echo "# Run fio"
-"${XNVME_REPOS}/subprojects/fio/fio" \
-  /usr/local/share/xnvme/xnvme-compare.fio \
-  --section=default \
-  --ioengine="io_uring" \
-  --filename="/dev/nvme1n1"
+  echo "# Run fio"
+  "${XNVME_REPOS}/subprojects/fio/fio" \
+    /usr/local/share/xnvme/xnvme-compare.fio \
+    --section=default \
+    --ioengine="io_uring" \
+    --filename="${dev_path}"
+done
 
 echo "# Disconnect, unmount the block-device"
 nvme disconnect --nqn="${NVMET_SUBSYS_NQN}"

--- a/docs/tutorial/fabrics/fabrics_initiator_xnvme.sh
+++ b/docs/tutorial/fabrics/fabrics_initiator_xnvme.sh
@@ -6,16 +6,18 @@ source fabrics_initiator_modules.sh
 echo "# Prepare the SPDK/DPDK environment"
 xnvme-driver
 
-echo "# Enumerate the device"
+echo "# Enumerate the transport"
 xnvme enum --uri "${NVMET_TRADDR}:${NVMET_TRSVCID}"
 
-echo "# Inspect the device"
-xnvme info "${NVMET_TRADDR}:${NVMET_TRSVCID}" --dev-nsid="${NVMET_SUBSYS_NSID}"
+for nsid in $(seq "$(echo "${NVMET_PCIE_IDS}" | wc -w)"); do
+  echo "# Inspect nsid: '${nsid}' using xNVMe"
+  xnvme info "${NVMET_TRADDR}:${NVMET_TRSVCID}" --dev-nsid="${nsid}"
 
-echo "# Run fio"
-"${XNVME_REPOS}/subprojects/fio/fio" \
-  /usr/local/share/xnvme/xnvme-compare.fio \
-  --section=default \
-  --ioengine="external:$(pkg-config xnvme --variable=libdir)/libxnvme-fio-engine.so" \
-  --filename="${NVMET_TRADDR}\\:${NVMET_TRSVCID}" \
-  --xnvme_dev_nsid=1
+  echo "# Run fio"
+  "${XNVME_REPOS}/subprojects/fio/fio" \
+    /usr/local/share/xnvme/xnvme-compare.fio \
+    --section=default \
+    --ioengine="external:$(pkg-config xnvme --variable=libdir)/libxnvme-fio-engine.so" \
+    --filename="${NVMET_TRADDR}\\:${NVMET_TRSVCID}" \
+    --xnvme_dev_nsid="${nsid}"
+done


### PR DESCRIPTION
The NVMe-over-Fabrics tutorial in the documentation only exports a single device.
This is fine when showing the various components to configure in Linux and SPDK, however, not very useful for setting up a more realistic setup consisting of an array of devices. The latter would be useful to provide an easy guide to following for troubleshooting issues such as the one reported here:  https://github.com/OpenMPDK/xNVMe/issues/86

This PR is a WIP to expand the guide for multiple devices. Here is what is missing:

- [ ] The text needs an update; it is currently describing the old scripts
- [ ] Fix the ``fabrics_target_spdk.sh`` it is currently not constructing the subsystem correctly, it is listening but when using it, either via ``nvme-cli`` or ``xnvme`` then the second device is not showing up.