### PR TITLE
be/spdk: add transport ack timeout to fabrics

### DIFF
--- a/lib/xnvme_be_spdk_dev.c
+++ b/lib/xnvme_be_spdk_dev.c
@@ -380,6 +380,7 @@ _spdk_setup_controller_opts(struct xnvme_opts *opts, const struct spdk_nvme_tran
 		ctrlr_opts->header_digest = 1;
 		ctrlr_opts->data_digest = 1;
 		ctrlr_opts->keep_alive_timeout_ms = 0;
+		ctrlr_opts->transport_ack_timeout = 16;
 		if (opts->hostnqn) {
 			strncpy(ctrlr_opts->hostnqn, opts->hostnqn, SPDK_NVMF_NQN_MAX_LEN);
 		}


### PR DESCRIPTION
Resolves #130 

This is to avoid a situation where xnvme hangs because the fabrics connection is dropped.

This solution was chosen over
spdk_nvme_ctrlr_register_timeout_callback(),
since it calls the completion callback function when it fails and allows the user to handle the error as they see fit.

The downside is that the user will potentially have to wait for the timeout twice, once when checking for command completion and again when closing the device.