### PR TITLE
Misc. ci and testing

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -503,6 +503,7 @@ jobs:
       if: (!(contains(matrix.container.ver, 'centos7') || contains(matrix.container.ver, 'opensuse') || contains(matrix.container.ver,
         'buster') || contains(matrix.container.ver, 'bionic') || contains(matrix.container.ver, 'focal') || contains(matrix.container.ver,
         '15.4') || contains(matrix.container.ver, '15.3') || contains(matrix.container.os, 'gentoo')))
+      continue-on-error: true
       run: |
         cd toolbox/workflow && cijoe \
         --config "configs/ramdisk.config" \

--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,26 @@ gen-src-archive:
 	$(MESON) dist -C $(BUILD_DIR) --include-subprojects --no-tests --formats gztar
 	@echo "## xNVMe: make gen-src-archive [DONE]"
 
+define gen-artifacts
+# Generate artifacts in "/tmp/artifacts" for local guest provisoning
+#
+# This is a helper to produce the set of files used by toolbox/workflows/provision.workflow
+# The set of files would usually be downloaded from the CI build-artifacts, however, this helper
+# provides the means to perform local provisioning without downloading files.
+endef
+.PHONY: gen-artifacts
+gen-artifacts: gen-src-archive
+	@echo "## xNVMe: make gen-artifacts"
+	@cd python/xnvme-cy-bindings && make clean build-py-env build-sdist
+	@mkdir -p /tmp/artifacts
+	@ls -l /tmp/artifacts
+	@cp builddir/meson-dist/xnvme-$(PROJECT_VER).tar.gz /tmp/artifacts/xnvme.tar.gz
+	@cp python/xnvme-core/dist/xnvme-core-$(PROJECT_VER).tar.gz /tmp/artifacts/xnvme-core.tar.gz
+	@cp python/xnvme-cy-header/dist/xnvme-cy-header-$(PROJECT_VER).tar.gz /tmp/artifacts/xnvme-cy-header.tar.gz
+	@cp python/xnvme-cy-bindings/dist/xnvme-cy-bindings-$(PROJECT_VER).tar.gz /tmp/artifacts/xnvme-cy-bindings.tar.gz
+	@ls -l /tmp/artifacts
+	@echo "## xNVMe: make gen-artifacts [DONE]"
+
 define gen-bash-completions-help
 # Helper-target to produce Bash-completions for tools (tools, examples, tests)
 #

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ GIT = $$( \
 
 BUILD_DIR?=builddir
 TOOLBOX_DIR?=toolbox
-PROJECT_VER = $(( python3 $(TOOLBOX_DIR)/xnvme_ver.py --path meson.build ))
+PROJECT_VER = $$( python3 $(TOOLBOX_DIR)/xnvme_ver.py --path meson.build )
 
 define default-help
 # invoke: 'make info', 'make tags', 'make git-setup', 'make config' and 'make build'
@@ -152,14 +152,13 @@ endef
 .PHONY: info
 info:
 	@echo "## xNVMe: make info"
-	@echo "OSTYPE: $(OSTYPE)"
 	@echo "PLATFORM: $(PLATFORM)"
 	@echo "CC: $(CC)"
 	@echo "CXX: $(CXX)"
 	@echo "MAKE: $(MAKE)"
 	@echo "CTAGS: $(CTAGS)"
 	@echo "NPROC: $(NPROC)"
-	@echo "PROJECT_VER: $(PROTECT_VER)"
+	@echo "PROJECT_VER: $(PROJECT_VER)"
 	@echo "## xNVMe: make info [DONE]"
 
 define build-help

--- a/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/apps/test_fio.py
+++ b/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/apps/test_fio.py
@@ -13,5 +13,10 @@ def test_fio_engine(cijoe, device, be_opts, cli_args):
 
     fio_output_fpath = Path("/tmp/fio-output.txt")
 
-    err, _ = fio_fancy(cijoe, fio_output_fpath, "verify", "xnvme", device, be_opts)
+    # size = "64M"
+    size = "1G"
+
+    err, _ = fio_fancy(
+        cijoe, fio_output_fpath, "verify", "xnvme", device, be_opts, {}, {"size": size}
+    )
     assert not err

--- a/toolbox/workflow/provision.workflow
+++ b/toolbox/workflow/provision.workflow
@@ -23,6 +23,8 @@ steps:
 
 - name: start
   uses: qemu.guest_start_nvme
+#  with:
+#    nvme_img_root: '/tmp'
 
 - name: check
   run: |

--- a/toolbox/workflow/test-debian-bullseye.workflow
+++ b/toolbox/workflow/test-debian-bullseye.workflow
@@ -6,7 +6,22 @@ steps:
 - name: sysinfo
   uses: linux.sysinfo
 
-- name: test
+- name: test_ramdisk
   uses: core.testrunner
   with:
-    args: '--pyargs cijoe.xnvme.tests'
+    args: '--pyargs cijoe.xnvme.tests -k "ramdisk"'
+
+- name: test_os
+  uses: core.testrunner
+  with:
+    args: '--pyargs cijoe.xnvme.tests -k "(not ramdisk) and (not pcie) and (not fabrics)"'
+
+- name: test_pcie
+  uses: core.testrunner
+  with:
+    args: '--pyargs cijoe.xnvme.tests -k "pcie"'
+
+- name: test_fabrics
+  uses: core.testrunner
+  with:
+    args: '--pyargs cijoe.xnvme.tests -k "fabrics"'


### PR DESCRIPTION
This PR contains a handful of changes to CI and testing which either improves or prepares for further improvement.
Please see the commit-messages for details.
Additional notes are also provided below.

# Reduce time spent on switching driver attachment

At the time of creating this PR then a testrun consumed about 2 hours of wall-clock time. This is an attempt at cutting that down.

- [x] Each test checks whether switching driver-attachment is needed and switches accordingly. This side-effect task consumes a lot of time. To improve this, then tests are grouped to run for all instances requiring a certain configuration. This has cut +30min of the testing time.

# Reduce time spent doing I/O

To reduce the time spent, the goal was to make emulated I/O faster. Currently attempted:

* Running qemu with qcow-images on ``tmpfs``
* Running qemu with qcow-images on ``/dev/shm``

Surprisingly, neither of these approaches, although much faster on a local system, does not yield the same benefits when executed via the GitHUB Runner. This might be due to virtualization and/or container-overhead for I/O. The root cause have not been found.

Another approach now, is to take the most time-consuming tests using ``fio`` and reduce the amount of I/O they do. By reducing the verify-job from 1GB to 64M. This is not ideal as it reduces the confidence of tests, it would be preferable to figure out the issue with the lack of memory-backed ``tmpfs`` or ``/dev/shm``.

# Artifact generation

When provisioning a guest locally for development, then using the ``provision.workflow`` requires "artfiacts" to exist in "/tmp/artifacts". The intent when provisioning locally is that one downloads the artifacts from a failed run to reproduce it locally. However, it is often useful to generate that same set of artifacts locally. In this PR there is a change providing a ``make gen-artifacts`` helper to do exactly that.