### PR TITLE
Reduce CI wall-clock

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -317,8 +317,18 @@ jobs:
 
     - name: Python sdist-packages, build(xnvme-core, xnvme-cy-header, and xnvme-cy-bindings)
       run: |
-        cd python/xnvme-cy-bindings
-        make clean build-py-env build-sdist
+        pushd python/xnvme-core
+        make clean build
+        popd
+
+        pushd python/xnvme-cy-header
+        make clean build
+        popd
+
+        pushd python/xnvme-cy-bindings
+        # Explicitly avoid bdist build
+        make clean .build-py-env build-sdist
+        popd
 
     - name: Python sdist-packages, find(...)
       run: |

--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ endef
 .PHONY: gen-artifacts
 gen-artifacts: gen-src-archive
 	@echo "## xNVMe: make gen-artifacts"
-	@cd python/xnvme-cy-bindings && make clean build-py-env build-sdist
+	@cd python/xnvme-cy-bindings && make clean .build-py-env build-sdist
 	@mkdir -p /tmp/artifacts
 	@ls -l /tmp/artifacts
 	@cp builddir/meson-dist/xnvme-$(PROJECT_VER).tar.gz /tmp/artifacts/xnvme.tar.gz

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,0 +1,81 @@
+#
+# This Makefile serves as convenient command-line auto-completion when working on Python bindings
+#
+#
+
+define default-help
+# invoke: 'make uninstall', 'make install'
+endef
+.PHONY: default
+default: build
+	@echo "## py: make default"
+	@echo "## py: make default [DONE]"
+
+
+define all-help
+# Do the common task during development of: uninstall clean build install
+endef
+.PHONY: all
+all: uninstall clean build install
+
+define build-help
+# Call build on all subpackages
+endef
+.PHONY: build
+build:
+	@cd xnvme-core && make build
+	@cd xnvme-cy-header && make build
+	@cd xnvme-cy-bindings && make build
+
+
+define install-help
+# install all subpackages for current user
+endef
+.PHONY: install
+install:
+	@cd xnvme-core && make install
+	@cd xnvme-cy-header && make install
+	@cd xnvme-cy-bindings && make install
+
+define install-system-help
+# install all subpackages system-wide
+endef
+.PHONY: install-system
+install-system:
+	@cd xnvme-core && make install-system
+	@cd xnvme-cy-header && make install-system
+	@cd xnvme-cy-bindings && make install-system
+
+define uninstall-help
+# uninstall all subpackages
+#
+# Prefix with 'sudo' when uninstalling a system-wide installation
+endef
+.PHONY: uninstall
+uninstall:
+	@cd xnvme-core && make uninstall
+	@cd xnvme-cy-header && make uninstall
+	@cd xnvme-cy-bindings && make uninstall
+
+define clean-help
+# clean all subpackages
+endef
+.PHONY: clean
+clean:
+	@cd xnvme-core && make clean
+	@cd xnvme-cy-header && make clean
+	@cd xnvme-cy-bindings && make clean
+
+define help-help
+# Print the description of every target
+endef
+.PHONY: help
+help:
+	@./$(TOOLBOX_DIR)/print_help.py --repos .
+
+define help-verbose-help
+# Print the verbose description of every target
+endef
+.PHONY: help-verbose
+help-verbose:
+	@./$(TOOLBOX_DIR)/print_help.py --verbose --repos .

--- a/python/xnvme-core/Makefile
+++ b/python/xnvme-core/Makefile
@@ -18,11 +18,10 @@ default: build
 	@echo "## py: make default"
 	@echo "## py: make default [DONE]"
 
-define build-py-env-help
+define .build-py-env-help
 # Init python build virtual env
 endef
-.PHONY: build-py-env
-build-py-env:
+.build-py-env:
 	@echo "Creating Python virtual env"
 	@${PY} -m venv .build-py-env
 	@echo "Upgrading pip"
@@ -30,7 +29,7 @@ build-py-env:
 	@echo "Install python dependencies"
 	@${PY_ENV} -m pip install -r requirements.txt
 
-define build-help
+define all-help
 # Do the common task during development of: uninstall clean build install test
 endef
 .PHONY: all
@@ -40,7 +39,7 @@ define build-help
 # Generate ctypes, patch them, then create a source package
 endef
 .PHONY: build
-build: build-py-env generate-ctypes patch-ctypes
+build: .build-py-env generate-ctypes patch-ctypes
 	@echo "## py: make build-sdist"
 	@${PY_ENV} setup.py sdist
 	@echo "Rename 'xnvme-m.m.p.tar.gz' to 'xnvme-core-m.m.p.tar.gz'"
@@ -69,8 +68,6 @@ uninstall:
 
 define install-system-help
 # install system-wide
-#
-# install system-wide
 endef
 .PHONY: install-system
 install-system:
@@ -91,7 +88,7 @@ define generate-ctypes-help
 # Generate definitions (xnvme_ctypes.header) from xNVMe public C API headers
 endef
 .PHONY: generate-ctypes
-generate-ctypes: build-py-env
+generate-ctypes: .build-py-env
 	@echo "## py: gen"
 	@echo "## py:headers: ${XNVME_CAPI_HEADERS}"
 	@${PY_ENV_ACTIVATE} && clang2py ${XNVME_CAPI_HEADERS} --clang-args="-I../../include -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/ " > xnvme/ctypes_bindings/api.py
@@ -102,7 +99,7 @@ define patch-ctypes-help
 # Patch definitions (xnvme_ctypes.header)
 endef
 .PHONY: patch-ctypes
-patch-ctypes: build-py-env
+patch-ctypes: .build-py-env
 	@echo "## py: gen"
 	@${PY_ENV} aux/patch_ctypes_bindings.py --path xnvme/ctypes_bindings/api.py
 	@${PY_ENV_ACTIVATE} && black xnvme/ctypes_bindings/api.py || echo "could not fix format"
@@ -114,17 +111,15 @@ endef
 .PHONY: clean
 clean:
 	@echo "## py: clean"
-	@rm -r .build-py-env || echo "Cannot remove => That is OK"
-	@rm -r build || echo "Cannot remove => That is OK"
-	@rm -r dist || echo "Cannot remove => That is OK"
-	@rm -r *.egg-info || echo "Cannot remove => That is OK"
-	@rm MANIFEST || echo "Cannot remove => That is OK"
-	@rm xnvme/ctypes_bindings/api.py || echo "Cannot remove => That is OK"
+	@rm -f -r .build-py-env
+	@rm -f -r build
+	@rm -f -r dist
+	@rm -f -r *.egg-info
+	@rm -f MANIFEST
+	@rm -f xnvme/ctypes_bindings/api.py
 	@echo "## py: clean [DONE]"
 
 define help-help
-# Print the description of every target
-#
 # Print the description of every target
 endef
 .PHONY: help
@@ -132,8 +127,6 @@ help:
 	@./$(TOOLBOX_DIR)/print_help.py --repos .
 
 define help-verbose-help
-# Print the verbose description of every target
-#
 # Print the verbose description of every target
 endef
 .PHONY: help-verbose

--- a/python/xnvme-cy-bindings/Makefile
+++ b/python/xnvme-cy-bindings/Makefile
@@ -18,26 +18,21 @@ default: build
 	@echo "## py: make default [DONE]"
 
 
-define build-py-env-help
+define .build-py-env-help
 # Init python build virtual env
 endef
-.PHONY: build-py-env
-build-py-env:
+.build-py-env:
 	@echo "Creating Python virtual env"
 	@${PY} -m venv .build-py-env
-	@echo "Build local version of xnvme-core"
-	@cd ../xnvme-core; make clean build
-	@echo "Build local version of xnvme-cy-header"
-	@cd ../xnvme-cy-header; make clean build
 	@echo "Upgrading pip"
 	@${PY_ENV} -m pip install --upgrade pip setuptools
-	@echo "Install local version of xnvme-core"
+	@echo "Install local version of xnvme-core [REMEMBER TO REBUILD THESE!]"
 	@${PY_ENV} -m pip install ../xnvme-core/dist/xnvme-core-*.tar.gz
 	@${PY_ENV} -m pip install ../xnvme-cy-header/dist/xnvme-cy-header-*.tar.gz
 	@echo "Install python dependencies"
 	@${PY_ENV} -m pip install -r requirements.txt
 
-define build-help
+define all-help
 # Do the common task during development of: uninstall clean build install test
 endef
 .PHONY: all
@@ -47,7 +42,7 @@ define build-help
 # Generate cython pxd, ctypes, patch them, then create a source package
 endef
 .PHONY: build
-build: build-py-env build-sdist build-bdist
+build: .build-py-env build-sdist build-bdist
 
 define build-sdist-help
 # Generate cython pxd, ctypes, patch them, then create a source package
@@ -78,7 +73,7 @@ endef
 .PHONY: install
 install:
 	@echo "## py: make install"
-	@${PY} -m pip install dist/xnvme-cy-bindings-*.tar.gz --user
+	@${PY} -m pip install dist/$(subst -,_,$(PROJECT_NAME))-*.whl --user || ${PY} -m pip install dist/${PROJECT_NAME}-*.tar.gz --user --no-build-isolation
 	@echo "## py: make install [DONE]"
 
 define uninstall-help
@@ -94,13 +89,14 @@ uninstall:
 
 define install-system-help
 # install system-wide
-#
-# install system-wide
 endef
 .PHONY: install-system
 install-system:
 	@echo "## py: make install-system"
-	@${PY} -m pip install dist/xnvme-*.tar.gz
+	@${PY} --version
+	# --force needed, as when installing a whl, it apparently sees that the local dir has the package "installed".
+	# --no-deps needed, as it tries to find xnvme on PyPi.
+	@${PY} -m pip install dist/$(subst -,_,$(PROJECT_NAME))-*.whl --force --no-deps || ${PY} -m pip install dist/${PROJECT_NAME}-*.tar.gz --no-build-isolation
 	@echo "## py: make install-system [DONE]"
 
 define test-help
@@ -118,21 +114,19 @@ endef
 .PHONY: clean
 clean:
 	@echo "## py: clean"
-	@rm -r .build-py-env || echo "Cannot remove => That is OK"
-	@rm -r build || echo "Cannot remove => That is OK"
-	@rm -r dist || echo "Cannot remove => That is OK"
-	@rm -r *.egg-info || echo "Cannot remove => That is OK"
-	@rm MANIFEST || echo "Cannot remove => That is OK"
-	@rm xnvme/cython_bindings/*.pxd || echo "Cannot remove => That is OK"
-	@rm xnvme/cython_bindings/*.pyx || echo "Cannot remove => That is OK"
-	@rm xnvme/cython_bindings/*.c || echo "Cannot remove => That is OK"
-	@rm xnvme/cython_bindings/*.so || echo "Cannot remove => That is OK"
-	@find . -name '__pycache__' -type d -exec rm -rv {} \; || echo "Cannot remove => That is OK"
+	@rm -f -r .build-py-env
+	@rm -f -r build
+	@rm -f -r dist
+	@rm -f -r *.egg-info
+	@rm -f MANIFEST
+	@rm -f xnvme/cython_bindings/*.pxd
+	@rm -f xnvme/cython_bindings/*.pyx
+	@rm -f xnvme/cython_bindings/*.c
+	@rm -f xnvme/cython_bindings/*.so
+	@find . -name '__pycache__' -type d -exec rm -frv {} \; || echo "Cannot remove __pycache__ => That is OK"
 	@echo "## py: clean [DONE]"
 
 define help-help
-# Print the description of every target
-#
 # Print the description of every target
 endef
 .PHONY: help
@@ -140,8 +134,6 @@ help:
 	@./$(TOOLBOX_DIR)/print_help.py --repos .
 
 define help-verbose-help
-# Print the verbose description of every target
-#
 # Print the verbose description of every target
 endef
 .PHONY: help-verbose

--- a/python/xnvme-cy-header/Makefile
+++ b/python/xnvme-cy-header/Makefile
@@ -16,11 +16,10 @@ default: build
 	@echo "## py: make default"
 	@echo "## py: make default [DONE]"
 
-define build-py-env-help
+define .build-py-env-help
 # Init python build virtual env
 endef
-.PHONY: build-py-env
-build-py-env:
+.build-py-env:
 	@echo "Creating Python virtual env"
 	@${PY} -m venv .build-py-env
 	@echo "Upgrading pip"
@@ -28,7 +27,7 @@ build-py-env:
 	@echo "Install python dependencies"
 	@${PY_ENV} -m pip install -r requirements.txt
 
-define build-help
+define all-help
 # Do the common task during development of: uninstall clean build install test
 endef
 .PHONY: all
@@ -38,7 +37,7 @@ define build-help
 # Generate ctypes, patch them, then create a source package
 endef
 .PHONY: build
-build: build-py-env generate-cython-libxnvme-pxd
+build: .build-py-env generate-cython-libxnvme-pxd
 	@echo "## py: make build-sdist"
 	@${PY_ENV} setup.py sdist
 	@echo "## py: make build-sdist [DONE]"
@@ -65,8 +64,6 @@ uninstall:
 
 define install-system-help
 # install system-wide
-#
-# install system-wide
 endef
 .PHONY: install-system
 install-system:
@@ -87,7 +84,7 @@ define generate-cython-libxnvme-pxd-help
 # Generate Cython C API mapping (xnvme.cython_header) from xNVMe public C API headers
 endef
 .PHONY: generate-cython-libxnvme-pxd
-generate-cython-libxnvme-pxd: build-py-env
+generate-cython-libxnvme-pxd: .build-py-env
 	@echo "## py: generate-cython-libxnvme-pxd"
 	@${PY_ENV} aux/generate_cython_header.py --src-root ../..
 	@echo "## py: generate-cython-libxnvme-pxd [DONE]"
@@ -98,16 +95,14 @@ endef
 .PHONY: clean
 clean:
 	@echo "## py: clean"
-	@rm -r .build-py-env || echo "Cannot remove => That is OK"
-	@rm -r build || echo "Cannot remove => That is OK"
-	@rm -r dist || echo "Cannot remove => That is OK"
-	@rm -r *.egg-info || echo "Cannot remove => That is OK"
-	@rm MANIFEST || echo "Cannot remove => That is OK"
+	@rm -f -r .build-py-env
+	@rm -f -r build
+	@rm -f -r dist
+	@rm -f -r *.egg-info
+	@rm -f MANIFEST
 	@echo "## py: clean [DONE]"
 
 define help-help
-# Print the description of every target
-#
 # Print the description of every target
 endef
 .PHONY: help
@@ -115,8 +110,6 @@ help:
 	@./$(TOOLBOX_DIR)/print_help.py --repos .
 
 define help-verbose-help
-# Print the verbose description of every target
-#
 # Print the verbose description of every target
 endef
 .PHONY: help-verbose

--- a/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/apps/test_fio.py
+++ b/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/apps/test_fio.py
@@ -13,8 +13,8 @@ def test_fio_engine(cijoe, device, be_opts, cli_args):
 
     fio_output_fpath = Path("/tmp/fio-output.txt")
 
-    # size = "64M"
-    size = "1G"
+    size = "64M"
+    # size = "1G"
 
     err, _ = fio_fancy(
         cijoe, fio_output_fpath, "verify", "xnvme", device, be_opts, {}, {"size": size}

--- a/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/conftest.py
+++ b/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/conftest.py
@@ -211,7 +211,9 @@ def fabrics_setup(cijoe):
     sleep(2)
 
     # Create transport
-    err, _ = cijoe.run(f"{rpc} nvmf_create_transport -t {trtype} -u 16384 -m 8 -c 8192")
+    err, _ = cijoe.run(
+        f"{rpc} nvmf_create_transport -t {trtype} -u 131072 -m 8 -c 8192 -i 524288"
+    )
     assert not err
 
     count = 1


### PR DESCRIPTION
Before this PR wall-clock was around 1hour and 30min for the debian testrun.
With this PR the wall-clock is down to 40min for the debian testrun.

Trying out:

- [x] enable ioeventfd on the emulated nvme controllers.
  - result: https://github.com/OpenMPDK/xNVMe/actions/runs/3180754612
  - no measurable impact, still at 1hour and 30min
- [x] qemu-images raw-format
  - result: they were already in raw-format, nothing to gain there.
- [x] retry /dev/shm + reducing fio work
  - result: https://github.com/OpenMPDK/xNVMe/actions/runs/3180985899
  - result: https://github.com/OpenMPDK/xNVMe/actions/runs/3181649145
  - runs out of memory with hugepages... even in combination with reducing fio-work, dropping this pursuit.
- [x] reduce fio worksize from 1GB to 64M + tweak fabrics TCP transport
  - result: https://github.com/OpenMPDK/xNVMe/actions/runs/3182172002
  - currently seeing a failure but expecting a reduction to 40 minutes
  - yup, after fix, down to 40min for the testrun.

Using ``/dev/shm`` is interesting as fio is not the only I/O test. However, fio is the one with the largest-working set e.g. 1GB. Thus reducing it should have an impact. However, won't improve anything for the other I/O test. Reducing fio might have the added benefit that less working-memory is needed, instead of writing 1GB to the device, only 64M is written, and thus, less use of ``/dev/shm``.