### PR TITLE
Update fio subprojects to v3.32

### DIFF
--- a/subprojects/fio.wrap
+++ b/subprojects/fio.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 url = https://github.com/axboe/fio.git
-revision = fio-3.30
+revision = fio-3.32
 patch_directory = fio

--- a/subprojects/packagefiles/fio/meson.build
+++ b/subprojects/packagefiles/fio/meson.build
@@ -1,13 +1,13 @@
 project(
   'fio',
   'c',
-  version: '3.30',
+  version: '3.32',
 )
 fs = import('fs')
 
 if get_option('build_subprojects') and not fs.exists('config-host.h')
   message('Configuring ..')
-  run_command('./configure', capture: true, check: true)
+  run_command(['./configure', '--disable-xnvme'], capture: true, check: true)
 endif
 if get_option('build_subprojects') and not fs.exists('fio')
   cpu_count = run_command([


### PR DESCRIPTION
Bumping up fio such that we can compare built-in ``io_uring_cmd`` with xNVMe backend using ``io_uring_cmd``. The built of fio has ``--disable-xnvme`` as from the xNVMe side then the external engine is still in use until we get the Windows issue resolved.

Signed-off-by: Simon A. F. Lund <simon.lund@samsung.com>