### PR TITLE
test:enum: add test for individual backends

### DIFF
--- a/lib/xnvme_be_posix_dev.c
+++ b/lib/xnvme_be_posix_dev.c
@@ -84,7 +84,7 @@ xnvme_be_posix_dev_open(struct xnvme_dev *dev)
 		break;
 
 	case S_IFCHR:
-		XNVME_DEBUG("FAILED: open() : char-device-file");
+		XNVME_DEBUG("INFO: open() : char-device-file");
 		dev->ident.dtype = XNVME_DEV_TYPE_FS_FILE;
 		dev->ident.csi = XNVME_SPEC_CSI_FS;
 		dev->ident.nsid = 1;

--- a/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/logic/test_xnvme_tests_enum.py
+++ b/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/logic/test_xnvme_tests_enum.py
@@ -39,3 +39,14 @@ def test_multi_all_be(cijoe):
     XnvmeDriver.kernel_detach(cijoe)
     err, _ = cijoe.run("xnvme_tests_enum multi --count 4")
     assert not err
+
+
+def test_backend(cijoe):
+
+    XnvmeDriver.kernel_attach(cijoe)
+    err, _ = cijoe.run("xnvme_tests_enum backend")
+    assert not err
+
+    XnvmeDriver.kernel_detach(cijoe)
+    err, _ = cijoe.run("xnvme_tests_enum backend")
+    assert not err


### PR DESCRIPTION
This will test if the same backend is used for enumerating and opening devices.

This is related to #127 and #190 