### PR TITLE
be:linux:libaio: add spin-while-waiting

### DIFF
--- a/include/xnvme_be_linux_libaio.h
+++ b/include/xnvme_be_linux_libaio.h
@@ -11,7 +11,8 @@ struct xnvme_queue_libaio {
 	io_context_t aio_ctx;
 	struct io_event *aio_events;
 
-	uint8_t rsvd[213];
+	uint8_t poll_io;
+	uint8_t rsvd[212];
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_queue_libaio) == XNVME_BE_QUEUE_STATE_NBYTES,
 		    "Incorrect size")


### PR DESCRIPTION
The libaio backend implementation conservatively waits for at least a
single I/O to complete and a timespec to put an upper bound on how long
it waits. Such usage of the Linux aio interface is common as it
conserves CPU utilization.

However, one can trade CPU utilization for reduced latency and increased
IO rate by repeatedly calling io_getevents() with a min-value of 0. This
commit enables such behavior via the "poll_io" option for the libaio
backend implementation.