### PR TITLE
Add subnqn to device-identifier

### DIFF
--- a/include/libxnvme_ident.h
+++ b/include/libxnvme_ident.h
@@ -32,14 +32,17 @@ extern "C" {
  * @struct xnvme_ident
  */
 struct xnvme_ident {
-	char uri[XNVME_IDENT_URI_LEN];
+	char subnqn[256];
 
+	char uri[XNVME_IDENT_URI_LEN];
 	uint32_t dtype;
+
 	uint32_t nsid;
 	uint8_t csi;
-	uint8_t rsvd[3];
+
+	uint8_t rsvd[55];
 };
-XNVME_STATIC_ASSERT(sizeof(struct xnvme_ident) == 396, "Incorrect size")
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_ident) == 704, "Incorrect size")
 
 /**
  * Parse the given 'uri' into ::xnvme_ident

--- a/lib/xnvme_be.c
+++ b/lib/xnvme_be.c
@@ -457,6 +457,9 @@ xnvme_be_dev_idfy(struct xnvme_dev *dev)
 		goto exit;
 	}
 
+	// Store subnqn in device-identifier
+	memcpy(dev->ident.subnqn, idfy_ctrlr->ctrlr.subnqn, sizeof(dev->ident.subnqn));
+
 	// Store idfy-ctrlr and idfy-ns in device instance
 	memcpy(&dev->id.ctrlr, idfy_ctrlr, sizeof(*idfy_ctrlr));
 	memcpy(&dev->id.ns, idfy_ns, sizeof(*idfy_ns));

--- a/lib/xnvme_ident.c
+++ b/lib/xnvme_ident.c
@@ -46,7 +46,9 @@ xnvme_ident_yaml(FILE *stream, const struct xnvme_ident *ident, int indent, cons
 	wrtn += fprintf(stream, "%*suri: '%s'%s", indent, "", ident->uri, sep);
 	wrtn += fprintf(stream, "%*sdtype: 0x%x%s", indent, "", ident->dtype, sep);
 	wrtn += fprintf(stream, "%*snsid: 0x%x%s", indent, "", ident->nsid, sep);
-	wrtn += fprintf(stream, "%*scsi: 0x%x", indent, "", ident->csi);
+	wrtn += fprintf(stream, "%*scsi: 0x%x%s", indent, "", ident->csi, sep);
+
+	wrtn += fprintf(stream, "%*ssubnqn: '%s'", indent, "", ident->subnqn);
 
 	return wrtn;
 }


### PR DESCRIPTION
When enumerating e.g. ``xnvme enum --uri <fabrics>``, without a subnqn then the list of devices have duplicated entries as a remote endpoint can have multiple suibsystems, there is no telling them apart. Thus, adding the ``subnqn`` to identifiers.
This is related to: https://github.com/OpenMPDK/xNVMe/pull/110