### PR TITLE
tests: add ioworker test

### DIFF
--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_ioworker.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_ioworker.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Verify that the CLI `xnvme info` runs without error
+#
+# shellcheck disable=SC2119
+#
+CIJ_TEST_NAME=$(basename "${BASH_SOURCE[0]}")
+export CIJ_TEST_NAME
+# shellcheck source=modules/cijoe.sh
+source "$CIJ_ROOT/modules/cijoe.sh"
+test.enter
+
+: "${XNVME_URI:?Must be set and non-empty}"
+
+: "${XNVME_DEV_NSID:?Must be set and non-empty}"
+: "${XNVME_BE:?Must be set and non-empty}"
+
+# Instrumentation of the xNVMe runtime
+XNVME_RT_ARGS=""
+XNVME_RT_ARGS="${XNVME_RT_ARGS} --dev-nsid ${XNVME_DEV_NSID}"
+XNVME_RT_ARGS="${XNVME_RT_ARGS} --be ${XNVME_BE}"
+
+if ! cij.cmd "xnvme_tests_ioworker verify ${XNVME_URI} ${XNVME_RT_ARGS}"; then
+    test.fail
+fi
+
+test.pass

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_ioworker_sync.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_ioworker_sync.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Verify that the CLI `xnvme info` runs without error
+#
+# shellcheck disable=SC2119
+#
+CIJ_TEST_NAME=$(basename "${BASH_SOURCE[0]}")
+export CIJ_TEST_NAME
+# shellcheck source=modules/cijoe.sh
+source "$CIJ_ROOT/modules/cijoe.sh"
+test.enter
+
+: "${XNVME_URI:?Must be set and non-empty}"
+
+: "${XNVME_DEV_NSID:?Must be set and non-empty}"
+: "${XNVME_BE:?Must be set and non-empty}"
+
+# Instrumentation of the xNVMe runtime
+XNVME_RT_ARGS=""
+XNVME_RT_ARGS="${XNVME_RT_ARGS} --dev-nsid ${XNVME_DEV_NSID}"
+XNVME_RT_ARGS="${XNVME_RT_ARGS} --be ${XNVME_BE}"
+
+if ! cij.cmd "xnvme_tests_ioworker verify-sync ${XNVME_URI} ${XNVME_RT_ARGS}"; then
+    test.fail
+fi
+
+test.pass

--- a/toolbox/cijoe-pkg-xnvme/testplans/xnvme-base-ramdisk.plan
+++ b/toolbox/cijoe-pkg-xnvme/testplans/xnvme-base-ramdisk.plan
@@ -6,6 +6,7 @@ descr_long: |
   * device enumeration
   * admin-commands idfy-ns, idfy-ctrlr, get feature
   * queue-init/teardown of thrpool
+  * read/write
   Requires
   * XNVME_URI defines an amount of memory in GB e.g. "2GB"
 hooks: ["xnvme"]
@@ -36,3 +37,6 @@ testsuites:
 - name: xnvme_queue
   alias: "xNVMe: verify base functionality using be:ramdisk/async:thrpool"
   evars: {XNVME_ASYNC: "thrpool"}
+
+- name: xnvme_ioworker
+  alias: "xNVMe: verify base functionality using be:ramdisk"

--- a/toolbox/cijoe-pkg-xnvme/testplans/xnvme-base-spdk.plan
+++ b/toolbox/cijoe-pkg-xnvme/testplans/xnvme-base-spdk.plan
@@ -6,6 +6,7 @@ descr_long: |
   * device enumeration
   * admin-commands idfy-ns, idfy-ctrlr, get-log, get/set feature
   * queue-init/teardown
+  * read/write
   Requires
   * XNVME_URI points to an NVMe namespace e.g. /dev/nvme0n1
 hooks: ["sysinf", "xnvme"]
@@ -26,3 +27,6 @@ testsuites:
 - name: xnvme_queue
   alias: "xNVMe: verify base functionality using be:spdk"
   evars: {XNVME_ASYNC: "nvme"}
+
+- name: xnvme_ioworker
+  alias: "xNVMe: verify base functionality using be:spdk"

--- a/toolbox/cijoe-pkg-xnvme/testplans/xnvme-base-vfio.plan
+++ b/toolbox/cijoe-pkg-xnvme/testplans/xnvme-base-vfio.plan
@@ -6,6 +6,7 @@ descr_long: |
   * device enumeration
   * admin-commands idfy-ns, idfy-ctrlr, get-log, get/set feature
   * queue-init/teardown
+  * read/write
   Requires
   * XNVME_URI points to an NVMe namespace e.g. /dev/nvme0n1
 hooks: ["sysinf", "xnvme"]
@@ -25,3 +26,6 @@ testsuites:
 - name: xnvme_queue
   alias: "xNVMe: verify base functionality using be:vfio"
   evars: {XNVME_ASYNC: "vfio"}
+
+- name: xnvme_ioworker
+  alias: "xNVMe: verify base functionality using be:vfio"

--- a/toolbox/cijoe-pkg-xnvme/testsuites/xnvme_ioworker.suite
+++ b/toolbox/cijoe-pkg-xnvme/testsuites/xnvme_ioworker.suite
@@ -1,1 +1,2 @@
 xnvme_tests_ioworker.sh
+xnvme_tests_ioworker_sync.sh

--- a/toolbox/cijoe-pkg-xnvme/testsuites/xnvme_ioworker.suite
+++ b/toolbox/cijoe-pkg-xnvme/testsuites/xnvme_ioworker.suite
@@ -1,0 +1,1 @@
+xnvme_tests_ioworker.sh


### PR DESCRIPTION
Add ioworker read write test to relevant backends.

This is in preparation for the ramdisk enhancements, where the ioworker test is likely to be expanded.