### PR TITLE
toolbox/xnvme-driver: adapt syntax to bash 2.5.3

### DIFF
--- a/toolbox/xnvme-driver.sh
+++ b/toolbox/xnvme-driver.sh
@@ -469,9 +469,9 @@ function configure_linux_pci {
 function cleanup_linux {
 	shopt -s extglob nullglob
 	dirs_to_clean=""
-	dirs_to_clean="$(echo {/var/run,/tmp}/dpdk/spdk{,_pid}+([0-9])) "
+	dirs_to_clean="$(echo {/var/run,/tmp}/dpdk/spdk{,_pid}+[0-9]) "
 	if [[ -d $XDG_RUNTIME_DIR && $XDG_RUNTIME_DIR != *" "* ]]; then
-		dirs_to_clean+="$(readlink -e assert_not_empty $XDG_RUNTIME_DIR/dpdk/spdk{,_pid}+([0-9]) || true) "
+		dirs_to_clean+="$(readlink -e assert_not_empty $XDG_RUNTIME_DIR/dpdk/spdk{,_pid}+[0-9] || true) "
 	fi
 
 	files_to_clean=""
@@ -488,7 +488,7 @@ function cleanup_linux {
 	fi
 
 	shopt -s extglob
-	for fd_dir in $(echo /proc/+([0-9])); do
+	for fd_dir in $(echo /proc/+[0-9]); do
 		opened_files+="$(readlink -e assert_not_empty $fd_dir/fd/* || true)"
 	done
 	shopt -u extglob


### PR DESCRIPTION
xnvme-driver fails on FreeBSD in the CI, this is because FreeBSD is using bash 2.5.3. Which has deprecated the use of parentheses around brackets. Every instance of `([0-9])` has been changed to `[0-9]`