### PR TITLE
tests: add flag for be to enum

### DIFF
--- a/tests/enum.c
+++ b/tests/enum.c
@@ -171,6 +171,7 @@ static struct xnvmec_sub g_subs[] = {
 		test_enum,
 		{
 			{XNVMEC_OPT_SYS_URI, XNVMEC_LOPT},
+			{XNVMEC_OPT_BE, XNVMEC_LOPT},
 			{XNVMEC_OPT_COUNT, XNVMEC_LOPT},
 			{XNVMEC_OPT_VERBOSE, XNVMEC_LFLG},
 		},
@@ -183,6 +184,7 @@ static struct xnvmec_sub g_subs[] = {
 		test_enum_open,
 		{
 			{XNVMEC_OPT_SYS_URI, XNVMEC_LOPT},
+			{XNVMEC_OPT_BE, XNVMEC_LOPT},
 			{XNVMEC_OPT_COUNT, XNVMEC_LOPT},
 			{XNVMEC_OPT_VERBOSE, XNVMEC_LFLG},
 		},

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_enum_any_be_multi.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_enum_any_be_multi.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Verify xnvme_enumerate() and xnvme_dev_open() / xnvme_dev_close()
+#
+# shellcheck disable=SC2119
+#
+CIJ_TEST_NAME=$(basename "${BASH_SOURCE[0]}")
+export CIJ_TEST_NAME
+# shellcheck source=modules/cijoe.sh
+source "$CIJ_ROOT/modules/cijoe.sh"
+test.enter
+
+: "${XNVME_URI:?Must be set and non-empty}"
+
+COUNT=4
+
+if ! cij.cmd "xnvme_tests_enum multi --count ${COUNT}"; then
+    test.fail
+fi
+
+test.pass

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_enum_any_be_open.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_enum_any_be_open.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Verify xnvme_enumerate() and xnvme_dev_open() / xnvme_dev_close()
+#
+# shellcheck disable=SC2119
+#
+CIJ_TEST_NAME=$(basename "${BASH_SOURCE[0]}")
+export CIJ_TEST_NAME
+# shellcheck source=modules/cijoe.sh
+source "$CIJ_ROOT/modules/cijoe.sh"
+test.enter
+
+: "${XNVME_URI:?Must be set and non-empty}"
+
+COUNT=4
+
+if ! cij.cmd "xnvme_tests_enum open --count ${COUNT}"; then
+    test.fail
+fi
+
+test.pass

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_enum_multi.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_enum_multi.sh
@@ -11,10 +11,11 @@ source "$CIJ_ROOT/modules/cijoe.sh"
 test.enter
 
 : "${XNVME_URI:?Must be set and non-empty}"
+: "${XNVME_BE:?Must be set and non-empty}"
 
 COUNT=4
 
-if ! cij.cmd "xnvme_tests_enum multi --count ${COUNT}"; then
+if ! cij.cmd "xnvme_tests_enum multi --be ${XNVME_BE} --count ${COUNT}"; then
   test.fail
 fi
 

--- a/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_enum_open.sh
+++ b/toolbox/cijoe-pkg-xnvme/testcases/xnvme_tests_enum_open.sh
@@ -11,10 +11,11 @@ source "$CIJ_ROOT/modules/cijoe.sh"
 test.enter
 
 : "${XNVME_URI:?Must be set and non-empty}"
+: "${XNVME_BE:?Must be set and non-empty}"
 
 COUNT=4
 
-if ! cij.cmd "xnvme_tests_enum open --count ${COUNT}"; then
+if ! cij.cmd "xnvme_tests_enum open --be ${XNVME_BE} --count ${COUNT}"; then
   test.fail
 fi
 

--- a/toolbox/cijoe-pkg-xnvme/testsuites/xnvme_admin.suite
+++ b/toolbox/cijoe-pkg-xnvme/testsuites/xnvme_admin.suite
@@ -12,4 +12,6 @@ xnvme_feature_get.sh
 xnvme_feature_set.sh
 examples-xnvme_hello.sh
 xnvme_tests_enum_open.sh
+xnvme_tests_enum_any_be_open.sh
 xnvme_tests_enum_multi.sh
+xnvme_tests_enum_any_be_multi.sh

--- a/toolbox/cijoe-pkg-xnvme/testsuites/xnvme_admin_idfy_log.suite
+++ b/toolbox/cijoe-pkg-xnvme/testsuites/xnvme_admin_idfy_log.suite
@@ -8,4 +8,6 @@ xnvme_log-erri.sh
 xnvme_log-health.sh
 examples-xnvme_hello.sh
 xnvme_tests_enum_open.sh
+xnvme_tests_enum_any_be_open.sh
 xnvme_tests_enum_multi.sh
+xnvme_tests_enum_any_be_multi.sh

--- a/toolbox/cijoe-pkg-xnvme/testsuites/xnvme_admin_no_multi.suite
+++ b/toolbox/cijoe-pkg-xnvme/testsuites/xnvme_admin_no_multi.suite
@@ -11,3 +11,4 @@ xnvme_feature_get.sh
 xnvme_feature_set.sh
 examples-xnvme_hello.sh
 xnvme_tests_enum_open.sh
+xnvme_tests_enum_any_be_open.sh


### PR DESCRIPTION
Make it possible to run `xnvme_tests_enum` with different backends
Closes #129