### PR TITLE
ci,toolbox: add ramdisk testing

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -466,6 +466,59 @@ jobs:
         python3 -m pip install -r python/xnvme-cy-bindings/xnvme/cython_bindings/tests/requirements.txt --user
         python3 -m pytest --pyargs xnvme.cython_bindings -k 'test_version' -s
 
+    #
+    # Ramdisk testing
+    #
+    # skipping on distros with too old gcc/clang to build fio, and too old a Python to run cijoe
+    #
+    - name: Remove any existing cijoe installation and install from toolbox
+      if: (!(contains(matrix.container.ver, 'centos7') || contains(matrix.container.ver, 'opensuse') || contains(matrix.container.ver,
+        'buster') || contains(matrix.container.ver, 'bionic') || contains(matrix.container.ver, 'focal') || contains(matrix.container.ver,
+        '15.4') || contains(matrix.container.ver, '15.3') || contains(matrix.container.os, 'gentoo')))
+      run: |
+        python3 -m pip uninstall cijoe cijoe-pkg-xnvme cijoe-pkg-linux cijoe-pkg-qemu cijoe-pkg-example -y
+        python3 -m pip list
+        python3 -m pip install cijoe --upgrade
+        pushd toolbox/cijoe-pkg-xnvme && make all && popd
+        cijoe -r
+
+    - name: Install fio
+      if: (!(contains(matrix.container.ver, 'centos7') || contains(matrix.container.ver, 'opensuse') || contains(matrix.container.ver,
+        'buster') || contains(matrix.container.ver, 'bionic') || contains(matrix.container.ver, 'focal') || contains(matrix.container.ver,
+        '15.4') || contains(matrix.container.ver, '15.3') || contains(matrix.container.os, 'gentoo')))
+      run: |
+        cd subprojects/fio
+        ./configure --disable-xnvme --prefix=/opt/fio
+        make -j $(nproc)
+        make install
+
+    - name: Adjust the cijoe-configuration to match the location of the fio engine
+      if: (!(contains(matrix.container.ver, 'centos7') || contains(matrix.container.ver, 'opensuse') || contains(matrix.container.ver,
+        'buster') || contains(matrix.container.ver, 'bionic') || contains(matrix.container.ver, 'focal') || contains(matrix.container.ver,
+        '15.4') || contains(matrix.container.ver, '15.3') || contains(matrix.container.os, 'gentoo')))
+      run: |
+        sed -i "s|path: /usr/local.*|path: $(pkg-config xnvme --variable=libdir)/libxnvme-fio-engine.so|" toolbox/workflow/configs/ramdisk.config
+
+    - name: CIJOE, run test-ramdisk.workflow
+      if: (!(contains(matrix.container.ver, 'centos7') || contains(matrix.container.ver, 'opensuse') || contains(matrix.container.ver,
+        'buster') || contains(matrix.container.ver, 'bionic') || contains(matrix.container.ver, 'focal') || contains(matrix.container.ver,
+        '15.4') || contains(matrix.container.ver, '15.3') || contains(matrix.container.os, 'gentoo')))
+      run: |
+        cd toolbox/workflow && cijoe \
+        --config "configs/ramdisk.config" \
+        --workflow "test-ramdisk.workflow" \
+        --output "test-${{ matrix.container.os }}-${{ matrix.container.ver }}"
+
+    - name: CIJOE, upload test-ramdisk-report
+      uses: actions/upload-artifact@v2
+      if: (!(contains(matrix.container.ver, 'centos7') || contains(matrix.container.ver, 'opensuse') || contains(matrix.container.ver,
+        'buster') || contains(matrix.container.ver, 'bionic') || contains(matrix.container.ver, 'focal') || contains(matrix.container.ver,
+        '15.4') || contains(matrix.container.ver, '15.3') || contains(matrix.container.os, 'gentoo')))
+      with:
+        name: test-ramdisk-${{ matrix.container.os }}-${{ matrix.container.ver }}
+        path: toolbox/workflow/test-${{ matrix.container.os }}-${{ matrix.container.ver }}/*
+        if-no-files-found: error
+
   #
   # Build on macOS
   #
@@ -833,4 +886,3 @@ jobs:
         name: docgen-results-${{ matrix.guest.os }}-${{ matrix.guest.ver }}
         path: toolbox/workflow/docgen-${{ matrix.guest.os }}-${{ matrix.guest.ver }}/*
         if-no-files-found: error
-

--- a/lib/xnvme_buf.c
+++ b/lib/xnvme_buf.c
@@ -13,6 +13,7 @@ xnvme_buf_virt_alloc(size_t alignment, size_t nbytes)
 {
 	if (!nbytes) {
 		errno = EINVAL;
+		XNVME_DEBUG("FAILED: invalid value for nbytes: '%zu')", nbytes);
 		return NULL;
 	}
 	// nbytes has to be a multiple of alignment. Therefore, we round up to the nearest

--- a/tests/lblk.c
+++ b/tests/lblk.c
@@ -30,7 +30,7 @@ boilerplate(struct xnvmec *cli, uint8_t **wbuf, uint8_t **rbuf, size_t *buf_nbyt
 	*rng_slba = cli->args.slba;
 	*rng_elba = cli->args.elba;
 
-	*mdts_naddr = XNVME_MIN(geo->mdts_nbytes / geo->lba_nbytes, 256);
+	*mdts_naddr = XNVME_MAX(XNVME_MIN(geo->mdts_nbytes / geo->lba_nbytes, 256), 1);
 	*buf_nbytes = (*mdts_naddr) * geo->lba_nbytes;
 
 	// Construct a range if none is given

--- a/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/conftest.py
+++ b/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/conftest.py
@@ -41,20 +41,21 @@ def xnvme_be_opts(options=None, only_labels=[]):
                 for be_admin in opts["admin"]:
                     for be_sync in opts["sync"]:
                         for be_async in opts["async"]:
+
                             for label in opts["label"]:
                                 if only_labels and label not in only_labels:
                                     continue
 
-                                all_configs.append(
-                                    {
-                                        "be": be,
-                                        "mem": be_mem,
-                                        "admin": be_admin,
-                                        "sync": be_sync,
-                                        "async": be_async,
-                                        "label": label,
-                                    }
-                                )
+                            all_configs.append(
+                                {
+                                    "be": be,
+                                    "mem": be_mem,
+                                    "admin": be_admin,
+                                    "sync": be_sync,
+                                    "async": be_async,
+                                    "label": opts["label"],
+                                }
+                            )
 
     filtered = []
     for cfg in all_configs:
@@ -118,7 +119,7 @@ def xnvme_setup(labels=[], opts=[]):
     )
 
     for be_opts in combinations:
-        search = labels + [be_opts["label"]]
+        search = labels + be_opts["label"]
         device = cijoe_config_get_device(search)
 
         dstr = device["uri"] if device else "None"

--- a/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/tools/test_xnvme.py
+++ b/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/tools/test_xnvme.py
@@ -62,6 +62,8 @@ def test_idfy_cs(cijoe, device, be_opts, cli_args):
 
     if be_opts["be"] == "linux" and be_opts["admin"] in ["block"]:
         pytest.skip(reason="[admin=block] does not implement idfy-cs")
+    if "ramdisk" in device["labels"]:
+        pytest.skip(reason="[be=ramdisk] does not implement idfy-cs")
 
     err, _ = cijoe.run(f"xnvme idfy-cs {cli_args}")
     assert not err
@@ -72,6 +74,8 @@ def test_format(cijoe, device, be_opts, cli_args):
 
     if be_opts["be"] == "linux" and be_opts["admin"] in ["block"]:
         pytest.skip(reason="[admin=block] does not implement format")
+    if "ramdisk" in device["labels"]:
+        pytest.skip(reason="[be=ramdisk] does not implement format")
 
     err, _ = cijoe.run(f"xnvme format {cli_args}")
     assert not err
@@ -93,7 +97,9 @@ def test_sanitize(cijoe, device, be_opts, cli_args):
 def test_log_erri(cijoe, device, be_opts, cli_args):
 
     if be_opts["be"] == "linux" and be_opts["admin"] in ["block"]:
-        pytest.skip(reason="[admin=block] does not implement health-log")
+        pytest.skip(reason="[admin=block] does not implement error-log")
+    if "ramdisk" in device["labels"]:
+        pytest.skip(reason="[be=ramdisk] does not implement error-log")
 
     err, _ = cijoe.run(f"xnvme log-erri {cli_args} --nsid {device['nsid']}")
     assert not err
@@ -104,6 +110,8 @@ def test_log_health(cijoe, device, be_opts, cli_args):
 
     if be_opts["be"] == "linux" and be_opts["admin"] in ["block"]:
         pytest.skip(reason="[admin=block] does not implement health-log")
+    if "ramdisk" in device["labels"]:
+        pytest.skip(reason="[be=ramdisk] does not implement health-log")
 
     # Check the controller
     err, _ = cijoe.run(f"xnvme log-health {cli_args} --nsid 0xFFFFFFFF")
@@ -117,7 +125,9 @@ def test_log_health(cijoe, device, be_opts, cli_args):
 def test_log(cijoe, device, be_opts, cli_args):
 
     if be_opts["be"] == "linux" and be_opts["admin"] in ["block"]:
-        pytest.skip(reason="[admin=block] does not implement get_log")
+        pytest.skip(reason="[admin=block] does not implement get-log")
+    if "ramdisk" in device["labels"]:
+        pytest.skip(reason="[be=ramdisk] does not implement get-log")
 
     lid, lsp, lpo_nbytes, rae, nbytes = "0x1", "0x0", 0, 0, 4096
 
@@ -133,6 +143,8 @@ def test_feature_get(cijoe, device, be_opts, cli_args):
 
     if be_opts["be"] == "linux" and be_opts["admin"] in ["block"]:
         pytest.skip(reason="[admin=block] does not implement feature-get")
+    if "ramdisk" in device["labels"]:
+        pytest.skip(reason="[be=ramdisk] does not implement feature-get")
 
     for fid, descr in [("0x4", "Temperature threshold"), ("0x5", "Error recovery")]:
         # Get fid without setting select-bit
@@ -148,6 +160,9 @@ def test_feature_get(cijoe, device, be_opts, cli_args):
 @xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
 def test_feature_set(cijoe, device, be_opts, cli_args):
 
+    if "ramdisk" in device["labels"]:
+        pytest.skip(reason="[be=ramdisk] does not implement feature-set")
+
     err, _ = cijoe.run(f"xnvme feature-set {cli_args} --fid 0x4 --feat 0x1 --save")
 
     if be_opts["admin"] == "block":
@@ -162,6 +177,8 @@ def test_padc(cijoe, device, be_opts, cli_args):
 
     if be_opts["be"] == "linux" and be_opts["admin"] in ["block"]:
         pytest.skip(reason="[admin=block] does not support admin-passthru")
+    if "ramdisk" in device["labels"]:
+        pytest.skip(reason="[be=ramdisk] does not implement this admin-opcode")
 
     opcode = "0x02"
     cns = "0x1"

--- a/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/xnvme_be_combinations.py
+++ b/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/xnvme_be_combinations.py
@@ -8,6 +8,15 @@ def get_combinations():
     }
 
     combos["linux"] = [
+        # Ramdisk
+        {
+            "be": ["ramdisk"],
+            "admin": ["ramdisk"],
+            "async": ["emu", "thrpool"],
+            "mem": ["posix"],
+            "sync": ["ramdisk"],
+            "label": ["bdev", "ramdisk"],
+        },
         # File-based I/O
         {
             "be": ["linux"],

--- a/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/xnvme_be_combinations.py
+++ b/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/xnvme_be_combinations.py
@@ -60,7 +60,15 @@ def get_combinations():
             "async": ["nvme"],
             "sync": ["nvme"],
             "admin": ["nvme"],
-            "label": ["pcie", "fabrics"],
+            "label": ["pcie"],
+        },
+        {
+            "be": ["spdk"],
+            "mem": ["spdk"],
+            "async": ["nvme"],
+            "sync": ["nvme"],
+            "admin": ["nvme"],
+            "label": ["fabrics"],
         },
     ]
     if False:

--- a/toolbox/workflow/configs/debian-bullseye.config
+++ b/toolbox/workflow/configs/debian-bullseye.config
@@ -137,6 +137,12 @@ devices:
   driver_attachment: "kernel"
   spdk_conf:
 
+- uri: "2GB"
+  nsid: 1
+  labels: ["dev", "bdev", "nvm", "ramdisk"]
+  driver_attachment: "kernel"
+  spdk_conf:
+
 xnvme:
   repository:
     upstream: "https://github.com/OpenMPDK/xNVMe.git"

--- a/toolbox/workflow/configs/freebsd-13.config
+++ b/toolbox/workflow/configs/freebsd-13.config
@@ -110,6 +110,12 @@ devices:
   driver_attachment: "kernel"
   spdk_conf:
 
+- uri: "2GB"
+  nsid: 1
+  labels: ["dev", "bdev", "nvm", "ramdisk"]
+  driver_attachment: "kernel"
+  spdk_conf:
+
 xnvme:
   repository:
     upstream: "https://github.com/OpenMPDK/xNVMe.git"

--- a/toolbox/workflow/configs/ramdisk.config
+++ b/toolbox/workflow/configs/ramdisk.config
@@ -1,0 +1,45 @@
+---
+devices:
+- uri: "2GB"
+  nsid: 1
+  labels: ["dev", "bdev", "nvm", "ramdisk"]
+  driver_attachment: "kernel"
+  spdk_conf:
+
+xnvme:
+  repository:
+    upstream: "https://github.com/OpenMPDK/xNVMe.git"
+    path: "/root/git/xnvme"
+
+  source:
+    path: "/tmp/xnvme_source"
+
+# Declaration of where fio is located on the test-target and which IO-engines it has available
+fio:
+  repository:
+    upstream: "https://github.com/axboe/fio.git"
+    path: "/root/git/fio"
+    tag: "fio-3.32"
+
+  build:
+    prefix: "/opt/fio"
+
+  bin: "/opt/fio/bin/fio"
+
+  engines:
+    libaio:
+      type: builtin
+    io_uring:
+      type: builtin
+    io_uring_cmd:
+      type: builtin
+
+    xnvme:
+      path: /usr/local/lib/x86_64-linux-gnu/libxnvme-fio-engine.so
+      type: external_dynamic
+    spdk_nvme:
+      path: /opt/aux/spdk_nvme
+      type: external_preload
+    spdk_bdev:
+      path: /opt/aux/spdk_bdev
+      type: external_preload

--- a/toolbox/workflow/test-ramdisk.workflow
+++ b/toolbox/workflow/test-ramdisk.workflow
@@ -1,0 +1,16 @@
+---
+doc: |
+  Test xNVMe using the ramdisk backend
+
+  Configuration
+  =============
+
+  * The tests utilize fio and thus the configuration must point to where custom fio is located
+  * The test **should** otherwise run without any system dependencies as they only utilize the
+    "ramdisk" backend
+
+steps:
+- name: test
+  uses: core.testrunner
+  with:
+    args: '--pyargs cijoe.xnvme.tests -k "ramdisk"'


### PR DESCRIPTION
There is currently no tests of the ramdisk functionality. This adds basic testing of it by:

* Add skip of tests for functionality the ramdisk does not implement
* Add the ramdisk to pytest-parametrization via xnvme_be_combinations
* Add a cijoe-configuration for running tests on local environment using the ramdisk
* Add a workflow running tests using the ramdisk

Additionally, the ``test-ramdisk.workflow`` is executed on Linux Distributions with recent Python and gcc.

This is useful in itself, and additionally a preparation for running full memory-leak checks with ``valgrind`` and other runtime-checkers as this will enable checks of the "upper-half" of xNVMe, that is, the helper-APIs and the backend factory.

This is also done as an enabler for PRs:

* https://github.com/OpenMPDK/xNVMe/pull/144
* https://github.com/OpenMPDK/xNVMe/pull/128

Such that there is infra for verifying the behavior of those two additions.