### PR TITLE
test,python: test_max_segments_ioctl if allocation fails

### DIFF
--- a/python/xnvme-cy-bindings/xnvme/cython_bindings/tests/test_linux_hugepage.py
+++ b/python/xnvme-cy-bindings/xnvme/cython_bindings/tests/test_linux_hugepage.py
@@ -83,9 +83,9 @@ class TestHugepage:
                 break
             xnvme.xnvme_buf_free(dev, max_segments)
         else:
-            assert (
-                None
-            ), "The buffer doesn't have more than BLK_MAX_SEGMENTS segments, as it should"
+            pytest.skip(
+                f"The buffer doesn't have more than BLK_MAX_SEGMENTS segments, as it should. The last buffer had {segment_count} segments."
+            )
 
         # Allocate buffer with a 'minimum' of segments -- anything less than BLK_MAX_SEGMENTS will do.
         # Strategy:


### PR DESCRIPTION
We cannot always consistently get a segmented buffer, as there is a bit of chance involved.

If we fail to allocate correctly, we just skip the test. This way, we will optimistically test when the buffer allocates, and otherwise, allow to pass the test without it.

Signed-off-by: Mads Ynddal <m.ynddal@samsung.com>