### PR TITLE
be:spdk: add support for subnqn

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -636,6 +636,7 @@ jobs:
         vm-image: ${{ matrix.guest.img }}
         vm-cloudinit: ${{ matrix.guest.os }}-${{ matrix.guest.ver }}
         cijoe-packages: './toolbox/cijoe-pkg-xnvme/'
+        cijoe-qemu-script: 'qemu_setup_nvme_2c3ns_nvm_zrwa.sh'
 
     - name: CIJOE, transfer source to qemu-guest
       run: |
@@ -739,6 +740,7 @@ jobs:
           --env ${{ steps.cijoe-qemu.outputs.target-env }} \
           --output ${{ steps.cijoe-qemu.outputs.results }} \
           --testplan \
+          "${CIJ_TESTPLANS}/xnvme-fabrics-subnqn.plan" \
           "${CIJ_TESTPLANS}/xnvme-cython.plan" \
           "${CIJ_TESTPLANS}/xnvme-python.plan" \
           "${CIJ_TESTPLANS}/xnvme-zns-zrwa-linux-nvme.plan" \

--- a/include/libxnvme.h
+++ b/include/libxnvme.h
@@ -70,6 +70,7 @@ struct xnvme_opts {
 	uint32_t main_core;    ///< SPDK multi-processing: main-core
 	const char *core_mask; ///< SPDK multi-processing: core-mask
 	const char *adrfam;    ///< SPDK fabrics: address-family, IPv4/IPv6
+	const char *subnqn;    ///< SPDK fabrics: Subsystem NQN
 	uint32_t spdk_fabrics; ///< Is assigned a value by backend if SPDK uses fabrics
 };
 

--- a/include/libxnvme_ident.h
+++ b/include/libxnvme_ident.h
@@ -32,14 +32,17 @@ extern "C" {
  * @struct xnvme_ident
  */
 struct xnvme_ident {
-	char uri[XNVME_IDENT_URI_LEN];
+	char subnqn[256];
 
+	char uri[XNVME_IDENT_URI_LEN];
 	uint32_t dtype;
+
 	uint32_t nsid;
 	uint8_t csi;
-	uint8_t rsvd[3];
+
+	uint8_t rsvd[55];
 };
-XNVME_STATIC_ASSERT(sizeof(struct xnvme_ident) == 396, "Incorrect size")
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_ident) == 704, "Incorrect size")
 
 /**
  * Parse the given 'uri' into ::xnvme_ident

--- a/include/libxnvmec.h
+++ b/include/libxnvmec.h
@@ -116,6 +116,8 @@ struct xnvmec_args {
 	const char *uri;
 	const char *sys_uri;
 
+	const char *subnqn;
+
 	const char *cmd_input;
 	const char *cmd_output;
 
@@ -352,7 +354,9 @@ enum xnvmec_opt {
 
 	XNVMEC_OPT_VEC_CNT = 97, ///< XNVMEC_OPT_VEC_CNT
 
-	XNVMEC_OPT_END = 98, ///< XNVMEC_OPT_END
+	XNVMEC_OPT_SUBNQN = 98, ///< XNVME_OPT_SUBNQN
+
+	XNVMEC_OPT_END = 99, ///< XNVMEC_OPT_END
 };
 
 /**

--- a/lib/xnvme_be.c
+++ b/lib/xnvme_be.c
@@ -459,6 +459,9 @@ xnvme_be_dev_idfy(struct xnvme_dev *dev)
 		goto exit;
 	}
 
+	// Store subnqn in device-identifier
+	memcpy(dev->ident.subnqn, idfy_ctrlr->ctrlr.subnqn, sizeof(dev->ident.subnqn));
+
 	// Store idfy-ctrlr and idfy-ns in device instance
 	memcpy(&dev->id.ctrlr, idfy_ctrlr, sizeof(*idfy_ctrlr));
 	memcpy(&dev->id.ns, idfy_ns, sizeof(*idfy_ns));

--- a/lib/xnvme_be_spdk_dev.c
+++ b/lib/xnvme_be_spdk_dev.c
@@ -306,9 +306,11 @@ _xnvme_be_spdk_ident_to_trid(const struct xnvme_ident *ident, struct xnvme_opts 
 				    spdk_nvme_transport_id_trtype_str(trtype));
 			return -EINVAL;
 		}
-		snprintf(trid_str, sizeof(trid_str), "trtype:%s adrfam:%s traddr:%s trsvcid:%d",
+		snprintf(trid_str, sizeof(trid_str),
+			 "trtype:%s adrfam:%s traddr:%s trsvcid:%d subnqn:%s",
 			 spdk_nvme_transport_id_trtype_str(trtype),
-			 opts->adrfam ? opts->adrfam : "IPv4", addr, port);
+			 opts->adrfam ? opts->adrfam : "IPv4", addr, port,
+			 opts->subnqn ? opts->subnqn : SPDK_NVMF_DISCOVERY_NQN);
 		break;
 
 	case SPDK_NVME_TRANSPORT_FC:
@@ -323,16 +325,6 @@ _xnvme_be_spdk_ident_to_trid(const struct xnvme_ident *ident, struct xnvme_opts 
 		XNVME_DEBUG("FAILED: parsing trid_str: %s from uri: %s, err: %d", trid_str,
 			    ident->uri, err);
 		return err;
-	}
-
-	switch (trtype) {
-	case SPDK_NVME_TRANSPORT_PCIE:
-		break;
-
-	case SPDK_NVME_TRANSPORT_TCP:
-	case SPDK_NVME_TRANSPORT_RDMA:
-		snprintf(trid->subnqn, sizeof trid->subnqn, "%s", SPDK_NVMF_DISCOVERY_NQN);
-		break;
 	}
 
 	return 0;
@@ -683,16 +675,16 @@ xnvme_be_spdk_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enum
 			}
 
 			snprintf(trid_str, sizeof trid_str,
-				 "trtype:%s adrfam:%s traddr:%s trsvcid:%d",
+				 "trtype:%s adrfam:%s traddr:%s trsvcid:%d subnqn:%s",
 				 spdk_nvme_transport_id_trtype_str(trtype),
-				 opts->adrfam ? opts->adrfam : "IPv4", addr, port);
+				 opts->adrfam ? opts->adrfam : "IPv4", addr, port,
+				 opts->subnqn ? opts->subnqn : SPDK_NVMF_DISCOVERY_NQN);
 
 			err = spdk_nvme_transport_id_parse(&trid, trid_str);
 			if (err) {
 				XNVME_DEBUG("FAILED: id_parse(): %s, err: %d", trid_str, err);
 				continue;
 			}
-			snprintf(trid.subnqn, sizeof trid.subnqn, "%s", SPDK_NVMF_DISCOVERY_NQN);
 			break;
 
 		case SPDK_NVME_TRANSPORT_FC:

--- a/lib/xnvme_ident.c
+++ b/lib/xnvme_ident.c
@@ -46,7 +46,9 @@ xnvme_ident_yaml(FILE *stream, const struct xnvme_ident *ident, int indent, cons
 	wrtn += fprintf(stream, "%*suri: '%s'%s", indent, "", ident->uri, sep);
 	wrtn += fprintf(stream, "%*sdtype: 0x%x%s", indent, "", ident->dtype, sep);
 	wrtn += fprintf(stream, "%*snsid: 0x%x%s", indent, "", ident->nsid, sep);
-	wrtn += fprintf(stream, "%*scsi: 0x%x", indent, "", ident->csi);
+	wrtn += fprintf(stream, "%*scsi: 0x%x%s", indent, "", ident->csi, sep);
+
+	wrtn += fprintf(stream, "%*ssubnqn: '%s'", indent, "", ident->subnqn);
 
 	return wrtn;
 }

--- a/lib/xnvmec.c
+++ b/lib/xnvmec.c
@@ -469,6 +469,13 @@ static struct xnvmec_opt_attr xnvmec_opts[] = {
 		.descr = "System URI e.g. '10.9.8.1:8888'",
 	},
 	{
+		.opt = XNVMEC_OPT_SUBNQN,
+		.vtype = XNVMEC_OPT_VTYPE_STR,
+		.name = "subnqn",
+		.descr = "Subsystem NQN of the NVMe over Fabrics endpoint e.g. "
+			 "'nqn.2022-06.io.xnvme:ctrlnode1'",
+	},
+	{
 		.opt = XNVMEC_OPT_CNTID,
 		.vtype = XNVMEC_OPT_VTYPE_HEX,
 		.name = "cntid",
@@ -1223,6 +1230,9 @@ xnvmec_assign_arg(struct xnvmec *cli, struct xnvmec_opt_attr *opt_attr, char *ar
 	case XNVMEC_OPT_SYS_URI:
 		args->sys_uri = arg ? arg : "INVALID_INPUT";
 		break;
+	case XNVMEC_OPT_SUBNQN:
+		args->subnqn = arg ? arg : "INVALID_INPUT";
+		break;
 	case XNVMEC_OPT_UUID:
 		args->uuid = num;
 		break;
@@ -1829,6 +1839,7 @@ xnvmec_cli_to_opts(const struct xnvmec *cli, struct xnvme_opts *opts)
 	opts->main_core = cli->args.main_core;
 	opts->core_mask = cli->args.core_mask;
 	opts->adrfam = cli->args.adrfam;
+	opts->subnqn = cli->args.subnqn;
 
 	errno = 0;
 

--- a/toolbox/cijoe-pkg-xnvme/envs/refenv-xnvme.sh
+++ b/toolbox/cijoe-pkg-xnvme/envs/refenv-xnvme.sh
@@ -103,3 +103,11 @@ HUGEMEM="${HUGEMEM:=2048}"; export HUGEMEM
 # Root directory of repo to locate Pytests etc.
 #
 XNVME_REPO="${HOME}/"; export XNVME_REPO
+
+#
+# Localhost NVMe-oF setup
+#
+: "${NVMET_IP:=127.0.0.1}"; export NVMET_IP
+: "${NVMET_PORT=4420}"; export NVMET_PORT
+: "${NVMET_SUBNQN_PREFIX=nqn.2022-06.io.xnvme:cnode}"; export NVMET_SUBNQN_PREFIX
+: "${NVMET_PCIE_IDS=0000:03:00.0 0000:04:00.0}"; export NVMET_PCIE_IDS

--- a/toolbox/cijoe-pkg-xnvme/hooks/spdk_nvmf_localhost_enter.sh
+++ b/toolbox/cijoe-pkg-xnvme/hooks/spdk_nvmf_localhost_enter.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Set up and initialize the localhost target
+# REQUIRES:
+# - NVMET_IP
+#   The ip of the target, in this case it should be: 127.0.0.1
+# - NVMET_PORT
+#   The port to export the devices, typically this is: 4420
+# - NVMET_SUBNQN_PREFIX
+#   The prefix of the nqn of the subsystem exported i.e.: "nqn.2022-06.io.xnvme:cnode"
+#   NOTE: a regular nqn includes a number at the end i.e.: "nqn.2022-06.io.xnvme:cnode1", this is added dynamically in this hook
+# - NVMET_PCIE_IDS
+#   The device ids separated by a space i.e.: "0000:02:00.0 0000:04:00.0"
+# - XNVME_REPO
+#   This is needed in to locate the SPDK "nvmf" binary and "rpc.py" script inside the xNVMe repos,
+#   such that the cijoe-hook can SSH into the machine, start the listener and export devices
+#
+CIJ_TEST_NAME="$(basename "${BASH_SOURCE[0]}")"
+export CIJ_TEST_NAME
+# shellcheck source=modules/cijoe.sh
+source "$CIJ_ROOT/modules/cijoe.sh"
+test.enter
+
+hook.spdk_nvmf_localhost_enter() {
+    if [[ ! -v NVMET_IP ]]; then
+        cij.error "spdk_nvmf_localhost_enter: Missing: NVMET_IP"
+        return 1
+    fi
+    if [[ ! -v NVMET_PORT ]]; then
+        cij.error "spdk_nvmf_localhost_enter: Missing: NVMET_PORT"
+        return 1
+    fi
+    if [[ ! -v NVMET_PCIE_IDS ]]; then
+        cij.error "spdk_nvmf_localhost_enter: Missing: NVMET_PCIE_IDS"
+        return 1
+    fi
+    if [[ ! -v XNVME_REPO ]]; then
+        cij.error "spdk_nvmf_localhost_enter: Missing: XNVME_REPO"
+        return 1
+    fi
+
+    local rpc="${XNVME_REPO}/subprojects/spdk/scripts/rpc.py"
+    local trtype="tcp"
+    local adrfam="ipv4"
+
+    cij.info "hook:spdk_nvmf_localhost_enter: Setting up NVMe-oF localhost target"
+
+    # Load modules
+    if ! cij.cmd "modprobe nvme && modprobe nvmet && modprobe nvmet_tcp && modprobe nvme_fabrics && modprobe nvme_tcp"; then
+        cij.err "spdk_nvmf_localhost_enter: failed to load modules"
+    fi
+
+    # Load xnvme SPDK driver
+    if ! cij.cmd "xnvme-driver"; then
+        cij.err "spdk_nvmf_localhost_enter: failed SPDK initialization"
+        return 1
+    fi
+
+    # Build the SPDK NVMe-oF target-app (nvmf_tgt)
+    if ! cij.cmd "cd ${XNVME_REPO}/subprojects/spdk/app/nvmf_tgt && make"; then
+        cij.err "spdk_nvmf_localhost_enter: failed to build 'nvmf_tgt'"
+        return 1
+    fi
+
+    # Kill nvmf_tgt if it is already running
+    if ! cij.cmd "pkill -f nvmf_tgt"; then
+        cij.info "spdk_nvmf_localhost_enter: failed killing 'nvmf_tgt'... that is ok. Probably just means it was not running."
+    fi
+
+    # Start 'nvmf_tgt' 
+    if ! cij.cmd "cd ${XNVME_REPO}/subprojects/spdk/build/bin && (nohup ./nvmf_tgt > foo.out 2> foo.err < /dev/null &)"; then
+        cij.err "spdk_nvmf_localhost_enter: failed to start 'nvmf_tgt'"
+        return 1
+    fi
+
+    # ... and give it two seconds to settle
+    sleep 2
+
+    # Create transport
+    if ! cij.cmd "${rpc} nvmf_create_transport -t ${trtype} -u 16384 -m 8 -c 8192"; then
+        cij.err "spdk_nvmf_localhost_enter: failed to create transport"
+        return 1
+    fi  
+
+    # Create subsystems, attach controllers and add listener 
+    count=0
+    for pcie_id in ${NVMET_PCIE_IDS}; do
+        count=$((count + 1))
+
+        if ! cij.cmd "${rpc} nvmf_create_subsystem ${NVMET_SUBNQN_PREFIX}${count} -a -s SPDK0000000000000${count} -d Controller${count}"; then
+            cij.err "spdk_nvmf_localhost_enter: failed to create subsystem: ${NVMET_SUBNQN_PREFIX}${count}"
+            return 1
+        fi
+
+        if ! cij.cmd "${rpc} bdev_nvme_attach_controller -b Nvme${count} -t PCIe -a ${pcie_id}"; then
+            cij.err "spdk_nvmf_localhost_enter: failed to attach controller: ${pcie_id}"
+            return 1
+        fi
+
+        if ! cij.cmd "${rpc} nvmf_subsystem_add_ns ${NVMET_SUBNQN_PREFIX}${count} Nvme${count}n1"; then
+            cij.err "spdk_nvmf_localhost_enter: failed to add namespace ${NVMET_SUBNQN_PREFIX}${count}: Nvme${count}n1"
+            return 1
+        fi
+
+        if ! cij.cmd "${rpc} nvmf_subsystem_add_listener ${NVMET_SUBNQN_PREFIX}${count} -t ${trtype} -a ${NVMET_IP} -s ${NVMET_PORT} -f ${adrfam}"; then
+            cij.err "spdk_nvmf_localhost_enter: failed to add listener to ${NVMET_SUBNQN_PREFIX}${count}: ${NVMET_IP}:${NVMET_PORT}"
+            return 1
+        fi
+    done
+
+    return 0
+}
+hook.spdk_nvmf_localhost_enter
+exit $?

--- a/toolbox/cijoe-pkg-xnvme/hooks/spdk_nvmf_localhost_exit.sh
+++ b/toolbox/cijoe-pkg-xnvme/hooks/spdk_nvmf_localhost_exit.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Shutdown the target controller
+#
+CIJ_TEST_NAME="$(basename "${BASH_SOURCE[0]}")"
+export CIJ_TEST_NAME
+# shellcheck source=modules/cijoe.sh
+source "$CIJ_ROOT/modules/cijoe.sh"
+test.enter
+
+hook.spdk_nvmf_localhost_exit() {
+    cij.info "hook:spdk_nvmf_localhost_exit: Kill target controller"
+    if ! cij.cmd "pkill -f nvmf_tgt"; then
+        cij.err "spdk_nvmf_localhost_exit: Failed killing nvmf_tgt"
+        return 1;
+    fi
+    return 0
+}
+
+hook.spdk_nvmf_localhost_exit
+exit $?

--- a/toolbox/cijoe-pkg-xnvme/testcases/fabrics_enum_subnqn.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/fabrics_enum_subnqn.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Verify that the `xnvme enum` runs without error using '--subnqn' for Fabrics
+#
+# shellcheck disable=SC2119
+#
+CIJ_TEST_NAME=$(basename "${BASH_SOURCE[0]}")
+export CIJ_TEST_NAME
+# shellcheck source=modules/cijoe.sh
+source "$CIJ_ROOT/modules/cijoe.sh"
+test.enter
+
+: "${NVMET_IP:?Must be set and non-empty}"
+: "${NVMET_PORT:?Must be set and non-empty}"
+: "${NVMET_SUBNQN_PREFIX:?Must be set and non-empty}"
+
+if ! cij.cmd "xnvme enum --uri ${NVMET_IP}:${NVMET_PORT} --subnqn ${NVMET_SUBNQN_PREFIX}1"; then
+    test.fail
+fi
+
+if ! cij.cmd "xnvme enum --uri ${NVMET_IP}:${NVMET_PORT} --subnqn ${NVMET_SUBNQN_PREFIX}2"; then
+    test.fail
+fi
+
+if ! cij.cmd "xnvme enum --uri ${NVMET_IP}:${NVMET_PORT}"; then
+    test.fail
+fi
+
+test.pass

--- a/toolbox/cijoe-pkg-xnvme/testcases/fabrics_info_subnqn.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/fabrics_info_subnqn.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Verify that the `xnvme info` runs without error using '--subnqn' for Fabrics
+#
+# shellcheck disable=SC2119
+#
+CIJ_TEST_NAME=$(basename "${BASH_SOURCE[0]}")
+export CIJ_TEST_NAME
+# shellcheck source=modules/cijoe.sh
+source "$CIJ_ROOT/modules/cijoe.sh"
+test.enter
+
+: "${NVMET_IP:?Must be set and non-empty}"
+: "${NVMET_PORT:?Must be set and non-empty}"
+: "${NVMET_SUBNQN_PREFIX:?Must be set and non-empty}"
+
+if ! cij.cmd "xnvme info ${NVMET_IP}:${NVMET_PORT} --dev-nsid=1 --subnqn ${NVMET_SUBNQN_PREFIX}1"; then
+    test.fail
+fi
+
+if ! cij.cmd "xnvme info ${NVMET_IP}:${NVMET_PORT} --dev-nsid=1 --subnqn ${NVMET_SUBNQN_PREFIX}2"; then
+    test.fail
+fi
+
+if ! cij.cmd "xnvme info ${NVMET_IP}:${NVMET_PORT} --dev-nsid=1"; then
+    test.fail
+fi
+
+test.pass

--- a/toolbox/cijoe-pkg-xnvme/testfiles/qemu_setup_nvme_2c3ns_nvm_zrwa.sh
+++ b/toolbox/cijoe-pkg-xnvme/testfiles/qemu_setup_nvme_2c3ns_nvm_zrwa.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Set up a PCIe Configuration with:
+#
+# - Two controllers:
+#   - One with:
+#     - One NVM Namespace 4k lbads
+#     - One Zoned Namespace (with ZRWA) 512 lbads
+#   - One with:
+#     - One NVM Namespace 4k lbads
+#
+
+qemu_setup_pcie() {
+  local _ctrlr_mdts=7
+  local _ctrlr_ident="nvme0"
+
+  local _ns_nvm_nsid=1
+  local _ns_nvm_lbads=12
+  local _ns_nvm_size="8G"
+  local _ns_nvm_ident="${_ctrlr_ident}n${_ns_nvm_nsid}"
+
+  local _ns_zns_nsid=2
+  local _ns_zns_lbads=9
+  local _ns_zns_size="8G"
+  local _ns_zns_ident="${_ctrlr_ident}n${_ns_zns_nsid}"
+
+
+  local snd_ctrlr_ident="nvme1"
+  local snd_ns_nvm_ident="${snd_ctrlr_ident}n${_ns_nvm_nsid}"
+
+  local _args=""
+
+  # Enable IOMMU
+  _args="${_args} -device intel-iommu,pt=on,intremap=on"
+
+  # Create the PCIe configuration args
+  _args="${_args} -device pcie-root-port,id=pcie_root_port1,chassis=1,slot=1"
+  _args="${_args} -device x3130-upstream,id=pcie_upstream_port1,bus=pcie_root_port1"
+  _args="${_args} -device xio3130-downstream,id=pcie_downstream_port1,bus=pcie_upstream_port1,chassis=2,slot=1"
+  _args="${_args} -device xio3130-downstream,id=pcie_downstream_port2,bus=pcie_upstream_port1,chassis=2,slot=2"
+
+  # Create the NVMe Controller configuration args
+  _args="${_args} -device nvme,id=${_ctrlr_ident},serial=deadbeef,bus=pcie_downstream_port1,mdts=${_ctrlr_mdts}"
+
+  # Create the NVM Namespace backing-image and QEMU configuration args
+  qemu.img_create "${_ns_nvm_ident}" "raw" "${_ns_nvm_size}"
+  _args="${_args} $(qemu.args_drive ${_ns_nvm_ident} raw)"
+  _args="${_args} -device nvme-ns,id=${_ns_nvm_ident}"
+  _args="${_args},drive=${_ns_nvm_ident}"
+  _args="${_args},bus=${_ctrlr_ident}"
+  _args="${_args},nsid=${_ns_nvm_nsid}"
+  _args="${_args},logical_block_size=$((1 << _ns_nvm_lbads))"
+  _args="${_args},physical_block_size=$((1 << _ns_nvm_lbads))"
+
+  # Create the Zoned Namespace backing-image and QEMU configuration args
+  qemu.img_create "${_ns_zns_ident}" "raw" "${_ns_zns_size}"
+  _args="${_args} $(qemu.args_drive ${_ns_zns_ident} raw)"
+
+  # Namespace setup
+  _args="${_args} -device nvme-ns,id=${_ns_zns_ident}"
+  _args="${_args},drive=${_ns_zns_ident}"
+  _args="${_args},bus=${_ctrlr_ident}"
+  _args="${_args},nsid=${_ns_zns_nsid}"
+  _args="${_args},logical_block_size=$((1 << _ns_zns_lbads))"
+  _args="${_args},physical_block_size=$((1 << _ns_zns_lbads))"
+
+  # zns specific args in lbas
+  local _zsze=8192
+  local _zcap=4096
+  local _foo=256
+
+  # zns specific args
+  _args="${_args},zoned=on"
+  _args="${_args},zoned.zone_size=$((_zsze << _ns_zns_lbads))"
+  _args="${_args},zoned.zone_capacity=$((_zcap << _ns_zns_lbads))"
+  _args="${_args},zoned.max_active=${_foo}"
+  _args="${_args},zoned.max_open=${_foo}"
+
+  # zns/zrwa specific args
+  _args="${_args},zoned.zrwas=$((24 << _ns_zns_lbads))"
+  _args="${_args},zoned.zrwafg=$((8 << _ns_zns_lbads))"
+  _args="${_args},zoned.numzrwa=${_foo}"
+
+  # Create the second NVMe Controller configuration args
+  _args="${_args} -device nvme,id=${snd_ctrlr_ident},serial=acdcbeef,bus=pcie_downstream_port2,mdts=${_ctrlr_mdts}"
+
+  # Create the NVM Namespace backing-image and QEMU configuration args
+  qemu.img_create "${snd_ns_nvm_ident}" "raw" "${_ns_nvm_size}"
+  _args="${_args} $(qemu.args_drive ${snd_ns_nvm_ident} raw)"
+  _args="${_args} -device nvme-ns,id=${snd_ns_nvm_ident}"
+  _args="${_args},drive=${snd_ns_nvm_ident}"
+  _args="${_args},bus=${snd_ctrlr_ident}"
+  _args="${_args},nsid=${_ns_nvm_nsid}"
+  _args="${_args},logical_block_size=$((1 << _ns_nvm_lbads))"
+  _args="${_args},physical_block_size=$((1 << _ns_nvm_lbads))"
+
+  : "${QEMU_SETUP_PCIE=${_args}}"; export QEMU_SETUP_PCIE
+}
+

--- a/toolbox/cijoe-pkg-xnvme/testplans/xnvme-fabrics-subnqn.plan
+++ b/toolbox/cijoe-pkg-xnvme/testplans/xnvme-fabrics-subnqn.plan
@@ -1,0 +1,21 @@
+---
+descr: Verify xNVMe functionality over Fabrics with multiple subsystems
+descr_long: |
+  Exercises 
+  * library-information
+  * device enumeration
+  Requires
+  * NVMET_IP The ip of the target
+  * NVMET_PORT The port to export the devices
+  * NVMET_SUBNQN_PREFIX The prefix of the nqn of the subsystem exported
+  * NVMET_PCIE_IDS The device ids separated by a space
+  * XNVME_REPO The path to the xNVMe repository
+hooks: ["xnvme", "spdk_nvmf_localhost"]
+evars:
+  XNVME_BE: "spdk"
+testsuites:
+- name: XNVME_FABRICS_SUBNQN
+  alias: "Verification of enumeration and library-information over fabrics with multiple subsystems"
+  testcases:
+  - fabrics_enum_subnqn.sh
+  - fabrics_info_subnqn.sh

--- a/tools/fio-engine/xnvme_fioe.c
+++ b/tools/fio-engine/xnvme_fioe.c
@@ -108,6 +108,7 @@ struct xnvme_fioe_options {
 	char *xnvme_async;
 	char *xnvme_sync;
 	char *xnvme_admin;
+	char *xnvme_dev_subnqn;
 };
 
 static struct fio_option options[] = {
@@ -176,6 +177,15 @@ static struct fio_option options[] = {
 		.group = FIO_OPT_G_INVALID,
 	},
 	{
+		.name = "xnvme_dev_subnqn",
+		.lname = "Subsystem nqn for Fabrics",
+		.type = FIO_OPT_STR_STORE,
+		.off1 = offsetof(struct xnvme_fioe_options, xnvme_dev_subnqn),
+		.help = "Subsystem NQN for Fabrics",
+		.category = FIO_OPT_C_ENGINE,
+		.group = FIO_OPT_G_INVALID,
+	},
+	{
 		.name = "xnvme_iovec",
 		.lname = "Vectored IOs",
 		.type = FIO_OPT_STR_SET,
@@ -211,6 +221,7 @@ static struct xnvme_opts xnvme_opts_from_fioe(struct thread_data *td)
 	struct xnvme_opts opts = xnvme_opts_default();
 
 	opts.nsid = o->xnvme_dev_nsid;
+	opts.subnqn = o->xnvme_dev_subnqn;
 	opts.be = o->xnvme_be;
 	opts.async = o->xnvme_async;
 	opts.sync = o->xnvme_sync;

--- a/tools/xnvme.c
+++ b/tools/xnvme.c
@@ -647,6 +647,7 @@ static struct xnvmec_sub g_subs[] = {
 		{
 			{XNVMEC_OPT_SYS_URI, XNVMEC_LOPT},
 			{XNVMEC_OPT_FLAGS, XNVMEC_LOPT},
+			{XNVMEC_OPT_SUBNQN, XNVMEC_LOPT},
 
 			{XNVMEC_OPT_BE, XNVMEC_LOPT},
 		},
@@ -659,6 +660,7 @@ static struct xnvmec_sub g_subs[] = {
 		{
 			{XNVMEC_OPT_URI, XNVMEC_POSA},
 
+			{XNVMEC_OPT_SUBNQN, XNVMEC_LOPT},
 			{XNVMEC_OPT_DEV_NSID, XNVMEC_LOPT},
 			{XNVMEC_OPT_BE, XNVMEC_LOPT},
 			{XNVMEC_OPT_ADMIN, XNVMEC_LOPT},


### PR DESCRIPTION
Make it possible to specify subnqn when running `xnvme enum` or `xnvme info` using NVMe over Fabrics.

Before this can be merged a test case for this must be added:
- [x] add test cases for subnqn