### PR TITLE
3p:spdk: prep for mandatory isa-l

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -367,6 +367,11 @@ jobs:
       run: |
         cat builddir/meson-logs/meson-log.txt || true
 
+    - name: isal-log-dump
+      if: always()
+      run: |
+        cat subprojects/spdk/isa-l/spdk-isal.log || true
+
     - name: Execute 'xnvme enum'
       run: xnvme enum
 

--- a/subprojects/packagefiles/spdk/meson.build
+++ b/subprojects/packagefiles/spdk/meson.build
@@ -56,15 +56,20 @@ dpdk_libnames = get_option('build_subprojects') ? [
   'rte_kvargs'
 ] : []
 
+isal_libnames = get_option('build_subprojects') ? [
+  'isal',
+] : []
+
 cc = meson.get_compiler('c')
 spdk_paths = []
 spdk_libs = []
-foreach libname : spdk_libnames + dpdk_libnames
+foreach libname : spdk_libnames + dpdk_libnames + isal_libnames
   lib_dep = cc.find_library(
     libname,
     dirs: [
       meson.current_source_dir() / 'build' / 'lib',
       meson.current_source_dir() / 'dpdk' / 'build' / 'lib',
+      meson.current_source_dir() / 'isa-l' / '.libs',
     ],
     static: true
   )
@@ -74,6 +79,7 @@ foreach libname : spdk_libnames + dpdk_libnames
   paths = [
     meson.current_source_dir() / 'build' / 'lib' / 'lib' + libname + '.a',
     meson.current_source_dir() / 'dpdk' / 'build' / 'lib' / 'lib' + libname + '.a',
+    meson.current_source_dir() / 'isa-l' / '.libs' / 'lib' + libname + '.a',
   ]
   foreach path : paths
     if lib_dep.found() and fs.exists(path)

--- a/subprojects/packagefiles/spdk/spdk_build.sh
+++ b/subprojects/packagefiles/spdk/spdk_build.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-make -j

--- a/subprojects/packagefiles/spdk/spdk_configure.sh
+++ b/subprojects/packagefiles/spdk/spdk_configure.sh
@@ -5,7 +5,6 @@
   --without-crypto \
   --without-fuse \
   --without-idxd \
-  --without-isal \
   --without-iscsi-initiator \
   --without-nvme-cuse \
   --without-ocf \

--- a/toolbox/pkgs/archlinux-latest.txt
+++ b/toolbox/pkgs/archlinux-latest.txt
@@ -4,6 +4,7 @@ git
 libaio
 libutil-linux
 meson
+nasm
 ncurses
 ninja
 numactl

--- a/toolbox/pkgs/centos-centos7.sh
+++ b/toolbox/pkgs/centos-centos7.sh
@@ -13,6 +13,16 @@ yum install -y devtoolset-8
 # Install packages via the system package-manager (yum)
 yum install -y $(cat "toolbox/pkgs/centos-centos7.txt")
 
+# Install nasm from source
+git clone https://github.com/netwide-assembler/nasm.git
+cd nasm
+git checkout nasm-2.15
+./autogen.sh
+./configure --prefix=/usr
+make -j $(nproc)
+make install
+cd ..
+
 # The meson version available via yum is tool old < 0.54 and the Python version is tool old to
 # support the next release of meson, so to fix this, Python3 is installed from source and meson
 # installed via the Python package-manager pip

--- a/toolbox/pkgs/centos-centos7.txt
+++ b/toolbox/pkgs/centos-centos7.txt
@@ -1,11 +1,12 @@
 CUnit-devel
+autoconf
 git
 glibc-static
 libaio-devel
 libffi-devel
+libtool
 libuuid-devel
 make
-nasm
 ncurses-devel
 numactl-devel
 openssl-devel

--- a/toolbox/pkgs/centos-stream8.txt
+++ b/toolbox/pkgs/centos-stream8.txt
@@ -1,4 +1,5 @@
 CUnit-devel
+autoconf
 diffutils
 findutils
 gcc
@@ -6,8 +7,10 @@ gcc-c++
 git
 libaio-devel
 libffi-devel
+libtool
 libuuid-devel
 make
+nasm
 numactl-devel
 openssl-devel
 patch

--- a/toolbox/pkgs/centos-stream9.txt
+++ b/toolbox/pkgs/centos-stream9.txt
@@ -1,12 +1,15 @@
 CUnit-devel
+autoconf
 diffutils
 findutils
 gcc
 gcc-c++
 git
 libaio-devel
+libtool
 libuuid-devel
 make
+nasm
 numactl-devel
 openssl-devel
 patch

--- a/toolbox/pkgs/debian-bookworm.txt
+++ b/toolbox/pkgs/debian-bookworm.txt
@@ -1,3 +1,4 @@
+autoconf
 build-essential
 clang-format
 git
@@ -6,6 +7,7 @@ libcunit1-dev
 libncurses5-dev
 libnuma-dev
 libssl-dev
+libtool
 meson
 nasm
 pkg-config

--- a/toolbox/pkgs/debian-bullseye.txt
+++ b/toolbox/pkgs/debian-bullseye.txt
@@ -1,4 +1,4 @@
-astyle
+autoconf
 build-essential
 clang-format
 git
@@ -7,6 +7,7 @@ libcunit1-dev
 libncurses5-dev
 libnuma-dev
 libssl-dev
+libtool
 nasm
 pkg-config
 python3

--- a/toolbox/pkgs/debian-buster.txt
+++ b/toolbox/pkgs/debian-buster.txt
@@ -1,3 +1,4 @@
+autoconf
 build-essential
 git
 libaio-dev
@@ -5,6 +6,7 @@ libcunit1-dev
 libncurses5-dev
 libnuma-dev
 libssl-dev
+libtool
 nasm
 pkg-config
 python3

--- a/toolbox/pkgs/fedora-34.txt
+++ b/toolbox/pkgs/fedora-34.txt
@@ -1,13 +1,16 @@
 CUnit-devel
+autoconf
 diffutils
 findutils
 g++
 gcc
 git
 libaio-devel
+libtool
 libuuid-devel
 make
 meson
+nasm
 numactl-devel
 openssl-devel
 patch

--- a/toolbox/pkgs/fedora-35.txt
+++ b/toolbox/pkgs/fedora-35.txt
@@ -1,13 +1,16 @@
 CUnit-devel
+autoconf
 diffutils
 findutils
 g++
 gcc
 git
 libaio-devel
+libtool
 libuuid-devel
 make
 meson
+nasm
 numactl-devel
 openssl-devel
 patch

--- a/toolbox/pkgs/fedora-36.txt
+++ b/toolbox/pkgs/fedora-36.txt
@@ -1,13 +1,16 @@
 CUnit-devel
+autoconf
 diffutils
 findutils
 g++
 gcc
 git
 libaio-devel
+libtool
 libuuid-devel
 make
 meson
+nasm
 numactl-devel
 openssl-devel
 patch

--- a/toolbox/pkgs/freebsd-13.txt
+++ b/toolbox/pkgs/freebsd-13.txt
@@ -6,6 +6,7 @@ devel/py-pyelftools
 e2fsprogs-libuuid
 git
 gmake
+libtool
 nasm
 ncurses
 ninja

--- a/toolbox/pkgs/opensuse-leap-15.3.txt
+++ b/toolbox/pkgs/opensuse-leap-15.3.txt
@@ -1,3 +1,4 @@
+autoconf
 cunit-devel
 findutils
 gcc
@@ -7,8 +8,10 @@ gzip
 libaio-devel
 libnuma-devel
 libopenssl-devel
+libtool
 libuuid-devel
 make
+nasm
 patch
 pkg-config
 python3

--- a/toolbox/pkgs/opensuse-leap-15.4.txt
+++ b/toolbox/pkgs/opensuse-leap-15.4.txt
@@ -1,3 +1,4 @@
+autoconf
 cunit-devel
 findutils
 gcc
@@ -7,9 +8,11 @@ gzip
 libaio-devel
 libnuma-devel
 libopenssl-devel
+libtool
 libuuid-devel
 make
 meson
+nasm
 patch
 pkg-config
 python3

--- a/toolbox/pkgs/opensuse-tumbleweed-latest.txt
+++ b/toolbox/pkgs/opensuse-tumbleweed-latest.txt
@@ -1,3 +1,4 @@
+autoconf
 cunit-devel
 findutils
 gcc
@@ -7,9 +8,11 @@ gzip
 libaio-devel
 libnuma-devel
 libopenssl-devel
+libtool
 libuuid-devel
 make
 meson
+nasm
 patch
 pkg-config
 python3

--- a/toolbox/pkgs/ubuntu-bionic.sh
+++ b/toolbox/pkgs/ubuntu-bionic.sh
@@ -17,6 +17,16 @@ apt-get -qy autoclean
 # Install packages via the system package-manager (apt-get)
 apt-get install -qy $(cat "toolbox/pkgs/ubuntu-bionic.txt")
 
+# Install nasm from source
+git clone https://github.com/netwide-assembler/nasm.git
+cd nasm
+git checkout nasm-2.15
+./autogen.sh
+./configure --prefix=/usr
+make -j $(nproc)
+make install
+cd ..
+
 # Install packages via the Python package-manager (pip)
 python3 -m pip install --upgrade pip
 python3 -m pip install meson ninja pyelftools

--- a/toolbox/pkgs/ubuntu-bionic.txt
+++ b/toolbox/pkgs/ubuntu-bionic.txt
@@ -1,3 +1,4 @@
+autoconf
 build-essential
 g++-8
 gcc-8
@@ -7,6 +8,7 @@ libcunit1-dev
 libncurses5-dev
 libnuma-dev
 libssl-dev
+libtool
 nasm
 pkg-config
 python3-pip

--- a/toolbox/pkgs/ubuntu-focal.txt
+++ b/toolbox/pkgs/ubuntu-focal.txt
@@ -1,3 +1,4 @@
+autoconf
 build-essential
 g++
 gcc
@@ -7,6 +8,7 @@ libcunit1-dev
 libncurses5-dev
 libnuma-dev
 libssl-dev
+libtool
 nasm
 pkg-config
 python3

--- a/toolbox/pkgs/ubuntu-jammy.txt
+++ b/toolbox/pkgs/ubuntu-jammy.txt
@@ -1,3 +1,4 @@
+autoconf
 build-essential
 g++
 gcc
@@ -7,6 +8,7 @@ libcunit1-dev
 libncurses5-dev
 libnuma-dev
 libssl-dev
+libtool
 nasm
 pkg-config
 python3


### PR DESCRIPTION
With the next release isa-l will be mandatory in SPDK.
This PR prepares for that by not disabling it in the build and adjusting the pkg-installation scripts in ``toolbox``.
Only the Debian pkg-scripts have been updated at this point, expecting build errors on the other distros.