### PR TITLE
Enable WQ sharing (ATTACH_WQ) for SQPOLL

### DIFF
--- a/lib/xnvme_be_linux_async_liburing.c
+++ b/lib/xnvme_be_linux_async_liburing.c
@@ -130,6 +130,11 @@ xnvme_be_linux_liburing_init(struct xnvme_queue *q, int opts)
 			if (!g_sqpoll_wq.is_initialized) {
 				struct io_uring_params sqpoll_wq_params = {0};
 
+				env = getenv("XNVME_QUEUE_SQPOLL_CPU");
+				if (env) {
+					sqpoll_wq_params.flags |= IORING_SETUP_SQ_AFF;
+					sqpoll_wq_params.sq_thread_cpu = atoi(env);
+				}
 				sqpoll_wq_params.flags |= IORING_SETUP_SQPOLL;
 				sqpoll_wq_params.flags |= IORING_SETUP_SINGLE_ISSUER;
 


### PR DESCRIPTION
This PR provides the means to and changes behavior of ``async=io_uring`` and ``async=io_uring_cmd`` in the following ways:

* Share the kernel-side sqpoll thread-pool among multiple ``xnvme_queue`` instances
  * Do this by default, disable with env(``XNVME_QUEUE_SQPOLL_AWQ=0``)
* Provides control of cpu affinity for the thread-pool via environment variable ``XNVME_QUEUE_SQPOLL_CPU``
* Ads ``SINGLE_ISSUER`` optimization