### PR TITLE
Remove SLIST(sys/queue.h) from API

### DIFF
--- a/include/libxnvme.h
+++ b/include/libxnvme.h
@@ -19,7 +19,6 @@ extern "C" {
 #include <stdlib.h>
 #include <stdbool.h>
 #include <sys/types.h>
-#include <sys/queue.h>
 #include <sys/uio.h>
 #include <libxnvme_be.h>
 #include <libxnvme_dev.h>
@@ -350,11 +349,9 @@ struct xnvme_cmd_ctx {
 	///< Field containing command-options, the field is initialized by helper-functions
 	uint32_t opts;
 
-	uint8_t be_rsvd[4]; ///< Fields reserved for use by library internals
-
-	///< Field for including the command-context in BSD-style singly-linked-lists (SLIST)
-	SLIST_ENTRY(xnvme_cmd_ctx) link;
+	uint8_t be_rsvd[12]; ///< Fields reserved for use by library internals
 };
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_cmd_ctx) == 128, "Incorrect size")
 
 /**
  * Assign a callback-function and argument to be used with the given command-context

--- a/include/xnvme_queue.h
+++ b/include/xnvme_queue.h
@@ -3,12 +3,39 @@
 // SPDX-License-Identifier: Apache-2.0
 #ifndef __INTERNAL_XNVME_QUEUE_H
 #define __INTERNAL_XNVME_QUEUE_H
+#include <sys/queue.h>
+
+/**
+ * Internal command-context representation, the difference between this and the 'struct
+ * xnvme_cmd_ctx' in the public API, are that the last eight bytes of 'struct xnvme_cmd_ctx_entry'
+ * has a SLIST_ENTRY link. This is not provided in the public API to avoid issues with the
+ * availability of queue.h on various platforms, when consuming the xNVMe headers.
+ */
+struct xnvme_cmd_ctx_entry {
+	struct xnvme_spec_cmd cmd;
+	struct xnvme_spec_cpl cpl;
+
+	struct xnvme_dev *dev;
+
+	struct {
+		struct xnvme_queue *queue;
+		xnvme_queue_cb cb;
+		void *cb_arg;
+	} async;
+
+	uint32_t opts;
+
+	uint8_t be_rsvd[4];
+
+	SLIST_ENTRY(xnvme_cmd_ctx_entry) link;
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_cmd_ctx_entry) == 128, "Incorrect size")
 
 struct xnvme_queue_base {
 	struct xnvme_dev *dev; ///< Device on which the queue operates
 	uint32_t capacity;     ///< Maximum number of outstanding commands
 	uint32_t outstanding;  ///< Number of currently outstanding commands
-	SLIST_HEAD(, xnvme_cmd_ctx) pool;
+	SLIST_HEAD(, xnvme_cmd_ctx_entry) pool;
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_queue_base) == 24, "Incorrect size")
 
@@ -17,7 +44,7 @@ struct xnvme_queue {
 
 	uint8_t be_rsvd[232]; ///< Auxilary backend data
 
-	struct xnvme_cmd_ctx pool_storage[];
+	struct xnvme_cmd_ctx_entry pool_storage[];
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_queue) == XNVME_BE_QUEUE_STATE_NBYTES, "Incorrect size")
 

--- a/lib/xnvme_be_windows_dev.c
+++ b/lib/xnvme_be_windows_dev.c
@@ -12,6 +12,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <initguid.h>
 #include <windows.h>
 #include <Setupapi.h>
 #include <libxnvme_spec_fs.h>

--- a/lib/xnvme_queue.c
+++ b/lib/xnvme_queue.c
@@ -141,7 +141,7 @@ xnvme_queue_get_outstanding(struct xnvme_queue *queue)
 struct xnvme_cmd_ctx *
 xnvme_queue_get_cmd_ctx(struct xnvme_queue *queue)
 {
-	struct xnvme_cmd_ctx *ctx = SLIST_FIRST(&queue->base.pool);
+	struct xnvme_cmd_ctx *ctx = (struct xnvme_cmd_ctx *)SLIST_FIRST(&queue->base.pool);
 
 	if (!ctx) {
 		errno = ENOMEM;
@@ -156,7 +156,7 @@ xnvme_queue_get_cmd_ctx(struct xnvme_queue *queue)
 int
 xnvme_queue_put_cmd_ctx(struct xnvme_queue *queue, struct xnvme_cmd_ctx *ctx)
 {
-	SLIST_INSERT_HEAD(&queue->base.pool, ctx, link);
+	SLIST_INSERT_HEAD(&queue->base.pool, (struct xnvme_cmd_ctx_entry *)ctx, link);
 
 	return 0;
 }

--- a/python/xnvme-cy-header/auxiliary/generate_cython_header.py
+++ b/python/xnvme-cy-header/auxiliary/generate_cython_header.py
@@ -6,8 +6,6 @@ from io import StringIO
 import autopxd
 
 regex = [
-    r"s/SLIST_ENTRY\(xnvme_cmd_ctx\)/struct{struct xnvme_cmd_ctx *sle_next;}/g",
-    r"s/SLIST_HEAD\(, xnvme_cmd_ctx\)/struct{struct xnvme_cmd_ctx *slh_first;}/g",
     r"s/struct iovec\s?\*/void */g",
     # NOTE: Cython doesn't support arrays without length specified
     r"s/xnvme_be_attr item\[\]/xnvme_be_attr item[1]/g",


### PR DESCRIPTION
Now, two things:

* Removes the "SLIST" data structure from the public API
* Adds a missing header-inclusion in the Windows backend

See commit-messages for details.