### PR TITLE
py: fix void_pointer casting

### DIFF
--- a/python/xnvme-cy-bindings/auxiliary/autopxd_py_templates.py
+++ b/python/xnvme-cy-bindings/auxiliary/autopxd_py_templates.py
@@ -191,7 +191,11 @@ cdef class {block_name}(xnvme_base):
             self._self_cast_void_p(__void_p)
 
     def _self_cast_void_p(self, void_p):
-        self.pointer = <{lib_prefix}.{block_name} *> void_p.pointer
+        self.pointer = <{lib_prefix}.{block_name} *> (<uintptr_t> void_p.pointer)
+
+    def __getattr__(self, attr_name):
+        if attr_name == 'void_pointer':
+            return <uintptr_t> self.pointer
 """
 
 SETTER_TEMPLATE = """
@@ -242,7 +246,7 @@ cdef class {block_name}(xnvme_base):
     fields = [{fields}]
 
     def _self_cast_void_p(self, void_p):
-        self.pointer = <{lib_prefix}.{block_name} *> void_p.pointer
+        self.pointer = <{lib_prefix}.{block_name} *> (<uintptr_t> void_p.pointer)
 
     def _self_alloc(self):
         self.pointer = <{lib_prefix}.{block_name} *> calloc(1, sizeof({lib_prefix}.{block_name}))

--- a/python/xnvme-cy-bindings/xnvme/cython_bindings/tests/test_basics.py
+++ b/python/xnvme-cy-bindings/xnvme/cython_bindings/tests/test_basics.py
@@ -34,3 +34,20 @@ def test_ident(dev):
     ident = xnvme.xnvme_dev_get_ident(dev)
     assert ident.nsid == 1
     assert ident.to_dict()
+
+
+def test_pointers(dev):
+    # A random xNVMe object which is easy to create
+    ctx = xnvme.xnvme_cmd_ctx_from_dev(dev)
+
+    # Verify that we are pointing to the struct cmd embedded at the origin of ctx (they will share address)
+    assert ctx.void_pointer == ctx.cmd.void_pointer
+
+    # Verify that we are pointing to the struct cpl embedded at the origin of ctx + the size of cmd
+    assert ctx.void_pointer + ctx.cmd.sizeof == ctx.cpl.void_pointer
+
+    # Check pointers are well defined and stable -- i.e. not generated at each call
+    assert ctx.dev.void_pointer == ctx.dev.void_pointer
+
+    # Check that a pointer from two places to the same struct shows the same address
+    assert ctx.dev.void_pointer == xnvme.xnvme_dev_get_geo(ctx.dev).void_pointer


### PR DESCRIPTION
Fix issue with casting between encapsulated xNVMe objects in Python. Cython wouldn't do the proper casting, and cast a PyObject* instead of the integer value it represents.

Signed-off-by: Mads Ynddal <m.ynddal@samsung.com>