### PR TITLE
Change format-specifiers to PRI-macro

### DIFF
--- a/lib/xnvme_be.c
+++ b/lib/xnvme_be.c
@@ -87,12 +87,12 @@ xnvme_lba_fpr(FILE *stream, uint64_t lba, enum xnvme_pr opts)
 
 	switch (opts) {
 	case XNVME_PR_TERSE:
-		wrtn += fprintf(stream, "0x%016lx", lba);
+		wrtn += fprintf(stream, "0x%016" PRIx64, lba);
 		break;
 
 	case XNVME_PR_DEF:
 	case XNVME_PR_YAML:
-		wrtn += fprintf(stream, "lba: 0x%016lx\n", lba);
+		wrtn += fprintf(stream, "lba: 0x%016" PRIx64 "\n", lba);
 		break;
 	}
 

--- a/lib/xnvme_geo.c
+++ b/lib/xnvme_geo.c
@@ -38,11 +38,11 @@ xnvme_geo_yaml(FILE *stream, const struct xnvme_geo *geo, int indent, const char
 	wrtn += fprintf(stream, "%*snpugrp: %u%s", indent, "", geo->npugrp, sep);
 	wrtn += fprintf(stream, "%*snpunit: %u%s", indent, "", geo->npunit, sep);
 	wrtn += fprintf(stream, "%*snzone: %u%s", indent, "", geo->nzone, sep);
-	wrtn += fprintf(stream, "%*snsect: %zu%s", indent, "", geo->nsect, sep);
+	wrtn += fprintf(stream, "%*snsect: %" PRIu64 "%s", indent, "", geo->nsect, sep);
 	wrtn += fprintf(stream, "%*snbytes: %u%s", indent, "", geo->nbytes, sep);
 	wrtn += fprintf(stream, "%*snbytes_oob: %u%s", indent, "", geo->nbytes_oob, sep);
 
-	wrtn += fprintf(stream, "%*stbytes: %zu%s", indent, "", geo->tbytes, sep);
+	wrtn += fprintf(stream, "%*stbytes: %" PRIu64 "%s", indent, "", geo->tbytes, sep);
 
 	wrtn += fprintf(stream, "%*smdts_nbytes: %u%s", indent, "", geo->mdts_nbytes, sep);
 

--- a/lib/xnvme_lba.c
+++ b/lib/xnvme_lba.c
@@ -27,10 +27,10 @@ xnvme_lba_range_fpr(FILE *stream, struct xnvme_lba_range *range, int opts)
 
 	wrtn += fprintf(stream, "\n");
 
-	wrtn += fprintf(stream, "  slba: 0x%016lx\n", range->slba);
-	wrtn += fprintf(stream, "  elba: 0x%016lx\n", range->elba);
+	wrtn += fprintf(stream, "  slba: 0x%016" PRIx64 "\n", range->slba);
+	wrtn += fprintf(stream, "  elba: 0x%016" PRIx64 "\n", range->elba);
 	wrtn += fprintf(stream, "  naddrs: %u\n", range->naddrs);
-	wrtn += fprintf(stream, "  nbytes: %zu\n", range->nbytes);
+	wrtn += fprintf(stream, "  nbytes: %" PRIu64 "\n", range->nbytes);
 	wrtn += fprintf(stream, "  attr: { is_zones: %d, is_valid: %d}\n", range->attr.is_zoned,
 			range->attr.is_valid);
 
@@ -83,12 +83,12 @@ xnvme_lba_range_from_offset_nbytes(struct xnvme_dev *dev, uint64_t offset, uint6
 	struct xnvme_lba_range rng = {0};
 
 	if (offset % geo->nbytes) {
-		XNVME_DEBUG("FAILED: offset: %zu, does not align to lba-width: %u", offset,
+		XNVME_DEBUG("FAILED: offset: %" PRIu64 ", does not align to lba-width: %u", offset,
 			    geo->nbytes);
 		return rng;
 	}
 	if (nbytes % geo->nbytes) {
-		XNVME_DEBUG("FAILED: nbytes: %zu, does not align to lba-width: %u", nbytes,
+		XNVME_DEBUG("FAILED: nbytes: %" PRIu64 ", does not align to lba-width: %u", nbytes,
 			    geo->nbytes);
 		return rng;
 	}

--- a/lib/xnvme_spec.c
+++ b/lib/xnvme_spec.c
@@ -92,16 +92,16 @@ log_erri_entry_fpr_yaml(FILE *stream, const struct xnvme_spec_log_erri_entry *en
 {
 	int wrtn = 0;
 
-	wrtn += fprintf(stream, "%*secnt: %zu%s", indent, "", entry->ecnt, sep);
+	wrtn += fprintf(stream, "%*secnt: %" PRIu64 "%s", indent, "", entry->ecnt, sep);
 	wrtn += fprintf(stream, "%*ssqid: %u%s", indent, "", entry->sqid, sep);
 	wrtn += fprintf(stream, "%*scid: %u%s", indent, "", entry->cid, sep);
 	wrtn += fprintf(stream, "%*sstatus: %#x%s", indent, "", entry->status.val, sep);
-	wrtn += fprintf(stream, "%*seloc: %#x%s", indent, "", entry->eloc, sep);
-	wrtn += fprintf(stream, "%*slba: %#lx%s", indent, "", entry->lba, sep);
+	wrtn += fprintf(stream, "%*seloc: %#" PRIx16 "%s", indent, "", entry->eloc, sep);
+	wrtn += fprintf(stream, "%*slba: %#" PRIx64 "%s", indent, "", entry->lba, sep);
 	wrtn += fprintf(stream, "%*snsid: %u%s", indent, "", entry->nsid, sep);
 	wrtn += fprintf(stream, "%*sven_si: %#x%s", indent, "", entry->ven_si, sep);
 	wrtn += fprintf(stream, "%*strtype: %#x%s", indent, "", entry->trtype, sep);
-	wrtn += fprintf(stream, "%*scmd_si: %#lx%s", indent, "", entry->cmd_si, sep);
+	wrtn += fprintf(stream, "%*scmd_si: %#" PRIx64 "%s", indent, "", entry->cmd_si, sep);
 	wrtn += fprintf(stream, "%*strtype_si: %#x", indent, "", entry->trtype_si);
 
 	return wrtn;
@@ -272,8 +272,10 @@ xnvme_spec_idfy_ctrl_fpr(FILE *stream, const struct xnvme_spec_idfy_ctrlr *idfy,
 	wrtn += fprintf(stream, "  hmpre: %d\n", idfy->hmpre);
 	wrtn += fprintf(stream, "  hmmin: %d\n", idfy->hmmin);
 	// TODO: present these better
-	wrtn += fprintf(stream, "  tnvmcap: [%zu, %zu]\n", idfy->tnvmcap[0], idfy->tnvmcap[1]);
-	wrtn += fprintf(stream, "  unvmcap: [%zu, %zu]\n", idfy->unvmcap[0], idfy->unvmcap[1]);
+	wrtn += fprintf(stream, "  tnvmcap: [%" PRIu64 ", %" PRIu64 "]\n", idfy->tnvmcap[0],
+			idfy->tnvmcap[1]);
+	wrtn += fprintf(stream, "  unvmcap: [%" PRIu64 ", %" PRIu64 "]\n", idfy->unvmcap[0],
+			idfy->unvmcap[1]);
 	wrtn += fprintf(stream, "  rpmbs: %#x\n", idfy->rpmbs.val);
 	wrtn += fprintf(stream, "  edstt: %d\n", idfy->edstt);
 	wrtn += fprintf(stream, "  dsto: %d\n", idfy->dsto.val);
@@ -294,7 +296,8 @@ xnvme_spec_idfy_ctrl_fpr(FILE *stream, const struct xnvme_spec_idfy_ctrlr *idfy,
 	wrtn += fprintf(stream, "  pels: %d\n", idfy->pels);
 	wrtn += fprintf(stream, "  domain_identifier: %d\n", idfy->domain_identifier);
 	// TODO: present these better
-	wrtn += fprintf(stream, "  megcap: [%zu, %zu]\n", idfy->megcap[0], idfy->megcap[1]);
+	wrtn += fprintf(stream, "  megcap: [%" PRIu64 ", %" PRIu64 "]\n", idfy->megcap[0],
+			idfy->megcap[1]);
 	wrtn += fprintf(stream, "  sqes: %#x\n", idfy->sqes.val);
 	wrtn += fprintf(stream, "  cqes: %#x\n", idfy->cqes.val);
 	wrtn += fprintf(stream, "  maxcmd: %d\n", idfy->maxcmd);
@@ -311,7 +314,8 @@ xnvme_spec_idfy_ctrl_fpr(FILE *stream, const struct xnvme_spec_idfy_ctrlr *idfy,
 	wrtn += fprintf(stream, "  sgls: %#x\n", idfy->sgls.val);
 	wrtn += fprintf(stream, "  mnan: %d\n", idfy->mnan);
 	// TODO: present these better
-	wrtn += fprintf(stream, "  maxdna: [%zu, %zu]\n", idfy->maxdna[0], idfy->maxdna[1]);
+	wrtn += fprintf(stream, "  maxdna: [%" PRIu64 ", %" PRIu64 "]\n", idfy->maxdna[0],
+			idfy->maxdna[1]);
 	wrtn += fprintf(stream, "  maxcna: %d\n", idfy->maxcna);
 	wrtn += fprintf(stream, "  subnqn: '%-.*s'\n", (int)sizeof(idfy->subnqn), idfy->subnqn);
 
@@ -348,9 +352,9 @@ xnvme_spec_idfy_ns_fpr(FILE *stream, const struct xnvme_spec_idfy_ns *idfy, int 
 	}
 
 	wrtn += fprintf(stream, "\n");
-	wrtn += fprintf(stream, "  nsze: %zu\n", idfy->nsze);
-	wrtn += fprintf(stream, "  ncap: %zu\n", idfy->ncap);
-	wrtn += fprintf(stream, "  nuse: %zu\n", idfy->nuse);
+	wrtn += fprintf(stream, "  nsze: %" PRIu64 "\n", idfy->nsze);
+	wrtn += fprintf(stream, "  ncap: %" PRIu64 "\n", idfy->ncap);
+	wrtn += fprintf(stream, "  nuse: %" PRIu64 "\n", idfy->nuse);
 	wrtn += fprintf(stream, "  nlbaf: %d\n", idfy->nlbaf);
 
 	wrtn += fprintf(stream, "  nsfeat:\n");
@@ -388,8 +392,8 @@ xnvme_spec_idfy_ns_fpr(FILE *stream, const struct xnvme_spec_idfy_ns *idfy, int 
 	wrtn += fprintf(stream, "  nabspf: %#x\n", idfy->nabspf);
 	wrtn += fprintf(stream, "  noiob: %#x\n", idfy->noiob);
 	wrtn += fprintf(stream, "  nvmcap:\n");
-	wrtn += fprintf(stream, "    - %zu\n", idfy->nvmcap[0]);
-	wrtn += fprintf(stream, "    - %zu\n", idfy->nvmcap[1]);
+	wrtn += fprintf(stream, "    - %" PRIu64 "\n", idfy->nvmcap[0]);
+	wrtn += fprintf(stream, "    - %" PRIu64 "\n", idfy->nvmcap[1]);
 	wrtn += fprintf(stream, "  npwg: %#x\n", idfy->npwg);
 	wrtn += fprintf(stream, "  npwa: %#x\n", idfy->npwa);
 	wrtn += fprintf(stream, "  npdg: %#x\n", idfy->npdg);
@@ -411,7 +415,7 @@ xnvme_spec_idfy_ns_fpr(FILE *stream, const struct xnvme_spec_idfy_ns *idfy, int 
 	}
 	wrtn += fprintf(stream, "]\n");
 
-	wrtn += fprintf(stream, "  eui64: %zu\n", idfy->eui64);
+	wrtn += fprintf(stream, "  eui64: %" PRIu64 "\n", idfy->eui64);
 	wrtn += fprintf(stream, "  # ms: meta-data-size-in-nbytes\n");
 	wrtn += fprintf(stream, "  # ds: data-size in 2^ds bytes\n");
 	wrtn += fprintf(stream, "  # rp: relative performance 00b, 1b 10b, 11b\n");
@@ -464,7 +468,7 @@ xnvme_spec_idfy_cs_fpr(FILE *stream, const struct xnvme_spec_idfy_cs *idfy, int 
 		wrtn += fprintf(stream, "\n");
 		wrtn += fprintf(stream, "  - { ");
 		wrtn += fprintf(stream, "iocsci: %d, ", i);
-		wrtn += fprintf(stream, "val: 0x%lx, ", iocscv->val);
+		wrtn += fprintf(stream, "val: 0x%" PRIx64 ", ", iocscv->val);
 		wrtn += fprintf(stream, "nvm: %d, ", iocscv->nvm);
 		wrtn += fprintf(stream, "zns: %d", iocscv->zns);
 		wrtn += fprintf(stream, " }");
@@ -536,9 +540,9 @@ xnvme_spec_cmd_fpr(FILE *stream, struct xnvme_spec_cmd *cmd, int opts)
 		wrtn += fprintf(stream, "  nsid: %#04x\n", cmd->common.nsid);
 		wrtn += fprintf(stream, "  cdw02: %#04x\n", cdw[2]);
 		wrtn += fprintf(stream, "  cdw03: %#04x\n", cdw[3]);
-		wrtn += fprintf(stream, "  mptr: %#08lx\n", cmd->common.mptr);
-		wrtn += fprintf(stream, "  prp1: %#08lx\n", cmd->common.dptr.prp.prp1);
-		wrtn += fprintf(stream, "  prp2: %#08lx\n", cmd->common.dptr.prp.prp2);
+		wrtn += fprintf(stream, "  mptr: %#08" PRIx64 "\n", cmd->common.mptr);
+		wrtn += fprintf(stream, "  prp1: %#08" PRIx64 "\n", cmd->common.dptr.prp.prp1);
+		wrtn += fprintf(stream, "  prp2: %#08" PRIx64 "\n", cmd->common.dptr.prp.prp2);
 		wrtn += fprintf(stream, "  cdw10: %#04x\n", cdw[10]);
 		wrtn += fprintf(stream, "  cdw11: %#04x\n", cdw[11]);
 		wrtn += fprintf(stream, "  cdw12: %#04x\n", cdw[12]);
@@ -613,7 +617,7 @@ lblk_scopy_fmt_zero_yaml(FILE *stream, const struct xnvme_spec_nvm_scopy_fmt_zer
 {
 	int wrtn = 0;
 
-	wrtn += fprintf(stream, "%*sslba: 0x%016lx%s", indent, "", entry->slba, sep);
+	wrtn += fprintf(stream, "%*sslba: 0x%016" PRIx64 "%s", indent, "", entry->slba, sep);
 
 	wrtn += fprintf(stream, "%*snlb: %u%s", indent, "", entry->nlb, sep);
 
@@ -938,11 +942,11 @@ xnvme_spec_znd_descr_fpr_yaml(FILE *stream, const struct xnvme_spec_znd_descr *d
 {
 	int wrtn = 0;
 
-	wrtn += fprintf(stream, "%*szslba: 0x%016lx%s", indent, "", descr->zslba, sep);
+	wrtn += fprintf(stream, "%*szslba: 0x%016" PRIx64 "%s", indent, "", descr->zslba, sep);
 
-	wrtn += fprintf(stream, "%*swp: 0x%016lx%s", indent, "", descr->wp, sep);
+	wrtn += fprintf(stream, "%*swp: 0x%016" PRIx64 "%s", indent, "", descr->wp, sep);
 
-	wrtn += fprintf(stream, "%*szcap: %zu%s", indent, "", descr->zcap, sep);
+	wrtn += fprintf(stream, "%*szcap: %" PRIu64 "%s", indent, "", descr->zcap, sep);
 
 	wrtn += fprintf(stream, "%*szt: %#x%s", indent, "", descr->zt, sep);
 
@@ -1026,7 +1030,7 @@ xnvme_spec_znd_log_changes_fpr(FILE *stream, const struct xnvme_spec_znd_log_cha
 
 	wrtn += fprintf(stream, "\n");
 	for (uint16_t idx = 0; idx < changes->nidents; ++idx) {
-		wrtn += fprintf(stream, "    - 0x%016lx\n", changes->idents[idx]);
+		wrtn += fprintf(stream, "    - 0x%016" PRIx64 "\n", changes->idents[idx]);
 	}
 
 	return wrtn;
@@ -1060,7 +1064,7 @@ xnvme_spec_znd_report_hdr_fpr(FILE *stream, const struct xnvme_spec_znd_report_h
 	}
 
 	wrtn += fprintf(stream, "\n");
-	wrtn += fprintf(stream, "  nzones: %zu\n", hdr->nzones);
+	wrtn += fprintf(stream, "  nzones: %" PRIu64 "\n", hdr->nzones);
 	wrtn += fprintf(stream, "\n");
 
 	return wrtn;
@@ -1125,7 +1129,7 @@ xnvme_spec_znd_idfy_lbafe_fpr(FILE *stream, struct xnvme_spec_znd_idfy_lbafe *zo
 		return wrtn;
 	}
 
-	wrtn += fprintf(stream, "{ zsze: %zu, zdes: %d }", zonef->zsze, zonef->zdes);
+	wrtn += fprintf(stream, "{ zsze: %" PRIu64 ", zdes: %d }", zonef->zsze, zonef->zdes);
 
 	return wrtn;
 }

--- a/lib/xnvme_znd.c
+++ b/lib/xnvme_znd.c
@@ -42,7 +42,8 @@ znd_report_init(struct xnvme_dev *dev, uint64_t slba, size_t limit, uint8_t exte
 	// Determine number of entries
 	nentries = limit ? limit : geo->nzone;
 	if (nentries > geo->nzone) {
-		XNVME_DEBUG("FAILED: nentries: %zu > geo->nzone: %u", nentries, geo->nzone);
+		XNVME_DEBUG("FAILED: nentries: %" PRIu64 " > geo->nzone: %u", nentries,
+			    geo->nzone);
 		errno = EINVAL;
 		return NULL;
 	}
@@ -121,8 +122,8 @@ xnvme_znd_report_from_dev(struct xnvme_dev *dev, uint64_t slba, size_t limit, ui
 		dbuf_nbytes += sizeof(*report);
 	} while ((dbuf_nbytes > geo->mdts_nbytes) && dbuf_nentries_max);
 
-	XNVME_DEBUG("INFO: dbuf_nentries_max: %zu", dbuf_nentries_max);
-	XNVME_DEBUG("INFO: dbuf_nbytes: %zu", dbuf_nbytes);
+	XNVME_DEBUG("INFO: dbuf_nentries_max: %" PRIu64, dbuf_nentries_max);
+	XNVME_DEBUG("INFO: dbuf_nbytes: %" PRIu64, dbuf_nbytes);
 
 	if (!dbuf_nentries_max) {
 		xnvme_buf_virt_free(report);
@@ -146,7 +147,7 @@ xnvme_znd_report_from_dev(struct xnvme_dev *dev, uint64_t slba, size_t limit, ui
 		size_t nentries =
 			XNVME_MIN(dbuf_nentries_max, ((report->zelba - zslba) / geo->nsect) + 1);
 
-		XNVME_DEBUG("INFO: nentries: %zu", nentries);
+		XNVME_DEBUG("INFO: nentries: %" PRIu64, nentries);
 		if ((!nentries) || (nentries > dbuf_nentries_max)) {
 			XNVME_DEBUG("ERR: invalid nentries");
 			break;
@@ -162,7 +163,7 @@ xnvme_znd_report_from_dev(struct xnvme_dev *dev, uint64_t slba, size_t limit, ui
 			errno = err ? -err : EIO;
 			return NULL;
 		}
-		XNVME_DEBUG("INFO: hdr->nzones: %zu", hdr->nzones);
+		XNVME_DEBUG("INFO: hdr->nzones: %" PRIu64, hdr->nzones);
 
 		if (nentries > hdr->nzones) {
 			XNVME_DEBUG("ERR: invalid nentries");
@@ -235,7 +236,7 @@ xnvme_znd_descr_from_dev(struct xnvme_dev *dev, uint64_t slba, struct xnvme_spec
 
 	hdr = (void *)dbuf;
 	if (!hdr->nzones) {
-		XNVME_DEBUG("FAILED: hdr->nzones: %zu", hdr->nzones);
+		XNVME_DEBUG("FAILED: hdr->nzones: %" PRIu64, hdr->nzones);
 		err = -EIO;
 		goto exit;
 	}
@@ -290,7 +291,7 @@ xnvme_znd_descr_from_dev_in_state(struct xnvme_dev *dev, enum xnvme_spec_znd_sta
 	dbuf_nbytes = sizeof(*hdr) + sizeof(*zdescr);
 	dbuf = xnvme_buf_alloc(dev, dbuf_nbytes);
 	if (!dbuf) {
-		XNVME_DEBUG("FAILED: xnvme_buf_alloc(%zu)", dbuf_nbytes);
+		XNVME_DEBUG("FAILED: xnvme_buf_alloc(%" PRIu64 ")", dbuf_nbytes);
 		return -errno;
 	}
 	memset(dbuf, 0, dbuf_nbytes);
@@ -305,7 +306,7 @@ xnvme_znd_descr_from_dev_in_state(struct xnvme_dev *dev, enum xnvme_spec_znd_sta
 
 	hdr = (void *)dbuf;
 	if (!hdr->nzones) {
-		XNVME_DEBUG("FAILED: hdr->nzones: %zu", hdr->nzones);
+		XNVME_DEBUG("FAILED: hdr->nzones: %" PRIu64, hdr->nzones);
 		err = -EIO;
 		goto exit;
 	}
@@ -471,17 +472,17 @@ xnvme_znd_report_fpr(FILE *stream, const struct xnvme_znd_report *report, int fl
 		return wrtn;
 	}
 
-	wrtn += fprintf(stream, "  report_nbytes: %zu\n", report->report_nbytes);
-	wrtn += fprintf(stream, "  entries_nbytes: %zu\n", report->entries_nbytes);
+	wrtn += fprintf(stream, "  report_nbytes: %" PRIu64 "\n", report->report_nbytes);
+	wrtn += fprintf(stream, "  entries_nbytes: %" PRIu64 "\n", report->entries_nbytes);
 
 	wrtn += fprintf(stream, "  zd_nbytes: %d\n", report->zd_nbytes);
 	wrtn += fprintf(stream, "  zdext_nbytes: %d\n", report->zdext_nbytes);
-	wrtn += fprintf(stream, "  zrent_nbytes: %zu\n", report->zrent_nbytes);
+	wrtn += fprintf(stream, "  zrent_nbytes: %" PRIu64 "\n", report->zrent_nbytes);
 
-	wrtn += fprintf(stream, "  zslba: 0x%016lx\n", report->zslba);
-	wrtn += fprintf(stream, "  zelba: 0x%016lx\n", report->zelba);
+	wrtn += fprintf(stream, "  zslba: 0x%016" PRIx64 "\n", report->zslba);
+	wrtn += fprintf(stream, "  zelba: 0x%016" PRIx64 "\n", report->zelba);
 
-	wrtn += fprintf(stream, "  nzones: %zu\n", report->nzones);
+	wrtn += fprintf(stream, "  nzones: %" PRIu64 "\n", report->nzones);
 	wrtn += fprintf(stream, "  nentries: %u\n", report->nentries);
 	wrtn += fprintf(stream, "  extended: %u\n", report->extended);
 

--- a/tests/ioworker.c
+++ b/tests/ioworker.c
@@ -96,11 +96,11 @@ iowork_pp(struct iowork *work)
 	printf("  io.naddr: %zu\n", work->io.naddr);
 	printf("  vectored: %d\n", work->vectored);
 	printf("  nworkers: %d\n", work->nworkers);
-	printf("  range.nbytes: %zu\n", work->range.nbytes);
-	printf("  range.naddr: %zu\n", work->range.naddr);
+	printf("  range.nbytes: %" PRIu64 "\n", work->range.nbytes);
+	printf("  range.naddr: %" PRIu64 "\n", work->range.naddr);
 	printf("  range.slba: %u\n", work->range.slba);
 	printf("  range.elba: %u\n", work->range.elba);
-	printf("  nio: %zu\n", work->nio);
+	printf("  nio: %" PRIu64 "\n", work->nio);
 
 	return 0;
 }
@@ -387,8 +387,8 @@ final(struct iowork work, int err)
 	iowork_teardown(&work);
 
 	if (err || (work.stats.nerrors) || diff) {
-		xnvmec_pinf("ERR: {err: %d, nerrs: %zu, diff: %zu}", err, work.stats.nerrors,
-			    diff);
+		xnvmec_pinf("ERR: {err: %d, nerrs: %" PRIu64 ", diff: %" PRIu64 "}", err,
+			    work.stats.nerrors, diff);
 		return EIO;
 	}
 

--- a/tests/scc.c
+++ b/tests/scc.c
@@ -227,7 +227,7 @@ _scopy_helper(struct xnvmec *cli, uint64_t tlbas)
 	xnvme_spec_nvm_scopy_source_range_pr(range, nr, XNVME_PR_DEF);
 
 	xnvmec_pinf("To:");
-	printf("sdlba: 0x%016lx\n", sdlba);
+	printf("sdlba: 0x%016" PRIx64 "\n", sdlba);
 
 	if (cli->args.clear) {
 		struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);

--- a/tools/fio-engine/xnvme_fioe.c
+++ b/tools/fio-engine/xnvme_fioe.c
@@ -865,7 +865,8 @@ static int xnvme_fioe_report_zones(struct thread_data *td, struct fio_file *f, u
 			break;
 
 		default:
-			log_err("ioeng->report_zones(%s): invalid type for zone at offset(%zu)\n",
+			log_err("ioeng->report_zones(%s): invalid type for zone at offset(%" PRIx64
+				")\n",
 				f->file_name, zbdz[idx].start);
 			err = -EIO;
 			goto exit;


### PR DESCRIPTION
The format-specificers used for hex-values e.g. lx/llx does not match the on Mac/clang. This changes the the use of those format-specifiers to use the PRIx64/PRIu64/PRIx16 macros.