### PR TITLE
Ankit/directives

### DIFF
--- a/include/libxnvme_adm.h
+++ b/include/libxnvme_adm.h
@@ -199,6 +199,23 @@ xnvme_nvm_sanitize(struct xnvme_cmd_ctx *ctx, uint8_t sanact, uint8_t ause, uint
 int
 xnvme_adm_dir_send(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t doper, uint32_t dtype,
 		   uint32_t dspec, uint32_t val);
+
+/**
+ * Submit and wait for completion of directive receive command
+ *
+ * @param ctx Pointer to ::xnvme_cmd_ctx
+ * @param nsid Namespace identifier
+ * @param doper Directive operation to perform
+ * @param dtype Directive type
+ * @param val Value specific to command dword 12
+ * @param dbuf pointer to data-payload
+ * @param dbuf_nbytes size of the data-payload in bytes
+ *
+ * @return On success, 0 is returned. On error, negative `errno` is returned.
+ */
+int
+xnvme_adm_dir_recv(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t doper, uint32_t dtype,
+		   uint32_t val, void *dbuf, size_t dbuf_nbytes);
 #ifdef __cplusplus
 }
 #endif

--- a/include/libxnvme_adm.h
+++ b/include/libxnvme_adm.h
@@ -184,6 +184,21 @@ int
 xnvme_nvm_sanitize(struct xnvme_cmd_ctx *ctx, uint8_t sanact, uint8_t ause, uint32_t ovrpat,
 		   uint8_t owpass, uint8_t oipbp, uint8_t nodas);
 
+/**
+ * Submit and wait for completion of directive send command
+ *
+ * @param ctx Pointer to ::xnvme_cmd_ctx
+ * @param nsid Namespace identifier
+ * @param doper Directive operation to perform
+ * @param dtype Directive type
+ * @param dspec Directive specific
+ * @param val Value specific to command dword 12
+ *
+ * @return On success, 0 is returned. On error, negative `errno` is returned.
+ */
+int
+xnvme_adm_dir_send(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t doper, uint32_t dtype,
+		   uint32_t dspec, uint32_t val);
 #ifdef __cplusplus
 }
 #endif

--- a/include/libxnvme_nvm.h
+++ b/include/libxnvme_nvm.h
@@ -77,6 +77,21 @@ int
 xnvme_nvm_write_zeroes(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t sdlba, uint16_t nlb);
 
 /**
+ * Submit, and optionally wait for completion of, a NVMe Write
+ *
+ * @param ctx Pointer to command context (::xnvme_cmd_ctx)
+ * @param opcode Opcode for the NVMe command
+ * @param nsid Namespace Identifier
+ * @param slba The LBA to start the write at
+ * @param nlb Number of LBAs to be written. NOTE: nlb is a zero-based value
+ *
+ * @return On success, 0 is returned. On error, negative `errno` is returned.
+ */
+void
+xnvme_prep_nvm(struct xnvme_cmd_ctx *ctx, uint8_t opcode, uint32_t nsid, uint64_t slba,
+	       uint16_t nlb);
+
+/**
  * Submit, and optionally wait for completion of a NVMe Simple-Copy-Command
  *
  * @see xnvme_cmd_opts

--- a/include/libxnvme_spec.h
+++ b/include/libxnvme_spec.h
@@ -954,6 +954,8 @@ enum xnvme_spec_adm_opc {
 
 	XNVME_SPEC_ADM_OPC_SFEAT = 0x09, ///< XNVME_SPEC_ADM_OPC_SFEAT
 	XNVME_SPEC_ADM_OPC_GFEAT = 0x0A, ///< XNVME_SPEC_ADM_OPC_GFEAT
+
+	XNVME_SPEC_ADM_OPC_DSEND = 0x19, ///< XNVME_SPEC_ADM_OPC_DSEND
 };
 
 /**
@@ -1003,6 +1005,32 @@ enum xnvme_spec_feat_sel {
 	XNVME_SPEC_FEAT_SEL_DEFAULT   = 0x1, ///< XNVME_SPEC_FEAT_SEL_DEFAULT
 	XNVME_SPEC_FEAT_SEL_SAVED     = 0x2, ///< XNVME_SPEC_FEAT_SEL_SAVED
 	XNVME_SPEC_FEAT_SEL_SUPPORTED = 0x3  ///< XNVME_SPEC_FEAT_SEL_SUPPORTED
+};
+
+/**
+ * @enum xnvme_spec_dir_types
+ */
+enum xnvme_spec_dir_types {
+	XNVME_SPEC_DIR_IDENTIFY = 0x0, ///< XNVME_SPEC_DIR_IDENTIFY
+	XNVME_SPEC_DIR_STREAMS  = 0x1, ///< XNVME_SPEC_DIR_STREAMS
+};
+
+/**
+ * @enum xnvme_spec_dsend_idfy_doper
+ */
+enum xnvme_spec_dsend_idfy_doper {
+	// Identify directive send enable directive
+	XNVME_SPEC_DSEND_IDFY_ENDIR = 0x1,
+};
+
+/**
+ * @enum xnvme_spec_dsend_streams_doper
+ */
+enum xnvme_spec_dsend_streams_doper {
+	// Streams directive send, release identifier
+	XNVME_SPEC_DSEND_STREAMS_RELID = 0x1,
+	// Streams directive send, release resources
+	XNVME_SPEC_DSEND_STREAMS_RELRS = 0x2,
 };
 
 /**
@@ -1277,6 +1305,36 @@ struct xnvme_spec_cmd_sfeat {
 	uint32_t cdw12_15[4]; ///< Command dword 12 to 15
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_cmd_sfeat) == 64, "Incorrect size")
+
+/**
+ * NVMe Command Accessor for the directive send command
+ *
+ * @struct xnvme_spec_cmd_dsend
+ */
+struct xnvme_spec_cmd_dsend {
+	uint32_t cdw00_09[10]; ///< Command dword 0 to 9
+
+	uint32_t numd; ///< Command dowrd 10
+
+	/* Command dword 11 */
+	uint32_t doper : 8;  ///< Directive operation
+	uint32_t dtype : 8;  ///< Directive type
+	uint32_t dspec : 16; ///< Directive specific
+
+	/* Command dword 12 */
+	union {
+		struct {
+			uint32_t endir  : 1; ///< Enable directive
+			uint32_t rsvd1  : 7;
+			uint32_t tdtype : 8; ///< Target directive to enable / disable
+			uint32_t rsvd2  : 16;
+		};
+		uint32_t val;
+	} cdw12;
+
+	uint32_t cdw13_15[3]; ///< Command dword 13 to 15
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_cmd_dsend) == 64, "Incorrect size")
 
 /**
  * NVMe Command Accessor for the identify command
@@ -1692,6 +1750,7 @@ struct xnvme_spec_cmd {
 		struct xnvme_spec_cmd_gfeat gfeat;
 		struct xnvme_spec_cmd_sfeat sfeat;
 		struct xnvme_spec_cmd_idfy idfy;
+		struct xnvme_spec_cmd_dsend dsend;
 		struct xnvme_spec_cmd_nvm nvm;
 		struct xnvme_spec_nvm_cmd_scopy scopy;
 		struct xnvme_spec_nvm_write_zeroes write_zeroes;

--- a/include/libxnvme_spec.h
+++ b/include/libxnvme_spec.h
@@ -1345,7 +1345,25 @@ struct xnvme_spec_cmd_nvm {
 	uint32_t fua    : 1; ///< FUA: Force unit access
 	uint32_t lr     : 1; ///< LR: Limited retry
 
-	uint32_t cdw13_15[3]; ///< Command dword 13 to 15
+	/* cdw 13 */
+	union {
+		struct {
+			uint32_t af    : 4; ///< Access Frequency
+			uint32_t al    : 2; ///< Access Latency
+			uint32_t sr    : 1; ///< Sequential Request
+			uint32_t incom : 1; ///< Incompressible
+			uint32_t rsvd3 : 8;
+			uint32_t dspec : 16; ///< Directive Specific
+		};
+		uint32_t val;
+	} cdw13;
+
+	/* cdw 14 */
+	uint32_t ilbrt : 32; ///< Initial Logical Block Reference Tag
+
+	/* cdw 15 */
+	uint32_t lbat  : 16; ///< Logical Block Application Tag
+	uint32_t lbatm : 16; ///< logical Block Application Tag Mask
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_cmd_nvm) == 64, "Incorrect size")
 

--- a/include/libxnvmec.h
+++ b/include/libxnvmec.h
@@ -221,6 +221,13 @@ struct xnvmec_args {
 	uint32_t oflags;
 
 	uint32_t vec_cnt;
+
+	uint32_t dtype;
+	uint32_t dspec;
+	uint32_t doper;
+	uint32_t endir;
+	uint32_t tgtdir;
+	uint32_t nsr;
 };
 
 void
@@ -358,7 +365,14 @@ enum xnvmec_opt {
 	XNVMEC_OPT_SUBNQN  = 98, ///< XNVME_OPT_SUBNQN
 	XNVMEC_OPT_HOSTNQN = 99, ///< XNVMEC_OPT_HOSTNQN
 
-	XNVMEC_OPT_END = 100, ///< XNVMEC_OPT_END
+	XNVMEC_OPT_DTYPE  = 100, ///< XNVMEC_OPT_DTYPE
+	XNVMEC_OPT_DSPEC  = 101, ///< XNVMEC_OPT_DSPEC
+	XNVMEC_OPT_DOPER  = 102, ///< XNVMEC_OPT_DOPER
+	XNVMEC_OPT_ENDIR  = 103, ///< XNVMEC_OPT_ENDIR
+	XNVMEC_OPT_TGTDIR = 104, ///< XNVMEC_OPT_TGTDIR
+	XNVMEC_OPT_NSR    = 105, ///< XNVMEC_OPT_NSR
+
+	XNVMEC_OPT_END = 106, ///< XNVMEC_OPT_END
 };
 
 /**

--- a/lib/xnvme_adm.c
+++ b/lib/xnvme_adm.c
@@ -148,3 +148,17 @@ xnvme_adm_dir_send(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t doper, uint
 
 	return xnvme_cmd_pass_admin(ctx, NULL, 0x0, NULL, 0x0);
 }
+
+int
+xnvme_adm_dir_recv(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t doper, uint32_t dtype,
+		   uint32_t val, void *dbuf, size_t dbuf_nbytes)
+{
+	ctx->cmd.common.opcode = XNVME_SPEC_ADM_OPC_DRECV;
+	ctx->cmd.common.nsid = nsid;
+	ctx->cmd.drecv.numd = (dbuf_nbytes) ? (dbuf_nbytes / sizeof(uint32_t) - 1u) : 0;
+	ctx->cmd.drecv.doper = doper;
+	ctx->cmd.drecv.dtype = dtype;
+	ctx->cmd.drecv.cdw12.val = val;
+
+	return xnvme_cmd_pass_admin(ctx, dbuf, dbuf_nbytes, NULL, 0x0);
+}

--- a/lib/xnvme_adm.c
+++ b/lib/xnvme_adm.c
@@ -134,3 +134,17 @@ xnvme_adm_sfeat(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t fid, uint32_t 
 
 	return xnvme_cmd_pass_admin(ctx, (void *)dbuf, dbuf_nbytes, NULL, 0x0);
 }
+
+int
+xnvme_adm_dir_send(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t doper, uint32_t dtype,
+		   uint32_t dspec, uint32_t val)
+{
+	ctx->cmd.common.opcode = XNVME_SPEC_ADM_OPC_DSEND;
+	ctx->cmd.common.nsid = nsid;
+	ctx->cmd.dsend.doper = doper;
+	ctx->cmd.dsend.dtype = dtype;
+	ctx->cmd.dsend.dspec = dspec;
+	ctx->cmd.dsend.cdw12.val = val;
+
+	return xnvme_cmd_pass_admin(ctx, NULL, 0x0, NULL, 0x0);
+}

--- a/lib/xnvme_nvm.c
+++ b/lib/xnvme_nvm.c
@@ -102,6 +102,16 @@ xnvme_nvm_write_zeroes(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t sdlba,
 	return xnvme_cmd_pass(ctx, NULL, 0, NULL, 0);
 }
 
+void
+xnvme_prep_nvm(struct xnvme_cmd_ctx *ctx, uint8_t opcode, uint32_t nsid, uint64_t slba,
+	       uint16_t nlb)
+{
+	ctx->cmd.common.opcode = opcode;
+	ctx->cmd.common.nsid = nsid;
+	ctx->cmd.nvm.slba = slba;
+	ctx->cmd.nvm.nlb = nlb;
+}
+
 int
 xnvme_nvm_scopy(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t sdlba,
 		struct xnvme_spec_nvm_scopy_fmt_zero *ranges, uint8_t nr,

--- a/lib/xnvme_spec.c
+++ b/lib/xnvme_spec.c
@@ -749,6 +749,148 @@ xnvme_spec_nvm_idfy_ns_pr(struct xnvme_spec_nvm_idfy_ns *idfy, int opts)
 }
 
 int
+xnvme_spec_drecv_idfy_fpr(FILE *stream, struct xnvme_spec_idfy_dir_rp *idfy, int opts)
+{
+	int wrtn = 0;
+
+	switch (opts) {
+	case XNVME_PR_DEF:
+	case XNVME_PR_YAML:
+		break;
+
+	case XNVME_PR_TERSE:
+		wrtn += fprintf(stream, "# ENOSYS: opts(%x)", opts);
+		return wrtn;
+	}
+
+	wrtn += fprintf(stream, "xnvme_spec_idfy_dir_rp:");
+	if (!idfy) {
+		wrtn += fprintf(stream, " ~\n");
+		return wrtn;
+	}
+
+	wrtn += fprintf(stream, "\n");
+	wrtn += fprintf(stream, "  directives_supported:\n");
+	wrtn += fprintf(stream, "    identify: %d\n", idfy->directives_supported.identify);
+	wrtn += fprintf(stream, "    streams: %d\n", idfy->directives_supported.streams);
+	wrtn += fprintf(stream, "  directives_enabled:\n");
+	wrtn += fprintf(stream, "    identify: %d\n", idfy->directives_enabled.identify);
+	wrtn += fprintf(stream, "    streams: %d\n", idfy->directives_enabled.streams);
+
+	return wrtn;
+}
+
+int
+xnvme_spec_drecv_idfy_pr(struct xnvme_spec_idfy_dir_rp *idfy, int opts)
+{
+	return xnvme_spec_drecv_idfy_fpr(stdout, idfy, opts);
+}
+
+int
+xnvme_spec_drecv_srp_fpr(FILE *stream, struct xnvme_spec_streams_dir_rp *srp, int opts)
+{
+	int wrtn = 0;
+
+	switch (opts) {
+	case XNVME_PR_DEF:
+	case XNVME_PR_YAML:
+		break;
+
+	case XNVME_PR_TERSE:
+		wrtn += fprintf(stream, "# ENOSYS: opts(%x)", opts);
+		return wrtn;
+	}
+
+	wrtn += fprintf(stream, "xnvme_spec_streams_dir_rp:");
+	if (!srp) {
+		wrtn += fprintf(stream, " ~\n");
+		return wrtn;
+	}
+
+	wrtn += fprintf(stream, "\n");
+	wrtn += fprintf(stream, "  msl: %d\n", srp->msl);
+	wrtn += fprintf(stream, "  nssa: %d\n", srp->nssa);
+	wrtn += fprintf(stream, "  nsso: %d\n", srp->nsso);
+	wrtn += fprintf(stream, "  multi_host: %d\n", srp->nssc.bits.multi_host);
+	wrtn += fprintf(stream, "  sws: %d\n", srp->sws);
+	wrtn += fprintf(stream, "  sgs: %d\n", srp->sgs);
+	wrtn += fprintf(stream, "  nsa: %d\n", srp->nsa);
+	wrtn += fprintf(stream, "  nso: %d\n", srp->nso);
+
+	return wrtn;
+}
+
+int
+xnvme_spec_drecv_srp_pr(struct xnvme_spec_streams_dir_rp *srp, int opts)
+{
+	return xnvme_spec_drecv_srp_fpr(stdout, srp, opts);
+}
+
+int
+xnvme_spec_drecv_sgs_fpr(FILE *stream, struct xnvme_spec_streams_dir_gs *sgs, int opts)
+{
+	int wrtn = 0;
+
+	switch (opts) {
+	case XNVME_PR_DEF:
+	case XNVME_PR_YAML:
+		break;
+
+	case XNVME_PR_TERSE:
+		wrtn += fprintf(stream, "# ENOSYS: opts(%x)", opts);
+		return wrtn;
+	}
+
+	wrtn += fprintf(stream, "xnvme_spec_streams_dir_rp:");
+	if (!sgs) {
+		wrtn += fprintf(stream, " ~\n");
+		return wrtn;
+	}
+
+	wrtn += fprintf(stream, "\n");
+	wrtn += fprintf(stream, "  open_sc: %d\n", sgs->open_sc);
+	for (int osc = 0; osc < sgs->open_sc; ++osc) {
+		wrtn += fprintf(stream, "  - sid[%d]: %d\n", osc, sgs->sid[osc]);
+	}
+
+	return wrtn;
+}
+
+int
+xnvme_spec_drecv_sgs_pr(struct xnvme_spec_streams_dir_gs *sgs, int opts)
+{
+	return xnvme_spec_drecv_sgs_fpr(stdout, sgs, opts);
+}
+
+int
+xnvme_spec_drecv_sar_fpr(FILE *stream, struct xnvme_spec_alloc_resource sar, int opts)
+{
+	int wrtn = 0;
+
+	switch (opts) {
+	case XNVME_PR_DEF:
+	case XNVME_PR_YAML:
+		break;
+
+	case XNVME_PR_TERSE:
+		wrtn += fprintf(stream, "# ENOSYS: opts(%x)", opts);
+		return wrtn;
+	}
+
+	wrtn += fprintf(stream, "xnvme_spec_alloc_resource:");
+	wrtn += fprintf(stream, "\n");
+	wrtn += fprintf(stream, "  nsa: %d\n", sar.bits.nsa);
+
+	return wrtn;
+}
+
+int
+xnvme_spec_drecv_sar_pr(struct xnvme_spec_alloc_resource sar, int opts)
+{
+	return xnvme_spec_drecv_sar_fpr(stdout, sar, opts);
+}
+
+int
 xnvme_spec_znd_descr_fpr_yaml(FILE *stream, const struct xnvme_spec_znd_descr *descr, int indent,
 			      const char *sep)
 {

--- a/lib/xnvme_spec_pp.c
+++ b/lib/xnvme_spec_pp.c
@@ -12,6 +12,8 @@ xnvme_spec_adm_opc_str(enum xnvme_spec_adm_opc eval)
 		return "ADM_OPC_LOG";
 	case XNVME_SPEC_ADM_OPC_SFEAT:
 		return "ADM_OPC_SFEAT";
+	case XNVME_SPEC_ADM_OPC_DSEND:
+		return "ADM_OPC_DSEND";
 	}
 
 	return "ENOSYS";

--- a/lib/xnvme_spec_pp.c
+++ b/lib/xnvme_spec_pp.c
@@ -14,6 +14,8 @@ xnvme_spec_adm_opc_str(enum xnvme_spec_adm_opc eval)
 		return "ADM_OPC_SFEAT";
 	case XNVME_SPEC_ADM_OPC_DSEND:
 		return "ADM_OPC_DSEND";
+	case XNVME_SPEC_ADM_OPC_DRECV:
+		return "ADM_OPC_DRECV";
 	}
 
 	return "ENOSYS";

--- a/lib/xnvmec.c
+++ b/lib/xnvmec.c
@@ -884,6 +884,43 @@ static struct xnvmec_opt_attr xnvmec_opts[] = {
 	},
 
 	{
+		.opt = XNVMEC_OPT_DTYPE,
+		.vtype = XNVMEC_OPT_VTYPE_HEX,
+		.name = "dtype",
+		.descr = "Directive type; Identify 0x0, Streams 0x1",
+	},
+	{
+		.opt = XNVMEC_OPT_DSPEC,
+		.vtype = XNVMEC_OPT_VTYPE_HEX,
+		.name = "dspec",
+		.descr = "Directive specification associated with directive type",
+	},
+	{
+		.opt = XNVMEC_OPT_DOPER,
+		.vtype = XNVMEC_OPT_VTYPE_HEX,
+		.name = "doper",
+		.descr = "Directive operation to perform",
+	},
+	{
+		.opt = XNVMEC_OPT_ENDIR,
+		.vtype = XNVMEC_OPT_VTYPE_HEX,
+		.name = "endir",
+		.descr = "Directive enable/disable; Enable 0x1, Disable 0x0",
+	},
+	{
+		.opt = XNVMEC_OPT_TGTDIR,
+		.vtype = XNVMEC_OPT_VTYPE_HEX,
+		.name = "tgtdir",
+		.descr = "Target directive to enable/disable",
+	},
+	{
+		.opt = XNVMEC_OPT_NSR,
+		.vtype = XNVMEC_OPT_VTYPE_HEX,
+		.name = "nsr",
+		.descr = "Namespace streams requested",
+	},
+
+	{
 		.opt = XNVMEC_OPT_END,
 		.vtype = XNVMEC_OPT_VTYPE_NUM,
 		.name = "",
@@ -1449,6 +1486,24 @@ xnvmec_assign_arg(struct xnvmec *cli, struct xnvmec_opt_attr *opt_attr, char *ar
 		break;
 	case XNVMEC_OPT_VEC_CNT:
 		args->vec_cnt = arg ? num : 0;
+		break;
+	case XNVMEC_OPT_DTYPE:
+		args->dtype = num;
+		break;
+	case XNVMEC_OPT_DSPEC:
+		args->dspec = num;
+		break;
+	case XNVMEC_OPT_DOPER:
+		args->doper = num;
+		break;
+	case XNVMEC_OPT_ENDIR:
+		args->endir = num;
+		break;
+	case XNVMEC_OPT_TGTDIR:
+		args->tgtdir = num;
+		break;
+	case XNVMEC_OPT_NSR:
+		args->nsr = num;
 		break;
 
 	case XNVMEC_OPT_END:

--- a/python/xnvme-cy-bindings/aux/autopxd_py.py
+++ b/python/xnvme-cy-bindings/aux/autopxd_py.py
@@ -237,6 +237,7 @@ from libxnvme cimport {', '.join(enum_defs)}
                 "xnvmec_cmd_from_file",
                 "xnvme_spec_feat_fpr",  # Takes struct (not pointer) as argument
                 "xnvme_spec_feat_pr",  # Takes struct (not pointer) as argument
+                "xnvme_spec_drecv_sar_pr",  # Takes struct (not pointer) as argument
                 "xnvmec_cmd_to_file",  # Somehow causes linking issues
             ]
             if func_name in ignore_list:

--- a/python/xnvme-cy-header/aux/generate_cython_header.py
+++ b/python/xnvme-cy-header/aux/generate_cython_header.py
@@ -15,6 +15,7 @@ regex = [
     r"s/xnvme_be_attr item\[\]/xnvme_be_attr item[1]/g",
     r"s/xnvme_ident entries\[\]/xnvme_ident entries[1]/g",
     r"s/uint8_t storage\[\]/uint8_t storage[1]/g",
+    r"s/uint16_t sid\[\]/uint16_t sid[1]/g",
 ]
 
 

--- a/tools/lblk.c
+++ b/tools/lblk.c
@@ -442,6 +442,80 @@ exit:
 	return err;
 }
 
+static int
+sub_write_directive(struct xnvmec *cli)
+{
+	struct xnvme_dev *dev = cli->args.dev;
+	struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
+	const struct xnvme_geo *geo = cli->args.geo;
+	const uint64_t slba = cli->args.slba;
+	const size_t nlb = cli->args.nlb;
+	uint32_t nsid = cli->args.nsid;
+	uint32_t dtype = cli->args.dtype;
+	uint32_t dspec = cli->args.dspec;
+
+	void *dbuf = NULL, *mbuf = NULL;
+	size_t dbuf_nbytes, mbuf_nbytes;
+	int err;
+
+	if (!cli->given[XNVMEC_OPT_NSID]) {
+		nsid = xnvme_dev_get_nsid(cli->args.dev);
+	}
+
+	dbuf_nbytes = (nlb + 1) * geo->lba_nbytes;
+	mbuf_nbytes = geo->lba_extended ? 0 : (nlb + 1) * geo->nbytes_oob;
+
+	xnvmec_pinf("Writing nsid: 0x%x, slba: 0x%016lx, nlb: %zu", nsid, slba, nlb);
+
+	xnvmec_pinf("Alloc/fill dbuf, dbuf_nbytes: %zu", dbuf_nbytes);
+	dbuf = xnvme_buf_alloc(dev, dbuf_nbytes);
+	if (!dbuf) {
+		err = -errno;
+		xnvmec_perr("xnvme_buf_alloc()", err);
+		goto exit;
+	}
+	err = xnvmec_buf_fill(dbuf, dbuf_nbytes,
+			      cli->args.data_input ? cli->args.data_input : "anum");
+	if (err) {
+		xnvmec_perr("xnvmec_buf_fill()", err);
+		goto exit;
+	}
+
+	if (mbuf_nbytes) {
+		xnvmec_pinf("Alloc/fill mbuf, mbuf_nbytes: %zu", mbuf_nbytes);
+		mbuf = xnvme_buf_alloc(dev, mbuf_nbytes);
+		if (!mbuf) {
+			err = -errno;
+			xnvmec_perr("xnvme_buf_alloc()", err);
+			goto exit;
+		}
+		err = xnvmec_buf_fill(mbuf, mbuf_nbytes, "anum");
+		if (err) {
+			xnvmec_perr("xnvmec_buf_fill()", err);
+			goto exit;
+		}
+	}
+
+	xnvmec_pinf("Preparing and sending the command...");
+	xnvme_prep_nvm(&ctx, XNVME_SPEC_NVM_OPC_WRITE, nsid, slba, nlb);
+	ctx.cmd.nvm.dtype = dtype;
+	ctx.cmd.nvm.cdw13.dspec = dspec;
+
+	err = xnvme_cmd_pass(&ctx, dbuf, dbuf_nbytes, mbuf, mbuf_nbytes);
+	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		xnvmec_perr("xnvme_cmd_pass()", err);
+		xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
+		err = err ? err : -EIO;
+		goto exit;
+	}
+
+exit:
+	xnvme_buf_free(dev, dbuf);
+	xnvme_buf_free(dev, mbuf);
+
+	return err;
+}
+
 //
 // Command-Line Interface (CLI) definition
 //
@@ -591,6 +665,27 @@ static struct xnvmec_sub g_subs[] = {
 			{XNVMEC_OPT_NSID, XNVMEC_LOPT},
 			{XNVMEC_OPT_DATA_INPUT, XNVMEC_LOPT},
 			{XNVMEC_OPT_META_INPUT, XNVMEC_LOPT},
+
+			{XNVMEC_OPT_DEV_NSID, XNVMEC_LOPT},
+			{XNVMEC_OPT_BE, XNVMEC_LOPT},
+			{XNVMEC_OPT_ADMIN, XNVMEC_LOPT},
+			{XNVMEC_OPT_SYNC, XNVMEC_LOPT},
+		},
+	},
+	{
+		"write-dir",
+		"Writes directive specific data and optionally metadata",
+		"Writes directive specific data and optionally metadata",
+		sub_write_directive,
+		{
+			{XNVMEC_OPT_URI, XNVMEC_POSA},
+			{XNVMEC_OPT_SLBA, XNVMEC_LREQ},
+			{XNVMEC_OPT_NLB, XNVMEC_LREQ},
+			{XNVMEC_OPT_NSID, XNVMEC_LOPT},
+			{XNVMEC_OPT_DATA_INPUT, XNVMEC_LOPT},
+			{XNVMEC_OPT_META_INPUT, XNVMEC_LOPT},
+			{XNVMEC_OPT_DTYPE, XNVMEC_LOPT},
+			{XNVMEC_OPT_DSPEC, XNVMEC_LOPT},
 
 			{XNVMEC_OPT_DEV_NSID, XNVMEC_LOPT},
 			{XNVMEC_OPT_BE, XNVMEC_LOPT},


### PR DESCRIPTION
This patch series add support for directives in xNVMe. This adds dir-send, dir-receive and write-dir to the lblk tool.

Few of the commands are such:

Enable streams directive
lblk dir-send /dev/ng0n1 --dtype 0 --doper 1 --endir 1 --tgtdir 1

Check for directive support
lblk dir-receive /dev/ng0n1 --dtype 0 --doper 1

Write 2 LBA's with stream identifier as 2
lblk write-dir /dev/ng0n1 --slba 0x0 --nlb 2 --dtype 1 --dspec 2