### PR TITLE
mk: fix gen_artifacts afte python refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ clean:
 	@echo "## xNVMe: make clean [DONE]"
 
 define clean-subprojects-help
-# Remove Meson builddir as well as running 'make clean' in all subprojects 
+# Remove Meson builddir as well as running 'make clean' in all subprojects
 endef
 .PHONY: clean-subprojects
 clean-subprojects:
@@ -284,7 +284,9 @@ endef
 .PHONY: gen-artifacts
 gen-artifacts: gen-src-archive
 	@echo "## xNVMe: make gen-artifacts"
-	@cd python/xnvme-cy-bindings && make clean .build-py-env build-sdist
+	@cd python/xnvme-core && make clean build
+	@cd python/xnvme-cy-header && make clean build
+	@cd python/xnvme-cy-bindings && make clean build-sdist
 	@mkdir -p /tmp/artifacts
 	@ls -l /tmp/artifacts
 	@cp builddir/meson-dist/xnvme-$(PROJECT_VER).tar.gz /tmp/artifacts/xnvme.tar.gz


### PR DESCRIPTION
gen_artifacts didn't correctly call build of all of the Python packages, and would fail to find the xnvme-core and xnvme-header dependencies.

Signed-off-by: Mads Ynddal <m.ynddal@samsung.com>