### PR TITLE
be/win: change xnvme installation path to '/usr'

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -717,8 +717,9 @@ jobs:
     - name: Execute xnvme commands
       shell: cmd
       run: |
-        set "PATH=%SystemDrive%\tools\msys64;!PATH!"
-        set "PATH=%SystemDrive%\tools\msys64\mingw64\bin;!PATH!"
+        set "PATH=%SystemDrive%\tools\msys64;%PATH%"
+        set "PATH=%SystemDrive%\tools\msys64\usr\bin;%PATH%"
+        set "PATH=%SystemDrive%\tools\msys64\mingw64\bin;%PATH%"
 
         xnvme.exe enum
         xnvme.exe library-info

--- a/build.bat
+++ b/build.bat
@@ -27,9 +27,9 @@ for %%i in (%*) do (
 	if "%%i"=="uninstall" set INSTALL=uninstall
 )
 
-set "PATH=%ALLUSERSPROFILE%\chocolatey\bin;!PATH!"
-set "PATH=%SystemDrive%\tools\msys64;!PATH!"
-set "PATH=%SystemDrive%\tools\msys64\mingw64\bin;!PATH!"
+set "PATH=%ALLUSERSPROFILE%\chocolatey\bin;%PATH%"
+set "PATH=%SystemDrive%\tools\msys64;%PATH%"
+set "PATH=%SystemDrive%\tools\msys64\mingw64\bin;%PATH%"
 
 
 if "%INFO%"=="info" (

--- a/build.bat
+++ b/build.bat
@@ -88,7 +88,7 @@ goto :eof
 :config
 	@echo "## xNVMe: make config"
 	@set CC=%CC%
-	%SH% -c "%MESON% setup %BUILD_DIR%"
+	%SH% -c "%MESON% setup %BUILD_DIR% --prefix=/usr"
 	@echo "## xNVMe: make config [DONE]"
 	@goto :eof
 


### PR DESCRIPTION
defined --prefix=/usr during configuration,
changing this so FIO can find xnvme components in
default path.

Signed-off-by: Rishabh Shukla <rishabh.sh@samsung.com>