### PR TITLE
test,python: mark test_max_segments_ioctl as flaky

### DIFF
--- a/python/xnvme-cy-bindings/xnvme/cython_bindings/tests/requirements.txt
+++ b/python/xnvme-cy-bindings/xnvme/cython_bindings/tests/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 numpy
 pytest-lazy-fixture
+flaky


### PR DESCRIPTION
By marking the test as flaky, and defining the conditions for a rerun, we will reduce the chance that this test fails.

Signed-off-by: Mads Ynddal <m.ynddal@samsung.com>