### PR TITLE
Changes to subprojects/liburing build

### DIFF
--- a/subprojects/packagefiles/liburing/liburing_build.sh
+++ b/subprojects/packagefiles/liburing/liburing_build.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-make -j CFLAGS="${CFLAGS} -fPIC"

--- a/subprojects/packagefiles/liburing/liburing_patches.sh
+++ b/subprojects/packagefiles/liburing/liburing_patches.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
-for patch in $(find patches -type f -name '0*.patch' | sort); do
-  patch -p1 --forward -i $patch
+for patchfile in $(find patches -type f -name '0*.patch' | sort); do
+  patch -p1 --forward -i $patchfile
 done

--- a/subprojects/packagefiles/liburing/meson.build
+++ b/subprojects/packagefiles/liburing/meson.build
@@ -5,8 +5,6 @@ project(
 )
 fs = import('fs')
 
-get_option('build_subprojects')
-
 if get_option('build_subprojects') and not fs.exists('config-host.h')
   message('Patching ..')
   run_command('./liburing_patches.sh', capture: true, check: true)
@@ -14,7 +12,23 @@ if get_option('build_subprojects') and not fs.exists('config-host.h')
   run_command('./liburing_configure.sh', capture: true, check: true)
 endif
 if get_option('build_subprojects') and not fs.exists('src' / 'liburing.a')
-  run_command('./liburing_build.sh', capture: true, check: true)
+  cpu_count = run_command([
+    import('python').find_installation('python3'),
+    '-c',
+    'from multiprocessing import cpu_count; print(cpu_count())'
+    ],
+    check: true,
+  ).stdout().strip()
+
+  message('Building ..')
+  run_command([
+      find_program(host_machine.system() == 'freebsd' ? 'gmake' : 'make'),
+      '-j',
+      cpu_count
+    ],
+    capture: true,
+    check: true
+  )
 endif
 
 liburing_lib = fs.exists('src' / 'liburing.a') ? meson.get_compiler('c').find_library(

--- a/subprojects/packagefiles/liburing/patches/0000-always-fpic.patch
+++ b/subprojects/packagefiles/liburing/patches/0000-always-fpic.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Makefile b/src/Makefile
+index 12cf49f..9f89264 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -9,7 +9,7 @@ CPPFLAGS ?=
+ override CPPFLAGS += -D_GNU_SOURCE \
+ 	-Iinclude/ -include ../config-host.h
+ CFLAGS ?= -g -O2 -Wall -Wextra -fno-stack-protector
+-override CFLAGS += -Wno-unused-parameter -Wno-sign-compare -DLIBURING_INTERNAL
++override CFLAGS += -Wno-unused-parameter -Wno-sign-compare -fPIC -DLIBURING_INTERNAL
+ SO_CFLAGS=-fPIC $(CFLAGS)
+ L_CFLAGS=$(CFLAGS)
+ LINK_FLAGS=

--- a/subprojects/packagefiles/liburing/patches/0001-memfd_issue.patch
+++ b/subprojects/packagefiles/liburing/patches/0001-memfd_issue.patch
@@ -1,0 +1,20 @@
+diff --git a/test/io_uring_register.c b/test/io_uring_register.c
+index e639f05..8c32670 100644
+--- a/test/io_uring_register.c
++++ b/test/io_uring_register.c
+@@ -34,12 +34,13 @@ static int devnull;
+ #if !defined(CONFIG_HAVE_MEMFD_CREATE)
+ #include <sys/syscall.h>
+ #include <linux/memfd.h>
+-
+-static int memfd_create(const char *name, unsigned int flags)
++#ifndef memfd_create
++int memfd_create(const char *name, unsigned int flags)
+ {
+ 	return (int)syscall(SYS_memfd_create, name, flags);
+ }
+ #endif
++#endif
+ 
+ 
+ static int expect_fail(int fd, unsigned int opcode, void *arg,


### PR DESCRIPTION
When taking a stab at RPM-packaging (https://github.com/OpenMPDK/xNVMe/tree/packaging/rpm) xNVMe it seemed better to change the way the liburing subproject is build by:

* Applying patches to enable -fPIC rather than ``make CFLAGS=...``  override
* Adding a patch to change the definition of ``memfd_create`` when it is missing

The latter patch should be reconsidered as it might be an issue with the mock-env used when doing ``fedpkg ..`` rather than a general issue, adding to that, in case of a general issue, then it should be submitted as a patch to upstream liburing.