### PR TITLE
New libvfn-based backend

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -745,10 +745,13 @@ jobs:
           "${CIJ_TESTPLANS}/xnvme-zns-zrwa-linux-spdk.plan" \
           "${CIJ_TESTPLANS}/xnvme-base-linux.plan" \
           "${CIJ_TESTPLANS}/xnvme-base-spdk.plan" \
+          "${CIJ_TESTPLANS}/xnvme-base-vfio.plan" \
           "${CIJ_TESTPLANS}/xnvme-nvm-spdk.plan" \
+          "${CIJ_TESTPLANS}/xnvme-nvm-vfio.plan" \
           "${CIJ_TESTPLANS}/xnvme-nvm-linux-nvme.plan" \
           "${CIJ_TESTPLANS}/xnvme-nvm-linux-null.plan" \
           "${CIJ_TESTPLANS}/xnvme-zns-spdk.plan" \
+          "${CIJ_TESTPLANS}/xnvme-zns-vfio.plan" \
           "${CIJ_TESTPLANS}/xnvme-zns-linux-nvme.plan" \
           "${CIJ_TESTPLANS}/xnvme-zns-linux-null.plan" \
           "${CIJ_TESTPLANS}/example_01.plan"

--- a/include/xnvme_be_registry.h
+++ b/include/xnvme_be_registry.h
@@ -10,5 +10,6 @@ extern struct xnvme_be xnvme_be_macos;
 extern struct xnvme_be xnvme_be_posix;
 extern struct xnvme_be xnvme_be_ramdisk;
 extern struct xnvme_be xnvme_be_windows;
+extern struct xnvme_be xnvme_be_vfio;
 
 #endif /* __INTERNAL_XNVME_BE_REGISTRY_H */

--- a/include/xnvme_be_vfio.h
+++ b/include/xnvme_be_vfio.h
@@ -1,0 +1,38 @@
+// Copyright (C) Simon A. F. Lund <simon.lund@samsung.com>
+// Copyright (C) Michael Bang <mi.bang@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#ifndef __INTERNAL_XNVME_BE_VFIO_H
+#define __INTERNAL_XNVME_BE_VFIO_H
+#include <errno.h>
+#include <pthread.h>
+
+#include <vfn/nvme.h>
+
+#include <xnvme_be.h>
+#include <xnvme_queue.h>
+
+struct xnvme_be_vfio_state {
+	struct nvme_ctrl *ctrl;
+	unsigned long long qidmap; // Queue identifier bit map
+	uint queue_id;             // Next queue id to be created on ctrl
+
+	struct nvme_sq *sq_sync;   // Submission queue for synchronous IOs
+	struct nvme_cq *cq_sync;   // Completion queue for synchronous IOs
+	struct nvme_cqe *cqe_sync; // Completion queue entry for synchronous IOs
+
+	uint8_t _rsvd[78];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_be_vfio_state) == XNVME_BE_STATE_NBYTES, "Incorrect size")
+
+int
+_xnvme_be_vfio_create_ioqpair(struct xnvme_be_vfio_state *state, int qd, int flags);
+int
+_xnvme_be_vfio_delete_ioqpair(struct xnvme_be_vfio_state *state, unsigned int qid);
+
+extern struct xnvme_be_admin g_xnvme_be_vfio_admin;
+extern struct xnvme_be_sync g_xnvme_be_vfio_sync;
+extern struct xnvme_be_async g_xnvme_be_vfio_async;
+extern struct xnvme_be_mem g_xnvme_be_vfio_mem;
+extern struct xnvme_be_dev g_xnvme_be_vfio_dev;
+
+#endif /* __INTERNAL_XNVME_BE_VFIO */

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -36,6 +36,12 @@ xnvmelib_source = [
   'xnvme_be_spdk_dev.c',
   'xnvme_be_spdk_mem.c',
   'xnvme_be_spdk_sync.c',
+  'xnvme_be_vfio.c',
+  'xnvme_be_vfio_admin.c',
+  'xnvme_be_vfio_async.c',
+  'xnvme_be_vfio_dev.c',
+  'xnvme_be_vfio_mem.c',
+  'xnvme_be_vfio_sync.c',
   'xnvme_be_windows.c',
   'xnvme_be_windows_async_iocp.c',
   'xnvme_be_windows_async_iocp_th.c',
@@ -75,16 +81,17 @@ xnvmelib_deps_shared = [
   aio_dep,
   setupapi_dep,
   corefoundation_dep,
-  iokit_dep
+  iokit_dep,
+  libvfn_dep,
 ]
 
 xnvmelib_deps_static = []
-xnvmelib_deps_static += [spdk_dep, uring_dep, corefoundation_dep, iokit_dep]
+xnvmelib_deps_static += [spdk_dep, uring_dep, corefoundation_dep, iokit_dep, libvfn_dep]
 xnvmelib_deps = xnvmelib_deps_shared + xnvmelib_deps_static
 
 xnvmelib_deps_bundle = [
   uring_dep,
-  spdk_dep
+  spdk_dep,
 ]
 
 # We are not relying on meson to control whether or not static/shared libraries are built, this is
@@ -114,17 +121,30 @@ xnvmelib_static = static_library(
 # Produce a static library containing xNVMe, liburing, and SPDK
 bundle_lib_paths = []
 bundle_lib_paths += [ 'lib' / 'libxnvme-static.a' ]
+
+if conf_data.get('XNVME_BE_LINUX_VFIO_ENABLED')
+  bundle_lib_paths += ['subprojects' / 'libvfn' / 'src' / 'libvfn.a']
+endif
+
 foreach blib : xnvmelib_deps_bundle
   if get_option('build_subprojects') and blib.found()
     bundle_lib_paths += blib.get_variable(internal: 'lib_paths').split(' ')
   endif
 endforeach
 
+xnvmelib_bundle_depends = [xnvmelib_static]
+
+if conf_data.get('XNVME_BE_LINUX_VFIO_ENABLED')
+  # custom targets cannot depend on dependency() objects, so depend on the
+  # library build target from the subproject.
+  xnvmelib_bundle_depends += subproject('libvfn').get_variable('vfn_lib')
+endif
+
 # missing xnvme and liburing, howto find / produce absolute paths to these?
 xnvmelib_bundle = custom_target(
   'xnvme',
   build_by_default: true,
-  depends: xnvmelib_static,
+  depends: xnvmelib_bundle_depends,
   command: [ prog_python, '@INPUT@', '--output', '@OUTPUT@', '--libs' ] + bundle_lib_paths,
   input: tb_library_bundler,
   output: 'libxnvme.a',

--- a/lib/xnvme_be.c
+++ b/lib/xnvme_be.c
@@ -18,8 +18,10 @@
 #include <xnvme_dev.h>
 
 static struct xnvme_be *g_xnvme_be_registry[] = {
-	&xnvme_be_spdk,  &xnvme_be_linux,   &xnvme_be_fbsd,    &xnvme_be_posix,
-	&xnvme_be_macos, &xnvme_be_windows, &xnvme_be_ramdisk, NULL};
+	&xnvme_be_spdk,    &xnvme_be_linux, &xnvme_be_fbsd,
+	&xnvme_be_posix,   &xnvme_be_macos, &xnvme_be_windows,
+	&xnvme_be_ramdisk, &xnvme_be_vfio,  NULL,
+};
 static int g_xnvme_be_count = sizeof g_xnvme_be_registry / sizeof *g_xnvme_be_registry - 1;
 
 int

--- a/lib/xnvme_be_vfio.c
+++ b/lib/xnvme_be_vfio.c
@@ -1,0 +1,70 @@
+// Copyright (C) Simon A. F. Lund <simon.lund@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_LINUX_VFIO_ENABLED
+#include <xnvme_be_posix.h>
+#include <xnvme_be_vfio.h>
+
+struct xnvme_be_mixin g_xnvme_be_mixin_vfio[] = {
+	{
+		.mtype = XNVME_BE_MEM,
+		.name = "vfio",
+		.descr = "Use libc malloc()/free() with sysconf for alignment",
+		.mem = &g_xnvme_be_vfio_mem,
+		.check_support = xnvme_be_supported,
+	},
+
+	{
+		.mtype = XNVME_BE_ASYNC,
+		.name = "vfio",
+		.descr = "Use the VFIO NVMe driver",
+		.async = &g_xnvme_be_vfio_async,
+		.check_support = xnvme_be_supported,
+	},
+
+	{
+		.mtype = XNVME_BE_SYNC,
+		.name = "vfio",
+		.descr = "Use the VFIO NVMe driver",
+		.sync = &g_xnvme_be_vfio_sync,
+		.check_support = xnvme_be_supported,
+	},
+
+	{
+		.mtype = XNVME_BE_ADMIN,
+		.name = "vfio",
+		.descr = "Use the VFIO NVMe driver",
+		.admin = &g_xnvme_be_vfio_admin,
+		.check_support = xnvme_be_supported,
+	},
+
+	{
+		.mtype = XNVME_BE_DEV,
+		.name = "vfio",
+		.descr = "Use the VFIO NVMe driver",
+		.dev = &g_xnvme_be_vfio_dev,
+		.check_support = xnvme_be_supported,
+	},
+};
+#endif
+
+struct xnvme_be xnvme_be_vfio = {
+	.mem = XNVME_BE_NOSYS_MEM,
+	.admin = XNVME_BE_NOSYS_ADMIN,
+	.sync = XNVME_BE_NOSYS_SYNC,
+	.async = XNVME_BE_NOSYS_QUEUE,
+	.dev = XNVME_BE_NOSYS_DEV,
+	.attr =
+		{
+			.name = "vfio",
+#ifdef XNVME_BE_LINUX_VFIO_ENABLED
+			.enabled = 1,
+#endif
+		},
+	.state = {0},
+#ifdef XNVME_BE_LINUX_VFIO_ENABLED
+	.nobjs = sizeof g_xnvme_be_mixin_vfio / sizeof *g_xnvme_be_mixin_vfio,
+	.objs = g_xnvme_be_mixin_vfio,
+#endif
+};

--- a/lib/xnvme_be_vfio_admin.c
+++ b/lib/xnvme_be_vfio_admin.c
@@ -1,0 +1,39 @@
+// Copyright (C) Simon A. F. Lund <simon.lund@samsung.com>
+// Copyright (C) Michael Bang <mi.bang@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_LINUX_VFIO_ENABLED
+#include <xnvme_dev.h>
+#include <errno.h>
+#include <xnvme_queue.h>
+#include <xnvme_be_vfio.h>
+
+int
+xnvme_be_vfio_sync_cmd_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes,
+			     void *XNVME_UNUSED(mbuf), size_t XNVME_UNUSED(mbuf_nbytes))
+{
+	struct xnvme_be_vfio_state *state = (void *)ctx->dev->be.state;
+	struct nvme_ctrl *ctrl = state->ctrl;
+	union nvme_cmd *cmd = (union nvme_cmd *)&ctx->cmd;
+	struct nvme_cqe *cqe = (struct nvme_cqe *)&ctx->cpl;
+
+	dbuf_nbytes = ALIGN_UP(dbuf_nbytes, 4096);
+
+	if (nvme_oneshot(ctrl, ctrl->adminq.sq, cmd, dbuf, dbuf_nbytes, cqe)) {
+		XNVME_DEBUG("FAILED: nvme_oneshot()");
+		return -errno;
+	}
+
+	return 0;
+}
+#endif
+
+struct xnvme_be_admin g_xnvme_be_vfio_admin = {
+	.id = "nvme",
+#ifdef XNVME_BE_LINUX_VFIO_ENABLED
+	.cmd_admin = xnvme_be_vfio_sync_cmd_admin,
+#else
+	.cmd_admin = xnvme_be_nosys_sync_cmd_admin,
+#endif
+};

--- a/lib/xnvme_be_vfio_async.c
+++ b/lib/xnvme_be_vfio_async.c
@@ -1,0 +1,171 @@
+// Copyright (C) Simon A. F. Lund <simon.lund@samsung.com>
+// Copyright (C) Michael Bang <mi.bang@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_LINUX_VFIO_ENABLED
+#include <libxnvme_spec_fs.h>
+#include <xnvme_dev.h>
+#include <xnvme_queue.h>
+#include <xnvme_be_vfio.h>
+
+struct xnvme_queue_vfio {
+	struct xnvme_queue_base base;
+
+	struct nvme_sq *sq;
+	struct nvme_cq *cq;
+	uint id;
+
+	uint8_t _rsvd[208];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_queue_vfio) == XNVME_BE_QUEUE_STATE_NBYTES,
+		    "Incorrect size")
+
+int
+xnvme_be_vfio_queue_init(struct xnvme_queue *q, int XNVME_UNUSED(opts))
+{
+	struct xnvme_queue_vfio *queue = (struct xnvme_queue_vfio *)q;
+	struct xnvme_be_vfio_state *state = (void *)queue->base.dev->be.state;
+	int qpid;
+
+	qpid = _xnvme_be_vfio_create_ioqpair(state, queue->base.capacity, 0x0);
+	if (qpid < 0) {
+		XNVME_DEBUG("FAILED: nvme_create_ioqpair(); err: %d", qpid);
+		return qpid;
+	}
+	queue->sq = &state->ctrl->sq[qpid];
+	queue->cq = &state->ctrl->cq[qpid];
+	queue->id = qpid;
+
+	return 0;
+}
+
+int
+xnvme_be_vfio_queue_term(struct xnvme_queue *q)
+{
+	struct xnvme_queue_vfio *queue = (struct xnvme_queue_vfio *)q;
+	struct xnvme_be_vfio_state *state = (void *)queue->base.dev->be.state;
+	return _xnvme_be_vfio_delete_ioqpair(state, queue->id);
+}
+
+int
+xnvme_be_vfio_queue_poke(struct xnvme_queue *queue, uint32_t max)
+{
+	struct xnvme_queue_vfio *q = (void *)queue;
+	unsigned int reaped = 0;
+
+	if (!max) {
+		max = queue->base.outstanding;
+	}
+
+	nvme_sq_run(q->sq);
+
+	do {
+		struct xnvme_cmd_ctx *ctx;
+
+		struct nvme_rq *rq;
+		struct nvme_cqe *cqe;
+
+		cqe = nvme_cq_get_cqe(q->cq);
+		if (!cqe) {
+			break;
+		}
+
+		reaped++;
+
+		rq = __nvme_rq_from_cqe(q->sq, cqe);
+
+		ctx = (struct xnvme_cmd_ctx *)rq->opaque;
+		memcpy(&ctx->cpl, cqe, sizeof(ctx->cpl));
+		ctx->async.cb(ctx, ctx->async.cb_arg);
+
+		nvme_rq_release(rq);
+	} while (reaped < max);
+
+	queue->base.outstanding -= reaped;
+
+	if (reaped) {
+		nvme_cq_update_head(q->cq);
+	}
+
+	return reaped;
+}
+
+int
+xnvme_be_vfio_async_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes, void *mbuf,
+			   size_t XNVME_UNUSED(mbuf_nbytes))
+{
+	struct xnvme_queue_vfio *q = (struct xnvme_queue_vfio *)ctx->async.queue;
+	struct xnvme_be_vfio_state *state = (void *)q->base.dev->be.state;
+	struct nvme_rq *rq;
+	uint64_t iova;
+
+	if (q->base.outstanding == q->base.capacity) {
+		XNVME_DEBUG("FAILED: queue is full");
+		return -EBUSY;
+	}
+
+	switch (ctx->cmd.common.opcode) {
+	case XNVME_SPEC_FS_OPC_READ:
+		ctx->cmd.nvm.slba = ctx->cmd.nvm.slba >> ctx->dev->geo.ssw;
+		ctx->cmd.common.opcode = XNVME_SPEC_NVM_OPC_READ;
+		break;
+
+	case XNVME_SPEC_FS_OPC_WRITE:
+		ctx->cmd.nvm.slba = ctx->cmd.nvm.slba >> ctx->dev->geo.ssw;
+		ctx->cmd.common.opcode = XNVME_SPEC_NVM_OPC_WRITE;
+		break;
+	}
+
+	rq = nvme_rq_acquire(q->sq);
+	rq->opaque = ctx;
+
+	if (dbuf) {
+		if (!vfio_iommu_vaddr_to_iova(&state->ctrl->pci.vfio.iommu, dbuf, &iova)) {
+			XNVME_DEBUG("FAILED: vfio_iommu_vaddr_to_iova()");
+			goto err;
+		}
+
+		nvme_rq_map_prp(rq, (union nvme_cmd *)&ctx->cmd, iova, dbuf_nbytes);
+	}
+
+	if (mbuf) {
+		if (!vfio_iommu_vaddr_to_iova(&state->ctrl->pci.vfio.iommu, mbuf, &iova)) {
+			XNVME_DEBUG("FAILED: vfio_iommu_vaddr_to_iova()");
+			goto err;
+		}
+
+		ctx->cmd.common.mptr = iova;
+	}
+
+	nvme_rq_exec(rq, (union nvme_cmd *)&ctx->cmd);
+
+	q->base.outstanding += 1;
+
+	return 0;
+
+err:
+	nvme_rq_release(rq);
+	return -EINVAL;
+}
+
+#endif
+
+struct xnvme_be_async g_xnvme_be_vfio_async = {
+	.id = "nvme",
+#ifdef XNVME_BE_LINUX_VFIO_ENABLED
+	.cmd_io = xnvme_be_vfio_async_cmd_io,
+	.cmd_iov = xnvme_be_nosys_queue_cmd_iov,
+	.poke = xnvme_be_vfio_queue_poke,
+	.wait = xnvme_be_nosys_queue_wait,
+	.init = xnvme_be_vfio_queue_init,
+	.term = xnvme_be_vfio_queue_term,
+#else
+	.cmd_io = xnvme_be_nosys_queue_cmd_io,
+	.cmd_iov = xnvme_be_nosys_queue_cmd_iov,
+	.poke = xnvme_be_nosys_queue_poke,
+	.wait = xnvme_be_nosys_queue_wait,
+	.init = xnvme_be_nosys_queue_init,
+	.term = xnvme_be_nosys_queue_term,
+#endif
+};

--- a/lib/xnvme_be_vfio_dev.c
+++ b/lib/xnvme_be_vfio_dev.c
@@ -1,0 +1,261 @@
+// Copyright (C) Simon A. F. Lund <simon.lund@samsung.com>
+// Copyright (C) Michael Bang <mi.bang@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_LINUX_VFIO_ENABLED
+#include <xnvme_dev.h>
+#include <libxnvme_spec_fs.h>
+#include <xnvme_be_vfio.h>
+
+/*
+ * Wrapper with reference count for the vfio controller
+ */
+struct xnvme_be_vfio_ctrlr_ref {
+	struct nvme_ctrl *ctrlr; ///< Pointer to attached controller
+	int refcount;            ///< # of refs. to 'ctrlr'
+	char uri[XNVME_IDENT_URI_LEN + 1];
+};
+
+#define XNVME_BE_VFIO_CREFS_LEN 100
+
+static struct xnvme_be_vfio_ctrlr_ref g_cref[XNVME_BE_VFIO_CREFS_LEN];
+
+/**
+ * Retrieve an already opened controller with the given ident.
+ *
+ * @return Returns a pointer to the cref on success. When no cref is found,
+ * NULL is returned.
+ */
+static struct nvme_ctrl *
+_vfio_cref_lookup(struct xnvme_ident *id)
+{
+	for (int i = 0; i < XNVME_BE_VFIO_CREFS_LEN; ++i) {
+		if (strncmp(g_cref[i].uri, id->uri, XNVME_IDENT_URI_LEN - 1)) {
+			continue;
+		}
+		if (!g_cref[i].ctrlr) {
+			XNVME_DEBUG("FAILED: corrupted ctrlr in cref");
+			return NULL;
+		}
+		if (g_cref[i].refcount < 1) {
+			XNVME_DEBUG("FAILED: corrupted refcount");
+			return NULL;
+		}
+
+		g_cref[i].refcount += 1;
+
+		return g_cref[i].ctrlr;
+	}
+
+	return NULL;
+}
+
+/**
+ * Insert the given controller. It must be opened before insertion.
+ *
+ * @return Returns 0 on success. On error, negated ``errno`` is returned.
+ */
+static int
+_vfio_cref_insert(struct xnvme_ident *ident, struct nvme_ctrl *ctrlr)
+{
+	if (!ctrlr) {
+		XNVME_DEBUG("FAILED: !ctrlr");
+		return -EINVAL;
+	}
+
+	for (int i = 0; i < XNVME_BE_VFIO_CREFS_LEN; ++i) {
+		if (g_cref[i].refcount) {
+			continue;
+		}
+
+		g_cref[i].ctrlr = ctrlr;
+		g_cref[i].refcount += 1;
+		strncpy(g_cref[i].uri, ident->uri, XNVME_IDENT_URI_LEN);
+
+		return 0;
+	}
+
+	return -ENOMEM;
+}
+
+/**
+ * Decrease the refcount by one for the given controller.
+ *
+ * @return Returns 0 on success. On error, negated ``errno`` is returned.
+ *
+ */
+int
+_vfio_cref_deref(struct nvme_ctrl *ctrlr)
+{
+	if (!ctrlr) {
+		XNVME_DEBUG("FAILED: !ctrlr");
+		return -EINVAL;
+	}
+
+	for (int i = 0; i < XNVME_BE_VFIO_CREFS_LEN; ++i) {
+		if (g_cref[i].ctrlr != ctrlr) {
+			continue;
+		}
+
+		if (g_cref[i].refcount < 1) {
+			XNVME_DEBUG("FAILED: invalid refcount: %d", g_cref[i].refcount);
+			return -EINVAL;
+		}
+
+		g_cref[i].refcount -= 1;
+
+		if (g_cref[i].refcount == 0) {
+			XNVME_DEBUG("INFO: refcount: %d => detaching", g_cref[i].refcount);
+			nvme_close(ctrlr);
+			memset(&g_cref[i], 0, sizeof(g_cref[i]));
+		}
+
+		return 0;
+	}
+
+	XNVME_DEBUG("FAILED: no tracking for %p", (void *)ctrlr);
+	return -EINVAL;
+}
+
+int
+xnvme_be_vfio_enumerate(const char *XNVME_UNUSED(sys_uri), struct xnvme_opts *XNVME_UNUSED(opts),
+			xnvme_enumerate_cb XNVME_UNUSED(cb_func), void *XNVME_UNUSED(cb_args))
+{
+	XNVME_DEBUG("xnvme_be_vfio_enumerate()");
+	return -ENOSYS;
+}
+
+int
+_xnvme_be_vfio_create_ioqpair(struct xnvme_be_vfio_state *state, int qd, int flags)
+{
+	unsigned int qid = __builtin_ffsll(state->qidmap);
+	int err;
+
+	if (qid == 0) {
+		XNVME_DEBUG("no free queue identifiers\n");
+		return -EBUSY;
+	}
+
+	qid--;
+
+	XNVME_DEBUG("nvme_create_ioqpair(%p, %d, %d, %d)", state->ctrl, qid, qd + 1, flags);
+
+	// nvme queue capacity must be one larger than the requested capacity
+	// since only n-1 slots in an NVMe queue may be used
+	err = nvme_create_ioqpair(state->ctrl, qid, qd + 1, flags);
+	if (err) {
+		return -errno;
+	}
+
+	state->qidmap &= ~(1ULL << qid);
+
+	return qid;
+}
+
+int
+_xnvme_be_vfio_delete_ioqpair(struct xnvme_be_vfio_state *state, unsigned int qid)
+{
+	if (nvme_delete_ioqpair(state->ctrl, qid)) {
+		return -errno;
+	}
+
+	state->qidmap |= 1ULL << qid;
+
+	return 0;
+}
+
+int
+xnvme_be_vfio_dev_open(struct xnvme_dev *dev)
+{
+	static const uint16_t nqueues = 63;
+
+	struct xnvme_be_vfio_state *state = (void *)dev->be.state;
+	struct nvme_ctrl *ctrl;
+	int qpid;
+	int err;
+
+	ctrl = _vfio_cref_lookup(&dev->ident);
+	if (!ctrl) {
+		struct nvme_ctrl_opts ctrl_opts = {
+			.nsqr = nqueues,
+			.ncqr = nqueues,
+		};
+
+		ctrl = calloc(1, sizeof(struct nvme_ctrl));
+		if (!ctrl) {
+			XNVME_DEBUG("FAILED: calloc()");
+			return -ENOMEM;
+		}
+		err = nvme_init(ctrl, dev->ident.uri, &ctrl_opts);
+		if (err) {
+			XNVME_DEBUG("FAILED: initializing nvme device: %d", errno);
+			return -errno;
+		}
+
+		state->ctrl = ctrl;
+		state->qidmap = -1 & ~0x1;
+
+		// create queues for sync backend requests
+		qpid = _xnvme_be_vfio_create_ioqpair(state, 31, 0x0);
+		if (qpid < 0) {
+			XNVME_DEBUG("FAILED: initializing qpairs for sync IO: %d", err);
+			return -errno;
+		}
+		state->sq_sync = &state->ctrl->sq[qpid];
+		state->cq_sync = &state->ctrl->cq[qpid];
+
+		// TODO: ctrl->config will contain the actual number of queues
+		// created (zero-based)
+
+		err = _vfio_cref_insert(&dev->ident, ctrl);
+		if (err) {
+			XNVME_DEBUG("FAILED: _cref_insert()");
+			return err;
+		}
+	}
+
+	dev->ident.dtype = XNVME_DEV_TYPE_NVME_NAMESPACE;
+	dev->ident.csi = XNVME_SPEC_CSI_NVM;
+	dev->ident.nsid = dev->opts.nsid;
+
+	err = xnvme_be_dev_idfy(dev);
+	if (err) {
+		XNVME_DEBUG("FAILED: open() : xnvme_be_dev_idfy()");
+		// _be_linux_state_term((void *)dev->be.state);
+		return err;
+	}
+	err = xnvme_be_dev_derive_geometry(dev);
+	if (err) {
+		XNVME_DEBUG("FAILED: open() : xnvme_be_dev_derive_geometry()");
+		return err;
+	}
+
+	return 0;
+}
+
+void
+xnvme_be_vfio_dev_close(struct xnvme_dev *dev)
+{
+	struct xnvme_be_vfio_state *state = (void *)dev->be.state;
+	// TODO: this should work, but I'm getting errors from libvfio's
+	// nvme_init when attempting to initialize the device again. Not sure
+	// if the error is in my or libvfio's code.
+	if (_vfio_cref_deref(state->ctrl)) {
+		XNVME_DEBUG("FAILED: _vfio_cref_deref()");
+	}
+}
+
+#endif
+
+struct xnvme_be_dev g_xnvme_be_vfio_dev = {
+#ifdef XNVME_BE_LINUX_VFIO_ENABLED
+	.enumerate = xnvme_be_vfio_enumerate,
+	.dev_open = xnvme_be_vfio_dev_open,
+	.dev_close = xnvme_be_vfio_dev_close,
+#else
+	.enumerate = xnvme_be_nosys_enumerate,
+	.dev_open = xnvme_be_nosys_dev_open,
+	.dev_close = xnvme_be_nosys_dev_close,
+#endif
+};

--- a/lib/xnvme_be_vfio_mem.c
+++ b/lib/xnvme_be_vfio_mem.c
@@ -1,0 +1,99 @@
+// Copyright (C) Simon A. F. Lund <simon.lund@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_LINUX_VFIO_ENABLED
+#include <xnvme_be_vfio.h>
+#include <xnvme_dev.h>
+#include <sys/mman.h>
+#include <errno.h>
+
+void *
+xnvme_be_vfio_buf_alloc(const struct xnvme_dev *dev, size_t nbytes, uint64_t *XNVME_UNUSED(phys))
+{
+	void *vaddr;
+	struct xnvme_be_vfio_state *state = (void *)dev->be.state;
+	struct vfio_state *vfio = &state->ctrl->pci.vfio;
+
+	XNVME_DEBUG("xnvme_be_vfio_buf_alloc(%p, %ld)", dev, nbytes);
+
+	nbytes = ALIGN_UP(nbytes, __VFN_PAGESIZE);
+
+	vaddr = mmap(NULL, nbytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+	if (vaddr == MAP_FAILED) {
+		XNVME_DEBUG("FAILED: mmap(): %s\n", strerror(errno));
+		return NULL;
+	}
+
+	XNVME_DEBUG("vfio_map_vaddr(%p, %p, %ld, NULL)", vfio, vaddr, nbytes);
+	if (vfio_map_vaddr(vfio, vaddr, nbytes, NULL)) {
+		XNVME_DEBUG("FAILED: vfio_map_vaddr(): %s\n", strerror(errno));
+		return NULL;
+	}
+
+	return vaddr;
+}
+
+void *
+xnvme_be_vfio_buf_realloc(const struct xnvme_dev *XNVME_UNUSED(dev), void *XNVME_UNUSED(buf),
+			  size_t XNVME_UNUSED(nbytes), uint64_t *XNVME_UNUSED(phys))
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
+void
+xnvme_be_vfio_buf_free(const struct xnvme_dev *dev, void *buf)
+{
+	struct xnvme_be_vfio_state *state = (void *)dev->be.state;
+	struct vfio_state *vfio = &state->ctrl->pci.vfio;
+	struct vfio_iommu_mapping *mapping;
+	size_t len;
+
+	XNVME_DEBUG("xnvme_be_vfio_buf_free(%p, %p)", dev, buf);
+
+	/*
+	 * munmap() requires the length of the previous memory-mapped area, so
+	 * grab the mapping and store the length.
+	 */
+	mapping = vfio_iommu_find_mapping(&vfio->iommu, buf);
+	if (!mapping) {
+		XNVME_DEBUG("no mapping for %p\n", buf);
+		return;
+	}
+
+	len = mapping->len;
+
+	if (vfio_unmap_vaddr(vfio, buf)) {
+		XNVME_DEBUG("FAILED: vfio_pci_unmap_vaddr(-, %p): %s\n", buf, strerror(errno));
+	}
+
+	if (munmap(buf, len)) {
+		XNVME_DEBUG("FAILED: munmap(%p, %zu): %s\n", buf, len, strerror(errno));
+	}
+}
+
+int
+xnvme_be_vfio_buf_vtophys(const struct xnvme_dev *XNVME_UNUSED(dev), void *XNVME_UNUSED(buf),
+			  uint64_t *XNVME_UNUSED(phys))
+{
+	// TODO: should this thing just map *buf to the iommu, i.e. same as is
+	// being done in `xnvme_be_vfio_buf_alloc` using `vfio_pci_dma_map()`?
+	errno = ENOSYS;
+	return -ENOSYS;
+}
+#endif
+
+struct xnvme_be_mem g_xnvme_be_vfio_mem = {
+#ifdef XNVME_BE_LINUX_VFIO_ENABLED
+	.buf_alloc = xnvme_be_vfio_buf_alloc,
+	.buf_realloc = xnvme_be_vfio_buf_realloc,
+	.buf_free = xnvme_be_vfio_buf_free,
+	.buf_vtophys = xnvme_be_vfio_buf_vtophys,
+#else
+	.buf_alloc = xnvme_be_nosys_buf_alloc,
+	.buf_realloc = xnvme_be_nosys_buf_realloc,
+	.buf_free = xnvme_be_nosys_buf_free,
+	.buf_vtophys = xnvme_be_nosys_buf_vtophys,
+#endif
+};

--- a/lib/xnvme_be_vfio_sync.c
+++ b/lib/xnvme_be_vfio_sync.c
@@ -1,0 +1,85 @@
+// Copyright (C) Simon A. F. Lund <simon.lund@samsung.com>
+// Copyright (C) Michael Bang <mi.bang@samsung.com>
+// SPDX-License-Identifier: Apache-2.0
+#include <xnvme_be.h>
+#include <xnvme_be_nosys.h>
+#ifdef XNVME_BE_LINUX_VFIO_ENABLED
+#include <libxnvme_spec_fs.h>
+#include <errno.h>
+#include <xnvme_dev.h>
+#include <xnvme_be_vfio.h>
+
+int
+xnvme_be_vfio_sync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes, void *mbuf,
+			  size_t XNVME_UNUSED(mbuf_nbytes))
+{
+	struct xnvme_be_vfio_state *state = (void *)ctx->dev->be.state;
+	struct nvme_ctrl *ctrl = state->ctrl;
+	struct nvme_rq *rq;
+	uint64_t iova;
+	int ret = 0;
+
+	switch (ctx->cmd.common.opcode) {
+	case XNVME_SPEC_NVM_OPC_READ:
+		break;
+
+	case XNVME_SPEC_FS_OPC_READ:
+		ctx->cmd.nvm.slba = ctx->cmd.nvm.slba >> ctx->dev->geo.ssw;
+		ctx->cmd.common.opcode = XNVME_SPEC_NVM_OPC_READ;
+		break;
+
+	case XNVME_SPEC_NVM_OPC_WRITE:
+		break;
+
+	case XNVME_SPEC_FS_OPC_WRITE:
+		ctx->cmd.nvm.slba = ctx->cmd.nvm.slba >> ctx->dev->geo.ssw;
+		ctx->cmd.common.opcode = XNVME_SPEC_NVM_OPC_WRITE;
+		break;
+	}
+
+	rq = nvme_rq_acquire(state->sq_sync);
+	if (!rq) {
+		return -errno;
+	}
+
+	if (dbuf) {
+		if (!vfio_iommu_vaddr_to_iova(&ctrl->pci.vfio.iommu, dbuf, &iova)) {
+			XNVME_DEBUG("FAILED: vfio_iommu_vaddr_to_iova()");
+			ret = -EINVAL;
+			goto out;
+		}
+
+		nvme_rq_map_prp(rq, (union nvme_cmd *)&ctx->cmd, iova, dbuf_nbytes);
+	}
+
+	if (mbuf) {
+		if (!vfio_iommu_vaddr_to_iova(&state->ctrl->pci.vfio.iommu, mbuf, &iova)) {
+			XNVME_DEBUG("FAILED: vfio_iommu_vaddr_to_iova()");
+			ret = -EINVAL;
+			goto out;
+		}
+
+		ctx->cmd.common.mptr = iova;
+	}
+
+	nvme_rq_exec(rq, (union nvme_cmd *)&ctx->cmd);
+
+	if (nvme_rq_poll(rq, &state->cqe_sync)) {
+		ret = -errno;
+	}
+
+out:
+	nvme_rq_release(rq);
+
+	return ret;
+}
+#endif
+
+struct xnvme_be_sync g_xnvme_be_vfio_sync = {
+	.id = "nvme",
+#ifdef XNVME_BE_LINUX_VFIO_ENABLED
+	.cmd_io = xnvme_be_vfio_sync_cmd_io,
+#else
+	.cmd_io = xnvme_be_nosys_sync_cmd_io,
+#endif
+};

--- a/meson.build
+++ b/meson.build
@@ -74,7 +74,10 @@ conf_data.set('XNVME_BE_LINUX_BLOCK_ZONED_ENABLED', is_linux ? cc.has_header('li
 conf_data.set('XNVME_BE_LINUX_LIBAIO_ENABLED', is_linux and get_option('with-libaio'))
 conf_data.set('XNVME_BE_LINUX_LIBURING_ENABLED', is_linux and get_option('with-liburing'))
 
+conf_data.set('XNVME_BE_LINUX_VFIO_ENABLED', is_linux and get_option('with-libvfn'))
+
 conf_data.set('XNVME_BE_MACOS_ENABLED', is_darwin)
+
 conf_data.set('XNVME_BE_FBSD_ENABLED', is_freebsd)
 conf_data.set('XNVME_BE_POSIX_ENABLED', is_linux or is_freebsd or is_darwin)
 
@@ -207,6 +210,15 @@ iokit_dep = dependency(
   'appleframeworks',
   modules: 'IOKit',
   required: is_darwin
+)
+libvfn_dep = dependency(
+  '_vfn',
+  default_options: [
+    'libnvme=disabled',
+    'docs=disabled',
+    'default_library=static',
+  ],
+  required: conf_data.get('XNVME_BE_LINUX_VFIO_ENABLED')
 )
 
 # Headers

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,7 @@
 option('with-liburing', type: 'boolean', value: true)
 option('with-libaio', type: 'boolean', value: true)
 option('with-spdk', type: 'boolean', value: true)
+option('with-libvfn', type: 'boolean', value: true)
 option('with-fio', type: 'boolean', value: true)
 
 option('be_ramdisk', type: 'boolean', value: true)

--- a/subprojects/libvfn.wrap
+++ b/subprojects/libvfn.wrap
@@ -1,0 +1,6 @@
+[wrap-git]
+url = https://github.com/OpenMPDK/libvfn.git
+revision = v1.0.0-rc0
+
+[provide]
+_vfn = libvfn_dep

--- a/toolbox/cijoe-pkg-xnvme/envs/refenv-xnvme-qemu.sh
+++ b/toolbox/cijoe-pkg-xnvme/envs/refenv-xnvme-qemu.sh
@@ -68,6 +68,8 @@ if [[ -v XNVME_BE && "$XNVME_BE" == "spdk" ]]; then
   else
     XNVME_URI="${PCI_DEV_NAME}"; export XNVME_URI
   fi
+elif [[ -v XNVME_BE && "${XNVME_BE}" == "vfio" ]]; then
+  XNVME_URI="${PCI_DEV_NAME}"; export XNVME_URI
 elif [[ -v XNVME_BE && "${XNVME_BE}" == "linux" ]]; then
   if [[ -v DEV_TYPE && "${DEV_TYPE}" == "nullblk" ]]; then
     case $NVME_NSTYPE in

--- a/toolbox/cijoe-pkg-xnvme/envs/refenv-xnvme.sh
+++ b/toolbox/cijoe-pkg-xnvme/envs/refenv-xnvme.sh
@@ -46,6 +46,8 @@ if [[ -v XNVME_BE && "$XNVME_BE" == "spdk" ]]; then
   else
     XNVME_URI="${PCI_DEV_NAME}"; export XNVME_URI
   fi
+elif [[ -v XNVME_BE && "${XNVME_BE}" == "vfio" ]]; then
+  XNVME_URI="${PCI_DEV_NAME}"; export XNVME_URI
 elif [[ -v XNVME_BE && "${XNVME_BE}" == "linux" ]]; then
   if [[ -v DEV_TYPE && "${DEV_TYPE}" == "nullblk" ]]; then
     case $NVME_NSTYPE in

--- a/toolbox/cijoe-pkg-xnvme/hooks/xnvme_enter.sh
+++ b/toolbox/cijoe-pkg-xnvme/hooks/xnvme_enter.sh
@@ -40,6 +40,9 @@ hook.xnvme_enter() {
     fi
     ;;
 
+  vfio)
+    ;;
+
   *)
     XNVME_DRIVER_CMD="${XNVME_DRIVER_CMD} reset"
   esac

--- a/toolbox/cijoe-pkg-xnvme/testplans/README.rst
+++ b/toolbox/cijoe-pkg-xnvme/testplans/README.rst
@@ -6,13 +6,16 @@ The following are run::
   xnvme-base-linux.plan
   xnvme-base-spdk.plan
   xnvme-base-fbsd.plan
+  xnvme-base-vfio.plan
 
   xnvme-nvm-linux-char.plan
   xnvme-nvm-linux-null.plan
   xnvme-nvm-linux-nvme.plan
   xnvme-nvm-spdk.plan
+  xnvme-nvm-vfio.plan
 
   xnvme-zns-linux-char.plan
   xnvme-zns-linux-null.plan
   xnvme-zns-linux-nvme.plan
   xnvme-zns-spdk.plan
+  xnvme-zns-vfio.plan

--- a/toolbox/cijoe-pkg-xnvme/testplans/xnvme-base-vfio.plan
+++ b/toolbox/cijoe-pkg-xnvme/testplans/xnvme-base-vfio.plan
@@ -1,0 +1,27 @@
+---
+descr: Verify base xNVMe functionality using the VFIO backend
+descr_long: |
+  Exercises
+  * library-information
+  * device enumeration
+  * admin-commands idfy-ns, idfy-ctrlr, get-log, get/set feature
+  * queue-init/teardown
+  Requires
+  * XNVME_URI points to an NVMe namespace e.g. /dev/nvme0n1
+hooks: ["sysinf", "xnvme"]
+evars:
+  NVME_NSTYPE: "lblk"
+  DEV_TYPE: "nvme"
+  XNVME_BE: "vfio"
+  XNVME_ADMIN: "vfio"
+
+testsuites:
+- name: xnvme_core
+  alias: "xNVMe: verify base functionality using be:vfio"
+
+- name: xnvme_admin_no_multi
+  alias: "xNVMe: verify base functionality using be:vfio"
+
+- name: xnvme_queue
+  alias: "xNVMe: verify base functionality using be:vfio"
+  evars: {XNVME_ASYNC: "vfio"}

--- a/toolbox/cijoe-pkg-xnvme/testplans/xnvme-nvm-vfio.plan
+++ b/toolbox/cijoe-pkg-xnvme/testplans/xnvme-nvm-vfio.plan
@@ -1,0 +1,35 @@
+---
+descr: Verify the xNVMe NVM Command-set using the VFIO NVMe driver backend
+descr_long: |
+  Verify xNVMe mandatory NVM Command-set using a NVMe device
+  Leaving out write-uncor as the qemu-instance primarily used for testing this
+  does not support it.
+hooks: ["sysinf", "xnvme"]
+evars:
+  CMD_PREFIX: " "
+  FIO_NRUNS: "1"
+  FIO_SECTION: "default"
+  FIO_SCRIPT: "xnvme-verify.fio"
+  FIO_IOENG_NAME: "xnvme"
+  NVME_NSTYPE: "lblk"
+  DEV_TYPE: "nvme"
+  XNVME_BE: "vfio"
+  XNVME_ADMIN: "vfio"
+  XNVME_SYNC: "vfio"
+
+testsuites:
+- name: xnvme_core
+  alias: "xNVMe: core library info and default enumeration"
+
+- name: xnvme_nvm
+  alias: "xNVMe: NVM Command Set using be:vfio"
+
+- name: xnvme_nvm_io
+  alias: "xNVMe: NVM Command Set using be:vfio"
+  evars: {XNVME_ASYNC: "vfio"}
+
+- name: xnvme_nvm_opt_scc
+  alias: "xNVMe: NVM Command Set (Simple-Copy) using be:vfio"
+
+- name: xnvme_nvm_opt_wzero
+  alias: "xNVMe: NVM Command Set (Write-Zero) using be:vfio"

--- a/toolbox/cijoe-pkg-xnvme/testplans/xnvme-zns-vfio.plan
+++ b/toolbox/cijoe-pkg-xnvme/testplans/xnvme-zns-vfio.plan
@@ -1,0 +1,32 @@
+---
+descr: Verify xNVMe Zoned Command Set using the VFIO NVMe driver backend
+descr_long: |
+  Basic verification of xNVMe using through the different IO and control paths.
+  Leaving out changes-log as it is not support in upstream qemu6
+hooks: ["sysinf", "xnvme"]
+evars:
+  CMD_PREFIX: " "
+  FIO_NRUNS: "1"
+  FIO_SECTION: "default"
+  FIO_SCRIPT: "xnvme-zoned.fio"
+  FIO_IOENG_NAME: "xnvme"
+  NVME_NSTYPE: "zoned"
+  DEV_TYPE: "nvme"
+  XNVME_BE: "vfio"
+  XNVME_ADMIN: "vfio"
+  XNVME_SYNC: "vfio"
+  XNVME_ASYNC: "vfio"
+
+testsuites:
+- name: xnvme_core
+  alias: "xNVMe: core library information and enumeration for convenience"
+
+- name: xnvme_zns
+  alias: "xNVMe: Zoned Command Set (mandatory) using be:vfio"
+
+- name: xnvme_zns_opt_append
+  alias: "xNVMe: Zoned Command Set (append) using be:vfio"
+
+- name: xnvme_zns_io
+  alias: "xNVMe: Zoned Command Set (I/O) using be:vfio"
+

--- a/toolbox/pkgs/alpine-latest.txt
+++ b/toolbox/pkgs/alpine-latest.txt
@@ -13,6 +13,7 @@ musl-dev
 ncurses
 ninja
 numactl-dev
+perl
 pkgconf
 py3-pip
 python3

--- a/tools/fio-engine/xnvme_fioe.c
+++ b/tools/fio-engine/xnvme_fioe.c
@@ -143,7 +143,8 @@ static struct fio_option options[] = {
 		.lname = "xNVMe Asynchronous command-interface",
 		.type = FIO_OPT_STR_STORE,
 		.off1 = offsetof(struct xnvme_fioe_options, xnvme_async),
-		.help = "Select xNVMe async. interface: [emu,thrpool,io_uring,libaio,posix,nil]",
+		.help = "Select xNVMe async. interface: "
+			"[emu,thrpool,io_uring,libaio,posix,vfio,nil]",
 		.category = FIO_OPT_C_ENGINE,
 		.group = FIO_OPT_G_INVALID,
 	},


### PR DESCRIPTION
Add a new user-space VFIO-based backend, implemented using libvfn. This backend is largely similar to be:spdk, but the core dependency (libvfn) is, dependency-wise, easier to handle than SPDK.
    
The backend is feature complete as far as it can be, considering the current limitations of libvfn. This includes no xnvme_buf_realloc() or iovec support. xnvme_buf_vtophys() is also unimplemented (physical address are invalid/irrelevant in this backend).