### PR TITLE
be: add earmark to dev_open() during enumeration

### DIFF
--- a/lib/xnvme_be_fbsd_dev.c
+++ b/lib/xnvme_be_fbsd_dev.c
@@ -20,6 +20,8 @@ xnvme_be_fbsd_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enum
 		XNVME_DEBUG("FAILED: sys_uri: %s is not supported", sys_uri);
 		return -ENOSYS;
 	}
+	struct xnvme_opts tmp_opts = *opts;
+	tmp_opts.be = xnvme_be_fbsd.attr.name;
 
 	for (int cid = 0; cid < 256; cid++) {
 		for (int nid = 0; nid < 256; nid++) {
@@ -34,7 +36,7 @@ xnvme_be_fbsd_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enum
 			}
 			snprintf(uri, XNVME_IDENT_URI_LEN - 1, "%s", path);
 
-			dev = xnvme_dev_open(uri, opts);
+			dev = xnvme_dev_open(uri, &tmp_opts);
 			if (!dev) {
 				XNVME_DEBUG("xnvme_dev_open(): %d", errno);
 				return -errno;

--- a/lib/xnvme_be_linux_dev.c
+++ b/lib/xnvme_be_linux_dev.c
@@ -288,6 +288,9 @@ xnvme_be_linux_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enu
 		return -ENOSYS;
 	}
 
+	struct xnvme_opts tmp_opts = *opts;
+	tmp_opts.be = xnvme_be_linux.attr.name;
+
 	nns = scandir("/sys/block", &ns, xnvme_path_nvme_filter, alphasort);
 	for (int ni = 0; ni < nns; ++ni) {
 		char uri[XNVME_IDENT_URI_LEN] = {0};
@@ -295,7 +298,7 @@ xnvme_be_linux_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enu
 
 		snprintf(uri, XNVME_IDENT_URI_LEN - 1, _PATH_DEV "%s", ns[ni]->d_name);
 
-		dev = xnvme_dev_open(uri, opts);
+		dev = xnvme_dev_open(uri, &tmp_opts);
 		if (!dev) {
 			XNVME_DEBUG("xnvme_dev_open(): %d", errno);
 			return -errno;
@@ -311,7 +314,7 @@ xnvme_be_linux_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enu
 
 		snprintf(uri, XNVME_IDENT_URI_LEN - 1, _PATH_DEV "%s", ns[ni]->d_name);
 
-		dev = xnvme_dev_open(uri, opts);
+		dev = xnvme_dev_open(uri, &tmp_opts);
 		if (!dev) {
 			XNVME_DEBUG("xnvme_dev_open(): %d", errno);
 			return -errno;

--- a/lib/xnvme_be_macos_dev.c
+++ b/lib/xnvme_be_macos_dev.c
@@ -127,6 +127,9 @@ xnvme_be_macos_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enu
 		return -ENOSYS;
 	}
 
+	struct xnvme_opts tmp_opts = *opts;
+	tmp_opts.be = xnvme_be_macos.attr.name;
+
 	for (int nid = 0; nid < 256; nid++) {
 		char path[128] = {0};
 		char disk_id[128] = {0};
@@ -143,7 +146,7 @@ xnvme_be_macos_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enu
 
 		snprintf(uri, XNVME_IDENT_URI_LEN - 1, "%s", path);
 
-		dev = xnvme_dev_open(uri, opts);
+		dev = xnvme_dev_open(uri, &tmp_opts);
 		if (!dev) {
 			XNVME_DEBUG("xnvme_dev_open(): %d", errno);
 			continue;

--- a/lib/xnvme_be_posix_dev.c
+++ b/lib/xnvme_be_posix_dev.c
@@ -84,7 +84,7 @@ xnvme_be_posix_dev_open(struct xnvme_dev *dev)
 		break;
 
 	case S_IFCHR:
-		XNVME_DEBUG("FAILED: open() : char-device-file");
+		XNVME_DEBUG("INFO: open() : char-device-file");
 		dev->ident.dtype = XNVME_DEV_TYPE_FS_FILE;
 		dev->ident.csi = XNVME_SPEC_CSI_FS;
 		dev->ident.nsid = 1;

--- a/lib/xnvme_be_spdk_dev.c
+++ b/lib/xnvme_be_spdk_dev.c
@@ -647,7 +647,10 @@ xnvme_be_spdk_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enum
 	}
 	XNVME_DEBUG("INFO: addr: %s, port: %d", addr, port);
 
-	ectx.opts = opts;
+	struct xnvme_opts tmp_opts = *opts;
+	tmp_opts.be = xnvme_be_spdk.attr.name;
+
+	ectx.opts = &tmp_opts;
 	ectx.enumerate_cb = cb_func;
 	ectx.cb_args = cb_args;
 

--- a/lib/xnvme_be_windows_dev.c
+++ b/lib/xnvme_be_windows_dev.c
@@ -309,6 +309,9 @@ xnvme_be_windows_enumerate(const char *sys_uri, struct xnvme_opts *opts,
 		return -ENOSYS;
 	}
 
+	struct xnvme_opts tmp_opts = *opts;
+	tmp_opts.be = xnvme_be_windows.attr.name;
+
 	int err = 0;
 	int num_devices = 0;
 	num_devices = _be_windows_populate_devices();
@@ -357,7 +360,7 @@ xnvme_be_windows_enumerate(const char *sys_uri, struct xnvme_opts *opts,
 			_stprintf_s(uri, XNVME_IDENT_URI_LEN - 1, _T("%s"), str_device_name);
 			printf("%s\n", uri);
 
-			dev = xnvme_dev_open(uri, opts);
+			dev = xnvme_dev_open(uri, &tmp_opts);
 			if (!dev) {
 				XNVME_DEBUG("xnvme_dev_open(): %d", errno);
 				return -errno;

--- a/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/logic/test_xnvme_tests_enum.py
+++ b/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/logic/test_xnvme_tests_enum.py
@@ -39,3 +39,14 @@ def test_multi_all_be(cijoe):
     XnvmeDriver.kernel_detach(cijoe)
     err, _ = cijoe.run("xnvme_tests_enum multi --count 4")
     assert not err
+
+
+def test_backend(cijoe):
+
+    XnvmeDriver.kernel_attach(cijoe)
+    err, _ = cijoe.run("xnvme_tests_enum backend")
+    assert not err
+
+    XnvmeDriver.kernel_detach(cijoe)
+    err, _ = cijoe.run("xnvme_tests_enum backend")
+    assert not err


### PR DESCRIPTION
Pass a copy of opts, with the respective backend set, to xnvme_dev_open().
This is to avoid a case where a different backend is used for
enumeration and opening the device.

Closes #127 
