### PR TITLE
CI: add scan-build to workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -94,6 +94,41 @@ jobs:
       run: pre-commit run --all-files
 
   #
+  # Code-analysis using scan-build
+  #
+  analyze-scan-build:
+    needs: source-archive
+    runs-on: ubuntu-latest
+    container: refenv/xnvme-devtools-ci:latest
+
+    steps:
+    - name: Retrieve the source-archive
+      uses: actions/download-artifact@v2
+      with:
+        name: archive-src
+    - name: Extract the full-source-archive
+      run: |
+        tar xzf xnvme*.tar.gz --strip 1
+        rm xnvme*.tar.gz
+
+    - name: install scan-build (clang-tools)
+      run: apt-get install -qy clang-tools
+
+    - name: Run config-debug
+      run: scan-build make config-debug
+
+    - name: Run scan-build
+      run: scan-build --exclude subprojects -o /tmp/scan-build-report make
+
+    - name: Upload scan-build report
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: scan-build-report
+        path: /tmp/scan-build-report/*
+        if-no-files-found: error
+
+  #
   # Code-analysis using GitHUB CodeQL
   #
   analyze-codeql:

--- a/lib/xnvme_be_linux_block.c
+++ b/lib/xnvme_be_linux_block.c
@@ -74,7 +74,7 @@ int
 xnvme_be_linux_sysfs_dev_attr_to_num(struct xnvme_dev *dev, const char *attr, uint64_t *num)
 {
 	const int buf_len = 0x1000;
-	char buf[buf_len];
+	char buf[0x1000] = {'\0'};
 	int base = 10;
 	int err;
 

--- a/lib/xnvme_be_posix_async_thrpool.c
+++ b/lib/xnvme_be_posix_async_thrpool.c
@@ -203,7 +203,7 @@ _posix_async_thrpool_term(struct xnvme_queue *q)
 		XNVME_DEBUG("FAILED: pthread_mutex_unlock(), err_lock: %d", err_lock);
 	}
 
-	for (int i = 0; i < queue->nthreads; i++) {
+	for (int i = 0; queue->threads && i < queue->nthreads; i++) {
 		pthread_join(queue->threads[i], NULL);
 	}
 	free(queue->threads);

--- a/tests/lblk.c
+++ b/tests/lblk.c
@@ -59,7 +59,8 @@ boilerplate(struct xnvmec *cli, uint8_t **wbuf, uint8_t **rbuf, size_t *buf_nbyt
 	if (!*rbuf) {
 		err = -ENOMEM;
 		xnvmec_perr("xnvme_buf_alloc()", err);
-		xnvme_buf_free(dev, *rbuf);
+		xnvme_buf_free(dev, *wbuf);
+		*wbuf = NULL;
 		return err;
 	}
 

--- a/tests/lblk.c
+++ b/tests/lblk.c
@@ -50,14 +50,14 @@ boilerplate(struct xnvmec *cli, uint8_t **wbuf, uint8_t **rbuf, size_t *buf_nbyt
 
 	*wbuf = xnvme_buf_alloc(dev, *buf_nbytes);
 	if (!*wbuf) {
-		err = -errno;
+		err = -ENOMEM;
 		xnvmec_perr("xnvme_buf_alloc()", err);
 		return err;
 	}
 
 	*rbuf = xnvme_buf_alloc(dev, *buf_nbytes);
 	if (!*rbuf) {
-		err = -errno;
+		err = -ENOMEM;
 		xnvmec_perr("xnvme_buf_alloc()", err);
 		xnvme_buf_free(dev, *rbuf);
 		return err;
@@ -277,7 +277,7 @@ test_scopy(struct xnvmec *cli)
 
 	sranges = xnvme_buf_alloc(dev, sizeof(*sranges));
 	if (!sranges) {
-		err = -errno;
+		err = -ENOMEM;
 		xnvmec_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}

--- a/tests/znd_state.c
+++ b/tests/znd_state.c
@@ -31,7 +31,7 @@ cmd_transition(struct xnvmec *cli)
 	struct xnvme_dev *dev = cli->args.dev;
 	uint32_t nsid;
 	uint64_t slba;
-	int err;
+	int err = 0;
 
 	nsid = cli->given[XNVMEC_OPT_NSID] ? cli->args.nsid : xnvme_dev_get_nsid(cli->args.dev);
 	slba = cli->given[XNVMEC_OPT_SLBA] ? cli->args.slba : 0x0;

--- a/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/tools/test_xnvme.py
+++ b/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/tools/test_xnvme.py
@@ -131,6 +131,9 @@ def test_log(cijoe, device, be_opts, cli_args):
 @xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
 def test_feature_get(cijoe, device, be_opts, cli_args):
 
+    if be_opts["be"] == "linux" and be_opts["admin"] in ["block"]:
+        pytest.skip(reason="[admin=block] does not implement feature-get")
+
     for fid, descr in [("0x4", "Temperature threshold"), ("0x5", "Error recovery")]:
         # Get fid without setting select-bit
         err, _ = cijoe.run(f"xnvme feature-get {cli_args} --fid {fid}")

--- a/tools/xdd.c
+++ b/tools/xdd.c
@@ -69,7 +69,18 @@ copy_async(struct xnvmec *cli)
 	tbytes = cli->args.data_nbytes;
 
 	iosize = cli->given[XNVMEC_OPT_IOSIZE] ? cli->args.iosize : IOSIZE_DEF;
+	if (!iosize) {
+		err = -EINVAL;
+		xnvmec_perr("iosize can't be set to 0", err);
+		return err;
+	}
+
 	qdepth = cli->given[XNVMEC_OPT_QDEPTH] ? cli->args.qdepth : QDEPTH_DEF;
+	if (!qdepth) {
+		err = -EINVAL;
+		xnvmec_perr("qdepth can't be set to 0", err);
+		return err;
+	}
 	start_offset = cli->given[XNVMEC_OPT_OFFSET] ? cli->args.offset : START_OFFSET_DEF;
 
 	src_dev = xnvme_file_open(src_uri, &src_opts);

--- a/tools/xnvme.c
+++ b/tools/xnvme.c
@@ -409,7 +409,7 @@ sub_gfeat(struct xnvmec *cli)
 	}
 
 exit:
-	return 0;
+	return err;
 }
 
 static int

--- a/tools/xnvme_file.c
+++ b/tools/xnvme_file.c
@@ -691,7 +691,18 @@ copy_file_async(struct xnvmec *cli)
 	src_fpath = cli->args.data_input;
 	dst_fpath = cli->args.data_output;
 	iosize = cli->given[XNVMEC_OPT_IOSIZE] ? cli->args.iosize : IOSIZE_DEF;
+	if (!iosize) {
+		err = -EINVAL;
+		xnvmec_perr("iosize can't be set to 0", err);
+		return err;
+	}
+
 	qdepth = cli->given[XNVMEC_OPT_QDEPTH] ? cli->args.qdepth : QDEPTH_DEF;
+	if (!qdepth) {
+		err = -EINVAL;
+		xnvmec_perr("qdepth can't be set to 0", err);
+		return err;
+	}
 
 	src_fh = xnvme_file_open(src_fpath, &src_opts);
 	if (src_fh == NULL) {


### PR DESCRIPTION
This is an experiment.
`scan-build` detects errors and warnings that I think is reasonable and should be addressed to improve code quality.
This PR will include fixes for the errors found and based on that we can make a decision of whether to make it a part of our CI.

Signed-off-by: Karl Bonde Torp <k.torp@samsung.com>