### PR TITLE
Add FDP changes in xNVMe

### DIFF
--- a/include/libxnvme_adm.h
+++ b/include/libxnvme_adm.h
@@ -83,6 +83,20 @@ xnvme_adm_idfy_ns_csi(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t csi,
 		      struct xnvme_spec_idfy *dbuf);
 
 /**
+ * Prepare NVMe Get Log Page command
+ *
+ * @param ctx Pointer to ::xnvme_cmd_ctx
+ * @param lid Log Page Identifier for the log to retrieve entries for
+ * @param lsp Log Specific Field for the log to retrieve entries for
+ * @param lpo_nbytes Log page Offset in BYTES
+ * @param nsid Namespace Identifier
+ * @param rae Retain Asynchronous Event, 0=Clear, 1=Retain
+ * @param dbuf_nbytes Number of BYTES to write from log-page to buf
+ */
+void
+xnvme_prep_adm_log(struct xnvme_cmd_ctx *ctx, uint8_t lid, uint8_t lsp, uint64_t lpo_nbytes,
+		   uint32_t nsid, uint8_t rae, uint32_t dbuf_nbytes);
+/**
  * Submit and wait for completion of an NVMe Get Log Page command
  *
  * @param ctx Pointer to ::xnvme_cmd_ctx

--- a/include/libxnvme_adm.h
+++ b/include/libxnvme_adm.h
@@ -115,6 +115,31 @@ xnvme_adm_log(struct xnvme_cmd_ctx *ctx, uint8_t lid, uint8_t lsp, uint64_t lpo_
 	      uint32_t nsid, uint8_t rae, void *dbuf, uint32_t dbuf_nbytes);
 
 /**
+ * Prepare NVMe Get Features (gfeat) command
+ *
+ * @param ctx Pointer to ::xnvme_cmd_ctx
+ * @param nsid Namespace identifier
+ * @param fid Feature identifier
+ * @param sel Select which value of the feature to select, that is, one of
+ * current/default/saved/supported
+ */
+void
+xnvme_prep_adm_gfeat(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t fid, uint8_t sel);
+
+/**
+ * Prepare NVMe Set Feature (sfeat) command
+ *
+ * @param ctx Pointer to ::xnvme_cmd_ctx
+ * @param nsid Namespace identifier
+ * @param fid Feature identifier (see NVMe 1.3; Figure 84)
+ * @param feat Structure defining feature attributes
+ * @param save Specify that controller shall save the attribute
+ */
+void
+xnvme_prep_adm_sfeat(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t fid, uint32_t feat,
+		     uint8_t save);
+
+/**
  * Submit and wait for completion of an NVMe Get Features (gfeat) command
  *
  * @param ctx Pointer to ::xnvme_cmd_ctx

--- a/include/libxnvme_nvm.h
+++ b/include/libxnvme_nvm.h
@@ -128,6 +128,41 @@ int
 xnvme_nvm_dsm(struct xnvme_cmd_ctx *ctx, uint32_t nsid, struct xnvme_spec_dsm_range *dsm_range,
 	      uint8_t nr, bool ad, bool idw, bool idr);
 
+/**
+ * Submit, and wait for completion of a I/O management receive command
+ *
+ * @see xnvme_cmd_opts
+ *
+ * @param ctx Pointer to command context (::xnvme_cmd_ctx)
+ * @param nsid Namespace Identifier
+ * @param mo Management operation
+ * @param mos Management operation specific field
+ * @param dbuf pointer to data-payload
+ * @param dbuf_nbytes size of the data-payload in bytes
+ *
+ * @return On success, 0 is returned. On error, negative `errno` is returned.
+ */
+int
+xnvme_nvm_mgmt_recv(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t mo, uint16_t mos, void *dbuf,
+		    uint32_t dbuf_nbytes);
+
+/**
+ * Submit, and wait for completion of a I/O management send command
+ *
+ * @see xnvme_cmd_opts
+ *
+ * @param ctx Pointer to command context (::xnvme_cmd_ctx)
+ * @param nsid Namespace Identifier
+ * @param mo Management operation
+ * @param mos Management operation specific field
+ * @param dbuf pointer to data-payload
+ * @param dbuf_nbytes size of the data-payload in bytes
+ *
+ * @return On success, 0 is returned. On error, negative `errno` is returned.
+ */
+int
+xnvme_nvm_mgmt_send(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t mo, uint16_t mos, void *dbuf,
+		    uint32_t dbuf_nbytes);
 #ifdef __cplusplus
 }
 #endif

--- a/include/libxnvme_spec.h
+++ b/include/libxnvme_spec.h
@@ -203,6 +203,182 @@ struct xnvme_spec_log_erri_entry {
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_log_erri_entry) == 64, "Incorrect size")
 
 /**
+ * NVMe Reclaim unit handle descriptor
+ *
+ * @struct xnvme_spec_ruh_desc
+ */
+struct xnvme_spec_ruh_desc {
+	uint8_t ruht; ///< Reclaim unit handle type
+	uint8_t rsvd[3];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_ruh_desc) == 4, "Incorrect size")
+
+/**
+ * NVMe FDP configuration descriptor
+ *
+ * @struct xnvme_spec_fdp_conf_desc
+ */
+struct xnvme_spec_fdp_conf_desc {
+	uint16_t ds;
+
+	/** FDP attributes */
+	union {
+		struct {
+			uint8_t rgif   : 4; ///< Reclaim group identifier format
+			uint8_t fdpvwc : 1; ///< FDP volatile write cache
+			uint8_t rsvd1  : 2;
+			uint8_t fdpcv  : 1; ///< FDP configuration valid
+		};
+		uint8_t val;
+	} fdpa;
+
+	uint8_t vss;      ///< Vendor specific size
+	uint32_t nrg;     ///< Number of reclaim groups
+	uint16_t nruh;    ///< Number of reclaim unit handles
+	uint16_t maxpids; ///< Max placement identifiers
+	uint32_t nns;     ///< Number of namespaces supported
+	uint64_t runs;    ///< Reclaim unit nominal size
+	uint32_t erutl;   ///< Estimated reclaim unit time limit
+	uint8_t rsvd28[36];
+	struct xnvme_spec_ruh_desc ruh_desc[];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_fdp_conf_desc) == 64, "Incorrect size")
+
+/**
+ * NVMe FDP configurations log page
+ *
+ * @struct xnvme_spec_log_fdp_conf
+ */
+struct xnvme_spec_log_fdp_conf {
+	uint16_t ncfg; ///< Number of FDP configurations
+	uint8_t version;
+	uint8_t rsvd1;
+	uint32_t size;
+	uint8_t rsvd2[8];
+	struct xnvme_spec_fdp_conf_desc conf_desc[];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_log_fdp_conf) == 16, "Incorrect size")
+
+/**
+ * NVMe Reclaim unit handle usage descriptor
+ *
+ * @struct xnvme_spec_ruhu_desc
+ */
+struct xnvme_spec_ruhu_desc {
+	uint8_t ruha; ///< Reclaim unit handle attributes
+	uint8_t rsvd[7];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_ruhu_desc) == 8, "Incorrect size")
+
+/**
+ * NVMe Reclaim unit handle usage log page
+ *
+ * @struct xnvme_spec_log_ruhu
+ */
+struct xnvme_spec_log_ruhu {
+	uint16_t nruh; ///< Number of Reclaim Unit Handles
+	uint8_t rsvd[6];
+	struct xnvme_spec_ruhu_desc ruhu_desc[];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_log_ruhu) == 8, "Incorrect size")
+
+/**
+ * NVMe FDP statistics log page
+ *
+ * @struct xnvme_spec_log_fdp_stats
+ */
+struct xnvme_spec_log_fdp_stats {
+	uint64_t hbmw[2]; ///< Host bytes with metadata written
+	uint64_t mbmw[2]; ///< Media bytes with metadata written
+	uint64_t mbe[2];  ///< Media bytes erased
+	uint8_t rsvd48[16];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_log_fdp_stats) == 64, "Incorrect size")
+
+/**
+ * Media reallocated
+ *
+ * @struct xnvme_spec_fdp_event_media_reallocated
+ */
+struct __attribute__((packed)) xnvme_spec_fdp_event_media_reallocated {
+	/** Specific event flags */
+	union {
+		struct {
+			uint8_t lbav : 1; ///< LLBA valid
+			uint8_t rsvd : 7;
+		};
+		uint8_t val;
+	} sef;
+
+	uint8_t rsvd1;
+	uint16_t nlbam; ///< Number of LBAs moved
+	uint64_t lba;   ///< Logical block address
+	uint8_t rsvd2[4];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_fdp_event_media_reallocated) == 16, "Incorrect size")
+
+/**
+ * NVMe FDP event
+ *
+ * @struct xnvme_spec_fdp_event
+ */
+struct __attribute__((packed)) xnvme_spec_fdp_event {
+	uint8_t type; ///< Event type
+
+	/** FDP event flags */
+	union {
+		struct {
+			uint8_t piv   : 1; ///< Placement identifier valid
+			uint8_t nsidv : 1; ///< NSID valid
+			uint8_t lv    : 1; ///< Location valid
+			uint8_t rsvd1 : 5;
+		};
+		uint8_t val;
+	} fdpef;
+
+	uint16_t pid;              ///< Placement identifier
+	uint64_t timestamp;        ///< Event timestamp
+	uint32_t nsid;             ///< Namespace identifier
+	uint8_t type_specific[16]; ///< Event type specific
+	uint16_t rgid;             ///< Reclaim group identifier
+	uint16_t ruhid;            ///< Reclaim unit handle identifier
+	uint8_t rsvd1[4];
+	uint8_t vs[24];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_fdp_event) == 64, "Incorrect size")
+
+/**
+ * NVMe FDP events log page
+ *
+ * @struct xnvme_spec_log_fdp_events
+ */
+struct xnvme_spec_log_fdp_events {
+	uint32_t nevents; ///< Number of FDP events
+	uint8_t rsvd[60];
+	struct xnvme_spec_fdp_event event[];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_log_fdp_events) == 64, "Incorrect size")
+
+/**
+ * NVMe FDP event descriptor
+ *
+ * @struct xnvme_spec_fdp_event_desc
+ */
+struct xnvme_spec_fdp_event_desc {
+	uint8_t type; ///< Event type
+
+	/** FDP event type attributes */
+	union {
+		struct {
+			uint8_t ee   : 1; ///< FDP event enabled
+			uint8_t rsvd : 7;
+		};
+		uint8_t val;
+	} fdpeta;
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_fdp_event_desc) == 2, "Incorrect size")
+
+/**
  * Identifiers (lpi) for NVMe get-log-page
  *
  * NVMe 1.4 - Figure ?
@@ -210,15 +386,61 @@ XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_log_erri_entry) == 64, "Incorrect s
  * @enum xnvme_spec_log_lpi
  */
 enum xnvme_spec_log_lpi {
-	XNVME_SPEC_LOG_RSVD      = 0x0, ///< XNVME_SPEC_LOG_RSVD
-	XNVME_SPEC_LOG_ERRI      = 0x1, ///< XNVME_SPEC_LOG_ERRI
-	XNVME_SPEC_LOG_HEALTH    = 0x2, ///< XNVME_SPEC_LOG_HEALTH
-	XNVME_SPEC_LOG_FW        = 0x3, ///< XNVME_SPEC_LOG_FW
-	XNVME_SPEC_LOG_CHNS      = 0x4, ///< XNVME_SPEC_LOG_CHNS
-	XNVME_SPEC_LOG_CSAE      = 0x5, ///< XNVME_SPEC_LOG_CSAE
-	XNVME_SPEC_LOG_SELFTEST  = 0x6, ///< XNVME_SPEC_LOG_SELFTEST
-	XNVME_SPEC_LOG_TELEHOST  = 0x7, ///< XNVME_SPEC_LOG_TELEHOST
-	XNVME_SPEC_LOG_TELECTRLR = 0x8, ///< XNVME_SPEC_LOG_TELECTRLR
+	XNVME_SPEC_LOG_RSVD      = 0x0,  ///< XNVME_SPEC_LOG_RSVD
+	XNVME_SPEC_LOG_ERRI      = 0x1,  ///< XNVME_SPEC_LOG_ERRI
+	XNVME_SPEC_LOG_HEALTH    = 0x2,  ///< XNVME_SPEC_LOG_HEALTH
+	XNVME_SPEC_LOG_FW        = 0x3,  ///< XNVME_SPEC_LOG_FW
+	XNVME_SPEC_LOG_CHNS      = 0x4,  ///< XNVME_SPEC_LOG_CHNS
+	XNVME_SPEC_LOG_CSAE      = 0x5,  ///< XNVME_SPEC_LOG_CSAE
+	XNVME_SPEC_LOG_SELFTEST  = 0x6,  ///< XNVME_SPEC_LOG_SELFTEST
+	XNVME_SPEC_LOG_TELEHOST  = 0x7,  ///< XNVME_SPEC_LOG_TELEHOST
+	XNVME_SPEC_LOG_TELECTRLR = 0x8,  ///< XNVME_SPEC_LOG_TELECTRLR
+	XNVME_SPEC_LOG_FDPCONF   = 0x20, ///< XNVME_SPEC_LOG_FDPCONF
+	XNVME_SPEC_LOG_FDPRUHU   = 0x21, ///< XNVME_SPEC_LOG_FDPRUHU
+	XNVME_SPEC_LOG_FDPSTATS  = 0x22, ///< XNVME_SPEC_LOG_FDPSTATS
+	XNVME_SPEC_LOG_FDPEVENTS = 0x23, ///< XNVME_SPEC_LOG_FDPEVENTS
+};
+
+/**
+ * @enum xnvme_spec_io_mgmt_recv_mo
+ */
+enum xnvme_spec_io_mgmt_recv_mo {
+	// Reclaim Unit Handle Status
+	XNVME_SPEC_IO_MGMT_RECV_RUHS = 0x1,
+};
+
+/**
+ * NVMe Reclaim unit handle status descriptor
+ *
+ * @struct xnvme_spec_ruhs_desc
+ */
+struct xnvme_spec_ruhs_desc {
+	uint16_t pi;     ///< Placement Identifier
+	uint16_t ruhi;   ///< Reclaim Unit Handle Identifier
+	uint32_t earutr; ///< Estimated Active Reclaim Unit Time Remaining
+	uint64_t ruamw;  ///< Reclaim Unit Available Media Writes
+	uint8_t rsvd[16];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_ruhs_desc) == 32, "Incorrect size")
+
+/**
+ * NVMe Reclaim Unit Handle Status
+ *
+ * @struct xnvme_spec_ruhs
+ */
+struct xnvme_spec_ruhs {
+	uint8_t rsvd[14];
+	uint16_t nruhsd; ///< Number of Reclaim Unit Handle Status Descriptors
+	struct xnvme_spec_ruhs_desc desc[];
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_ruhs) == 16, "Incorrect size")
+
+/**
+ * @enum xnvme_spec_io_mgmt_send_mo
+ */
+enum xnvme_spec_io_mgmt_send_mo {
+	// Reclaim Unit Handle Update
+	XNVME_SPEC_IO_MGMT_SEND_RUHU = 0x1,
 };
 
 /**
@@ -691,7 +913,12 @@ struct xnvme_spec_idfy_ctrlr {
 			/** Supports Extended lba formats */
 			uint32_t extended_lba_formats                        : 1;
 
-			uint32_t reserved                                    : 16;
+			uint32_t reserved1                                   : 3;
+
+			/** Supports flexible data placement */
+			uint32_t flexible_data_placement                     : 1;
+
+			uint32_t reserved2                                   : 12;
 		};
 		uint32_t val;
 	} ctratt;
@@ -1220,7 +1447,9 @@ enum xnvme_spec_nvm_opc {
 	XNVME_SPEC_NVM_OPC_WRITE_ZEROES        = 0x08, ///< XNVME_SPEC_NVM_OPC_WRITE_ZEROES
 	XNVME_SPEC_NVM_OPC_DATASET_MANAGEMENT  = 0x09, ///< XNVME_SPEC_NVM_OPC_DATASET_MANAGEMENT
 
-	XNVME_SPEC_NVM_OPC_SCOPY = 0x19, ///< XNVME_SPEC_NVM_OPC_SCOPY
+	XNVME_SPEC_NVM_OPC_SCOPY        = 0x19, ///< XNVME_SPEC_NVM_OPC_SCOPY
+	XNVME_SPEC_NVM_OPC_IO_MGMT_RECV = 0x12, ///< XNVME_SPEC_NVM_OPC_IO_MGMT
+	XNVME_SPEC_NVM_OPC_IO_MGMT_SEND = 0x1D, ///< XNVME_SPEC_NVM_OPC_IO_MGMT_SEND
 
 	XNVME_SPEC_NVM_OPC_FMT      = 0x80, ///< XNVME_SPEC_NVM_OPC_FMT
 	XNVME_SPEC_NVM_OPC_SANITIZE = 0x84, ///< XNVME_SPEC_NVM_OPC_SANITIZE
@@ -1234,13 +1463,15 @@ enum xnvme_spec_nvm_opc {
  * @enum xnvme_spec_feat_id
  */
 enum xnvme_spec_feat_id {
-	XNVME_SPEC_FEAT_ARBITRATION    = 0x1, ///< XNVME_SPEC_FEAT_ARBITRATION
-	XNVME_SPEC_FEAT_PWR_MGMT       = 0x2, ///< XNVME_SPEC_FEAT_PWR_MGMT
-	XNVME_SPEC_FEAT_LBA_RANGETYPE  = 0x3, ///< XNVME_SPEC_FEAT_LBA_RANGETYPE
-	XNVME_SPEC_FEAT_TEMP_THRESHOLD = 0x4, ///< XNVME_SPEC_FEAT_TEMP_THRESHOLD
-	XNVME_SPEC_FEAT_ERROR_RECOVERY = 0x5, ///< XNVME_SPEC_FEAT_ERROR_RECOVERY
-	XNVME_SPEC_FEAT_VWCACHE        = 0x6, ///< XNVME_SPEC_FEAT_VWCACHE
-	XNVME_SPEC_FEAT_NQUEUES        = 0x7, ///< XNVME_SPEC_FEAT_NQUEUES
+	XNVME_SPEC_FEAT_ARBITRATION    = 0x1,  ///< XNVME_SPEC_FEAT_ARBITRATION
+	XNVME_SPEC_FEAT_PWR_MGMT       = 0x2,  ///< XNVME_SPEC_FEAT_PWR_MGMT
+	XNVME_SPEC_FEAT_LBA_RANGETYPE  = 0x3,  ///< XNVME_SPEC_FEAT_LBA_RANGETYPE
+	XNVME_SPEC_FEAT_TEMP_THRESHOLD = 0x4,  ///< XNVME_SPEC_FEAT_TEMP_THRESHOLD
+	XNVME_SPEC_FEAT_ERROR_RECOVERY = 0x5,  ///< XNVME_SPEC_FEAT_ERROR_RECOVERY
+	XNVME_SPEC_FEAT_VWCACHE        = 0x6,  ///< XNVME_SPEC_FEAT_VWCACHE
+	XNVME_SPEC_FEAT_NQUEUES        = 0x7,  ///< XNVME_SPEC_FEAT_NQUEUES
+	XNVME_SPEC_FEAT_FDP_MODE       = 0x1D, ///< XNVME_SPEC_FEAT_FDP_MODE
+	XNVME_SPEC_FEAT_FDP_EVENTS     = 0x1E, ///< XNVME_SPEC_FEAT_FDP_EVENTS
 };
 
 /**
@@ -1307,23 +1538,35 @@ enum xnvme_spec_drecv_streams_doper {
 struct xnvme_spec_idfy_dir_rp {
 	/* Directives Supported */
 	struct {
-		uint8_t identify : 1; ///< Identify
-		uint8_t streams  : 1; ///< Streams
-		uint8_t rsvd1    : 6;
+		uint8_t identify       : 1; ///< Identify
+		uint8_t streams        : 1; ///< Streams
+		uint8_t data_placement : 1; ///< Data placement
+		uint8_t rsvd1          : 5;
 
 		uint8_t rsvd2[31];
 	} directives_supported;
 
 	/* Directives Enabled */
 	struct {
-		uint8_t identify : 1; ///< Identify
-		uint8_t streams  : 1; ///< Streams
-		uint8_t rsvd1    : 6;
+		uint8_t identify       : 1; ///< Identify
+		uint8_t streams        : 1; ///< Streams
+		uint8_t data_placement : 1; ///< Data placement
+		uint8_t rsvd1          : 5;
 
 		uint8_t rsvd2[31];
 	} directives_enabled;
 
-	uint8_t rsvd4[4032];
+	/* Directives Persistence */
+	struct {
+		uint8_t identify       : 1; ///< Identify
+		uint8_t streams        : 1; ///< Streams
+		uint8_t data_placement : 1; ///< Data placement
+		uint8_t rsvd1          : 5;
+
+		uint8_t rsvd2[31];
+	} directives_persistence;
+
+	uint8_t rsvd4[4000];
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_idfy_dir_rp) == 4096, "Incorrect size")
 
@@ -1411,6 +1654,13 @@ struct xnvme_spec_feat {
 			uint32_t nsqa : 16;
 			uint32_t ncqa : 16;
 		} nqueues;
+
+		struct {
+			uint32_t fdpe  : 1; ///< Flexible data placement enable
+			uint32_t rsvd1 : 7;
+			uint32_t fdpci : 8; ///< Flexible data placement configuration index
+			uint32_t rsvd2 : 16;
+		} fdp_mode;
 
 		uint32_t val; ///< For constructing feature without accessors
 	};
@@ -2146,6 +2396,53 @@ struct xnvme_spec_znd_cmd {
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_znd_cmd) == 64, "Incorrect size")
 
 /**
+ * NVMe Command Accessor for io management receive command
+ *
+ * @struct xnvme_spec_io_mgmt_recv_cmd
+ */
+struct xnvme_spec_io_mgmt_recv_cmd {
+	uint32_t cdw00_09[10]; ///< Command dword 0 to 9
+
+	uint32_t mo   : 8; ///< Management Operation
+	uint32_t rsvd : 8;
+	uint32_t mos  : 16; ///< Management Operation Specific
+
+	uint32_t numd; ///< cdw11
+
+	uint32_t cdw12_15[4]; ///< Command dword 12 to 15
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_io_mgmt_recv_cmd) == 64, "Incorrect size")
+
+/**
+ * NVMe Command Accessor for I/O management send
+ *
+ * @struct xnvme_spec_io_mgmt_send_cmd
+ */
+struct xnvme_spec_io_mgmt_send_cmd {
+	uint32_t cdw00_09[10]; ///< Command dword 0 to 9
+
+	uint32_t mo   : 8; ///< Management Operation
+	uint32_t rsvd : 8;
+	uint32_t mos  : 16; ///< Management Operation Specific
+
+	uint32_t cdw11_15[5]; ///< Command dword 11 to 15
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_io_mgmt_send_cmd) == 64, "Incorrect size")
+
+/**
+ * NVMe Command Accessors for I/O management
+ *
+ * @struct xnvme_spec_io_mgmt_cmd
+ */
+struct xnvme_spec_io_mgmt_cmd {
+	union {
+		struct xnvme_spec_io_mgmt_recv_cmd mgmt_recv;
+		struct xnvme_spec_io_mgmt_send_cmd mgmt_send;
+	};
+};
+XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_io_mgmt_cmd) == 64, "Incorrect size")
+
+/**
  * NVMe Command Accessors
  *
  * @struct xnvme_spec_cmd
@@ -2166,6 +2463,7 @@ struct xnvme_spec_cmd {
 		struct xnvme_spec_nvm_cmd_scopy scopy;
 		struct xnvme_spec_nvm_write_zeroes write_zeroes;
 		struct xnvme_spec_znd_cmd znd;
+		struct xnvme_spec_io_mgmt_cmd mgmt;
 	};
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_cmd) == 64, "Incorrect size")

--- a/include/libxnvme_spec.h
+++ b/include/libxnvme_spec.h
@@ -2799,6 +2799,62 @@ int
 xnvme_spec_log_erri_pr(const struct xnvme_spec_log_erri_entry *log, int limit, int opts);
 
 /**
+ * Prints the given :;xnvme_spec_log_fdp_conf to stdout
+ *
+ * @param log
+ * @param opts
+ * @return On success, the number of characters printed is returned.
+ */
+int
+xnvme_spec_log_fdp_conf_pr(const struct xnvme_spec_log_fdp_conf *log, int opts);
+
+/**
+ * Prints the given :;xnvme_spec_log_fdp_stats to stdout
+ *
+ * @param log
+ * @param opts
+ * @return On success, the number of characters printed is returned.
+ */
+int
+xnvme_spec_log_fdp_stats_pr(const struct xnvme_spec_log_fdp_stats *log, int opts);
+
+/**
+ * Prints the given :;xnvme_spec_log_fdp_events_entry to stdout
+ *
+ * @param log
+ * @param limit
+ * @param opts printer options, see ::xnvme_pr
+ * @return On success, the number of characters printed is returned.
+ */
+int
+xnvme_spec_log_fdp_events_pr(const struct xnvme_spec_log_fdp_events *log, int limit, int opts);
+
+/**
+ * Prints the given :;xnvme_spec_log_ruhu to stdout
+ *
+ * @param log
+ * @param limit
+ * @param opts printer options, see ::xnvme_pr
+ * @return On success, the number of characters printed is returned.
+ */
+int
+xnvme_spec_log_ruhu_pr(const struct xnvme_spec_log_ruhu *log, int limit, int opts);
+
+/**
+ * Prints the given :;xnvme_spec_ruhs to stdout
+ *
+ * @param ruhs
+ * @param limit
+ * @param opts printer options, see ::xnvme_pr
+ * @return On success, the number of characters printed is returned.
+ */
+int
+xnvme_spec_ruhs_pr(const struct xnvme_spec_ruhs *ruhs, int limit, int opts);
+
+/**
+ * Prints the given :;xnvme_spec_idfy_ns to the given output stream
+ *
+ * @param stream output stream used for printing
  * Prints the given :;xnvme_spec_idfy_ns to the given output stream
  *
  * @param stream output stream used for printing
@@ -2868,6 +2924,17 @@ xnvme_spec_feat_fpr(FILE *stream, uint8_t fid, struct xnvme_spec_feat feat, int 
  */
 int
 xnvme_spec_feat_pr(uint8_t fid, struct xnvme_spec_feat feat, int opts);
+
+/**
+ * Prints the :;xnvme_spec_fdp_event_desc to the given output stream
+ *
+ * @param buf Buffer which contains xnvme_spec_fdp_event_desc
+ * @param feat to get number of events
+ * @param opts printer options, see ::xnvme_pr
+ * @return On success, the number of characters printed is returned.
+ */
+int
+xnvme_spec_feat_fdp_events_pr(void *buf, struct xnvme_spec_feat feat, int opts);
 
 /**
  * Prints the given :;xnvme_spec_cmd to the given output stream

--- a/include/libxnvme_spec.h
+++ b/include/libxnvme_spec.h
@@ -1398,6 +1398,7 @@ struct xnvme_spec_feat {
 			uint32_t tmpth  : 16; ///< Temperature threshold
 			uint32_t tmpsel : 4;  ///< Threshold Temp. Select
 			uint32_t thsel  : 3;  ///< Threshold Type Select
+			uint32_t rsvd   : 9;
 		} temp_threshold;
 
 		struct {
@@ -1630,7 +1631,8 @@ struct xnvme_spec_cmd_gfeat {
 		uint32_t val;
 	} cdw10;
 
-	uint32_t cdw11_15[5]; ///< Command dword 11 to 15
+	uint32_t cdw11;       ///< Command dword 11
+	uint32_t cdw12_15[4]; ///< Command dword 12 to 15
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_cmd_gfeat) == 64, "Incorrect size")
 
@@ -1653,7 +1655,8 @@ struct xnvme_spec_cmd_sfeat {
 
 	struct xnvme_spec_feat feat; ///< Feature
 
-	uint32_t cdw12_15[4]; ///< Command dword 12 to 15
+	uint32_t cdw12;       ///< Command dword 12
+	uint32_t cdw13_15[3]; ///< Command dword 13 to 15
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_cmd_sfeat) == 64, "Incorrect size")
 

--- a/include/libxnvmec.h
+++ b/include/libxnvmec.h
@@ -255,6 +255,7 @@ struct xnvmec_args {
 	uint32_t tgtdir;
 	uint32_t nsr;
 	uint32_t lsi;
+	uint32_t pid;
 };
 
 void
@@ -410,7 +411,8 @@ enum xnvmec_opt {
 	XNVMEC_OPT_LLB = 112, ///< XNVMEC_OPT_LLB
 
 	XNVMEC_OPT_LSI = 113, ///< XNVMEC_OPT_LSI
-	XNVMEC_OPT_END = 114, ///< XNVMEC_OPT_END
+	XNVMEC_OPT_PID = 114, ///< XNVMEC_OPT_PID
+	XNVMEC_OPT_END = 115, ///< XNVMEC_OPT_END
 };
 
 /**

--- a/include/libxnvmec.h
+++ b/include/libxnvmec.h
@@ -254,6 +254,7 @@ struct xnvmec_args {
 	uint32_t endir;
 	uint32_t tgtdir;
 	uint32_t nsr;
+	uint32_t lsi;
 };
 
 void
@@ -408,7 +409,8 @@ enum xnvmec_opt {
 	XNVMEC_OPT_IDR = 111, ///< XNVMEC_OPT_IDR
 	XNVMEC_OPT_LLB = 112, ///< XNVMEC_OPT_LLB
 
-	XNVMEC_OPT_END = 113, ///< XNVMEC_OPT_END
+	XNVMEC_OPT_LSI = 113, ///< XNVMEC_OPT_LSI
+	XNVMEC_OPT_END = 114, ///< XNVMEC_OPT_END
 };
 
 /**

--- a/lib/xnvme_adm.c
+++ b/lib/xnvme_adm.c
@@ -3,6 +3,26 @@
 #include <libxnvme.h>
 #include <errno.h>
 
+void
+xnvme_prep_adm_log(struct xnvme_cmd_ctx *ctx, uint8_t lid, uint8_t lsp, uint64_t lpo_nbytes,
+		   uint32_t nsid, uint8_t rae, uint32_t dbuf_nbytes)
+{
+	uint32_t numdw;
+
+	numdw = dbuf_nbytes / sizeof(uint32_t) - 1u;
+
+	ctx->cmd.common.opcode = XNVME_SPEC_ADM_OPC_LOG;
+	ctx->cmd.common.nsid = nsid;
+
+	ctx->cmd.log.lid = lid;
+	ctx->cmd.log.lsp = lsp;
+	ctx->cmd.log.rae = rae;
+	ctx->cmd.log.numdl = numdw & 0xFFFFu;
+	ctx->cmd.log.numdu = (numdw >> 16) & 0xFFFFu;
+	ctx->cmd.log.lpou = (uint32_t)(lpo_nbytes >> 32);
+	ctx->cmd.log.lpol = (uint32_t)lpo_nbytes & 0xfffffff;
+}
+
 int
 xnvme_adm_log(struct xnvme_cmd_ctx *ctx, uint8_t lid, uint8_t lsp, uint64_t lpo_nbytes,
 	      uint32_t nsid, uint8_t rae, void *dbuf, uint32_t dbuf_nbytes)

--- a/lib/xnvme_adm.c
+++ b/lib/xnvme_adm.c
@@ -128,6 +128,26 @@ xnvme_adm_idfy_ns_csi(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t csi,
 	return xnvme_cmd_pass_admin(ctx, dbuf, dbuf_nbytes, NULL, 0x0);
 }
 
+void
+xnvme_prep_adm_gfeat(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t fid, uint8_t sel)
+{
+	ctx->cmd.common.opcode = XNVME_SPEC_ADM_OPC_GFEAT;
+	ctx->cmd.common.nsid = nsid;
+	ctx->cmd.gfeat.cdw10.fid = fid;
+	ctx->cmd.gfeat.cdw10.sel = sel;
+}
+
+void
+xnvme_prep_adm_sfeat(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t fid, uint32_t feat,
+		     uint8_t save)
+{
+	ctx->cmd.common.opcode = XNVME_SPEC_ADM_OPC_SFEAT;
+	ctx->cmd.common.nsid = nsid;
+	ctx->cmd.sfeat.cdw10.fid = fid;
+	ctx->cmd.sfeat.cdw10.save = save;
+	ctx->cmd.sfeat.feat.val = feat;
+}
+
 int
 xnvme_adm_gfeat(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t fid, uint8_t sel, void *dbuf,
 		size_t dbuf_nbytes)
@@ -149,8 +169,8 @@ xnvme_adm_sfeat(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t fid, uint32_t 
 	ctx->cmd.common.opcode = XNVME_SPEC_ADM_OPC_SFEAT;
 	ctx->cmd.common.nsid = nsid;
 	ctx->cmd.sfeat.cdw10.fid = fid;
-	ctx->cmd.sfeat.feat.val = feat;
 	ctx->cmd.sfeat.cdw10.save = save;
+	ctx->cmd.sfeat.feat.val = feat;
 
 	return xnvme_cmd_pass_admin(ctx, (void *)dbuf, dbuf_nbytes, NULL, 0x0);
 }

--- a/lib/xnvme_nvm.c
+++ b/lib/xnvme_nvm.c
@@ -149,3 +149,28 @@ xnvme_nvm_scopy(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t sdlba,
 
 	return xnvme_cmd_pass(ctx, ranges, ranges_nbytes, NULL, 0);
 }
+
+int
+xnvme_nvm_mgmt_recv(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t mo, uint16_t mos, void *dbuf,
+		    uint32_t dbuf_nbytes)
+{
+	ctx->cmd.common.opcode = XNVME_SPEC_NVM_OPC_IO_MGMT_RECV;
+	ctx->cmd.common.nsid = nsid;
+	ctx->cmd.mgmt.mgmt_recv.mo = mo;
+	ctx->cmd.mgmt.mgmt_recv.mos = mos;
+	ctx->cmd.mgmt.mgmt_recv.numd = dbuf_nbytes / sizeof(uint32_t) - 1u;
+
+	return xnvme_cmd_pass(ctx, dbuf, dbuf_nbytes, NULL, 0x0);
+}
+
+int
+xnvme_nvm_mgmt_send(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t mo, uint16_t mos, void *dbuf,
+		    uint32_t dbuf_nbytes)
+{
+	ctx->cmd.common.opcode = XNVME_SPEC_NVM_OPC_IO_MGMT_SEND;
+	ctx->cmd.common.nsid = nsid;
+	ctx->cmd.mgmt.mgmt_send.mo = mo;
+	ctx->cmd.mgmt.mgmt_send.mos = mos;
+
+	return xnvme_cmd_pass(ctx, dbuf, dbuf_nbytes, NULL, 0x0);
+}

--- a/lib/xnvme_spec.c
+++ b/lib/xnvme_spec.c
@@ -189,6 +189,243 @@ xnvme_spec_log_erri_pr(const struct xnvme_spec_log_erri_entry *log, int limit, i
 }
 
 int
+xnvme_spec_log_fdp_conf_fpr(FILE *stream, const struct xnvme_spec_log_fdp_conf *log, int opts)
+{
+	int wrtn = 0;
+
+	switch (opts) {
+	case XNVME_PR_TERSE:
+		wrtn += fprintf(stream, "# ENOSYS: opts(0x%x)", opts);
+		return wrtn;
+
+	case XNVME_PR_DEF:
+	case XNVME_PR_YAML:
+		break;
+	}
+
+	wrtn += fprintf(stream, "xnvme_spec_log_fdp_conf:");
+
+	if (!log) {
+		wrtn += fprintf(stream, " ~\n");
+		return wrtn;
+	}
+
+	wrtn += fprintf(stream, "\n");
+	wrtn += fprintf(stream, "  ncfg: %d\n", log->ncfg);
+	wrtn += fprintf(stream, "  version: %d\n", log->version);
+	wrtn += fprintf(stream, "  size: %d\n", log->size);
+
+	for (int i = 0; i <= log->ncfg; ++i) {
+		wrtn += fprintf(stream, "  config_desc: %d\n", i);
+		wrtn += fprintf(stream, "  ds: %d\n", log->conf_desc[i].ds);
+		wrtn += fprintf(stream, "  fdp attributes: {");
+		wrtn += fprintf(stream, "    rgif: %u", log->conf_desc[i].fdpa.rgif);
+		wrtn += fprintf(stream, "    fdpvwc: %u", log->conf_desc[i].fdpa.fdpvwc);
+		wrtn += fprintf(stream, "    fdpcv: %u", log->conf_desc[i].fdpa.fdpcv);
+		wrtn += fprintf(stream, "    val: %#x", log->conf_desc[i].fdpa.val);
+		wrtn += fprintf(stream, "  }\n");
+		wrtn += fprintf(stream, "  vss: %d\n", log->conf_desc[i].vss);
+		wrtn += fprintf(stream, "  nrg: %d\n", log->conf_desc[i].nrg);
+		wrtn += fprintf(stream, "  nruh: %d\n", log->conf_desc[i].nruh);
+		wrtn += fprintf(stream, "  maxpids: %d\n", log->conf_desc[i].maxpids);
+		wrtn += fprintf(stream, "  nns: %d\n", log->conf_desc[i].nns);
+		wrtn += fprintf(stream, "  runs: %" PRIu64 "\n", log->conf_desc[i].runs);
+		wrtn += fprintf(stream, "  erutl: %d\n", log->conf_desc[i].erutl);
+
+		for (int j = 0; j < log->conf_desc[i].nruh; j++) {
+			wrtn += fprintf(stream, "   - ruht[%d]: %d\n", j,
+					log->conf_desc[i].ruh_desc[j].ruht);
+		}
+	}
+
+	return wrtn;
+}
+
+int
+xnvme_spec_log_fdp_conf_pr(const struct xnvme_spec_log_fdp_conf *log, int opts)
+{
+	return xnvme_spec_log_fdp_conf_fpr(stdout, log, opts);
+}
+
+int
+xnvme_spec_log_fdp_stats_fpr(FILE *stream, const struct xnvme_spec_log_fdp_stats *log, int opts)
+{
+	int wrtn = 0;
+
+	switch (opts) {
+	case XNVME_PR_TERSE:
+		wrtn += fprintf(stream, "# ENOSYS: opts(0x%x)", opts);
+		return wrtn;
+
+	case XNVME_PR_DEF:
+	case XNVME_PR_YAML:
+		break;
+	}
+
+	wrtn += fprintf(stream, "xnvme_spec_log_fdp_stats:");
+
+	if (!log) {
+		wrtn += fprintf(stream, " ~\n");
+		return wrtn;
+	}
+
+	wrtn += fprintf(stream, "\n");
+	// TODO: present these better
+	wrtn += fprintf(stream, "  hbmw: [%" PRIu64 ", %" PRIu64 "]\n", log->hbmw[0],
+			log->hbmw[1]);
+	wrtn += fprintf(stream, "  mbmw: [%" PRIu64 ", %" PRIu64 "]\n", log->mbmw[0],
+			log->mbmw[1]);
+	wrtn += fprintf(stream, "  mbe: [%" PRIu64 ", %" PRIu64 "]\n", log->mbe[0], log->mbe[1]);
+
+	return wrtn;
+}
+
+int
+xnvme_spec_log_fdp_stats_pr(const struct xnvme_spec_log_fdp_stats *log, int opts)
+{
+	return xnvme_spec_log_fdp_stats_fpr(stdout, log, opts);
+}
+
+static inline int
+log_fdp_event_fpr_yaml(FILE *stream, const struct xnvme_spec_fdp_event *event, int indent,
+		       const char *sep)
+{
+	int wrtn = 0;
+
+	wrtn += fprintf(stream, "%*stype: %d%s", indent, "", event->type, sep);
+	wrtn += fprintf(stream, "%*sfdpef: %#x%s", indent, "", event->fdpef.val, sep);
+	wrtn += fprintf(stream, "%*spid: %d%s", indent, "", event->pid, sep);
+	wrtn += fprintf(stream, "%*stimestamp: %" PRIu64 "%s", indent, "", event->timestamp, sep);
+	wrtn += fprintf(stream, "%*snsid: %d%s", indent, "", event->nsid, sep);
+	// TODO: Event type specific field
+	wrtn += fprintf(stream, "%*srgid: %d%s", indent, "", event->rgid, sep);
+	wrtn += fprintf(stream, "%*sruhid: %d%s", indent, "", event->ruhid, sep);
+
+	return wrtn;
+}
+
+int
+xnvme_spec_log_fdp_events_fpr(FILE *stream, const struct xnvme_spec_log_fdp_events *log, int limit,
+			      int opts)
+{
+	int wrtn = 0;
+
+	switch (opts) {
+	case XNVME_PR_TERSE:
+		wrtn += fprintf(stream, "# ENOSYS: opts(0x%x)", opts);
+		return wrtn;
+
+	case XNVME_PR_DEF:
+	case XNVME_PR_YAML:
+		break;
+	}
+
+	wrtn += fprintf(stream, "xnvme_spec_log_fdp_events:\n");
+
+	if (!log) {
+		wrtn += fprintf(stream, " ~\n");
+		return wrtn;
+	}
+
+	wrtn += fprintf(stream, "  nevents: %d\n", log->nevents);
+
+	for (int i = 0; i < limit; ++i) {
+		struct xnvme_spec_fdp_event event;
+		event = log->event[i];
+		wrtn += fprintf(stream, "  - {");
+		wrtn += log_fdp_event_fpr_yaml(stream, &event, 0, ", ");
+		wrtn += fprintf(stream, "}\n");
+	}
+
+	return wrtn;
+}
+
+int
+xnvme_spec_log_fdp_events_pr(const struct xnvme_spec_log_fdp_events *log, int limit, int opts)
+{
+	return xnvme_spec_log_fdp_events_fpr(stdout, log, limit, opts);
+}
+
+int
+xnvme_spec_log_ruhu_fpr(FILE *stream, const struct xnvme_spec_log_ruhu *log, int limit, int opts)
+{
+	int wrtn = 0;
+
+	switch (opts) {
+	case XNVME_PR_TERSE:
+		wrtn += fprintf(stream, "# ENOSYS: opts(0x%x)", opts);
+		return wrtn;
+
+	case XNVME_PR_DEF:
+	case XNVME_PR_YAML:
+		break;
+	}
+
+	wrtn += fprintf(stream, "xnvme_spec_log_ruhu:\n");
+
+	if (!log) {
+		wrtn += fprintf(stream, " ~\n");
+		return wrtn;
+	}
+
+	wrtn += fprintf(stream, "  nruh: %d\n", log->nruh);
+
+	for (int i = 0; i < limit; ++i) {
+		wrtn += fprintf(stream, "  - ruhu_desc[%d]:  %#x\n", i, log->ruhu_desc[i].ruha);
+	}
+
+	return wrtn;
+}
+
+int
+xnvme_spec_log_ruhu_pr(const struct xnvme_spec_log_ruhu *log, int limit, int opts)
+{
+	return xnvme_spec_log_ruhu_fpr(stdout, log, limit, opts);
+}
+
+int
+xnvme_spec_ruhs_fpr(FILE *stream, const struct xnvme_spec_ruhs *ruhs, int limit, int opts)
+{
+	int wrtn = 0;
+
+	switch (opts) {
+	case XNVME_PR_TERSE:
+		wrtn += fprintf(stream, "# ENOSYS: opts(0x%x)", opts);
+		return wrtn;
+
+	case XNVME_PR_DEF:
+	case XNVME_PR_YAML:
+		break;
+	}
+
+	wrtn += fprintf(stream, "xnvme_spec_ruhs:\n");
+
+	if (!ruhs) {
+		wrtn += fprintf(stream, " ~\n");
+		return wrtn;
+	}
+
+	wrtn += fprintf(stream, "  nruhsd: %d\n", ruhs->nruhsd);
+
+	for (int i = 0; i < limit; ++i) {
+		wrtn += fprintf(stream, "  - ruhs_desc[%d] : {", i);
+		wrtn += fprintf(stream, " pi: %d", ruhs->desc[i].pi);
+		wrtn += fprintf(stream, " ruhi: %d", ruhs->desc[i].ruhi);
+		wrtn += fprintf(stream, " earutr: %d", ruhs->desc[i].earutr);
+		wrtn += fprintf(stream, " ruamw: %" PRIu64 "", ruhs->desc[i].ruamw);
+		wrtn += fprintf(stream, "}\n");
+	}
+
+	return wrtn;
+}
+
+int
+xnvme_spec_ruhs_pr(const struct xnvme_spec_ruhs *ruhs, int limit, int opts)
+{
+	return xnvme_spec_ruhs_fpr(stdout, ruhs, limit, opts);
+}
+
+int
 xnvme_spec_idfy_ctrl_fpr(FILE *stream, const struct xnvme_spec_idfy_ctrlr *idfy, int opts)
 {
 	int wrtn = 0;
@@ -595,6 +832,15 @@ xnvme_spec_feat_fpr(FILE *stream, uint8_t fid, struct xnvme_spec_feat feat, int 
 				feat.nqueues.ncqa);
 		return wrtn;
 
+	case XNVME_SPEC_FEAT_FDP_MODE:
+		wrtn += fprintf(stream, "feat: { fdpe: %u, fdpci: %u }\n", feat.fdp_mode.fdpe,
+				feat.fdp_mode.fdpci);
+		return wrtn;
+
+	case XNVME_SPEC_FEAT_FDP_EVENTS:
+		wrtn += fprintf(stream, "nevents: %u }\n", feat.val);
+		return wrtn;
+
 	case XNVME_SPEC_FEAT_ARBITRATION:
 	case XNVME_SPEC_FEAT_PWR_MGMT:
 	case XNVME_SPEC_FEAT_LBA_RANGETYPE:
@@ -609,6 +855,38 @@ int
 xnvme_spec_feat_pr(uint8_t fid, struct xnvme_spec_feat feat, int opts)
 {
 	return xnvme_spec_feat_fpr(stdout, fid, feat, opts);
+}
+
+int
+xnvme_spec_feat_fdp_events_fpr(FILE *stream, void *buf, struct xnvme_spec_feat feat, int opts)
+{
+	int wrtn = 0;
+
+	switch (opts) {
+	case XNVME_PR_TERSE:
+		wrtn += fprintf(stream, "# ENOSYS: opts(0x%x)", opts);
+		return wrtn;
+
+	case XNVME_PR_DEF:
+	case XNVME_PR_YAML:
+		break;
+	}
+
+	for (uint32_t i = 0; i < feat.val; i++) {
+		struct xnvme_spec_fdp_event_desc *desc =
+			&((struct xnvme_spec_fdp_event_desc *)buf)[i];
+		wrtn += fprintf(stream, "{ type: %#x, event enabled: %u }\n", desc->type,
+				desc->fdpeta.ee);
+		desc += sizeof(struct xnvme_spec_fdp_event_desc);
+	}
+
+	return wrtn;
+}
+
+int
+xnvme_spec_feat_fdp_events_pr(void *buf, struct xnvme_spec_feat feat, int opts)
+{
+	return xnvme_spec_feat_fdp_events_fpr(stdout, buf, feat, opts);
 }
 
 static int
@@ -819,9 +1097,18 @@ xnvme_spec_drecv_idfy_fpr(FILE *stream, struct xnvme_spec_idfy_dir_rp *idfy, int
 	wrtn += fprintf(stream, "  directives_supported:\n");
 	wrtn += fprintf(stream, "    identify: %d\n", idfy->directives_supported.identify);
 	wrtn += fprintf(stream, "    streams: %d\n", idfy->directives_supported.streams);
+	wrtn += fprintf(stream, "    data placement: %d\n",
+			idfy->directives_supported.data_placement);
 	wrtn += fprintf(stream, "  directives_enabled:\n");
 	wrtn += fprintf(stream, "    identify: %d\n", idfy->directives_enabled.identify);
 	wrtn += fprintf(stream, "    streams: %d\n", idfy->directives_enabled.streams);
+	wrtn += fprintf(stream, "    data_placement: %d\n",
+			idfy->directives_enabled.data_placement);
+	wrtn += fprintf(stream, "  directives_persistence:\n");
+	wrtn += fprintf(stream, "    identify: %d\n", idfy->directives_persistence.identify);
+	wrtn += fprintf(stream, "    streams: %d\n", idfy->directives_persistence.streams);
+	wrtn += fprintf(stream, "    data_placement: %d\n",
+			idfy->directives_persistence.data_placement);
 
 	return wrtn;
 }

--- a/lib/xnvme_spec_pp.c
+++ b/lib/xnvme_spec_pp.c
@@ -52,6 +52,10 @@ xnvme_spec_feat_id_str(enum xnvme_spec_feat_id eval)
 		return "FEAT_TEMP_THRESHOLD";
 	case XNVME_SPEC_FEAT_VWCACHE:
 		return "FEAT_VWCACHE";
+	case XNVME_SPEC_FEAT_FDP_MODE:
+		return "FEAT_FDP_MODE";
+	case XNVME_SPEC_FEAT_FDP_EVENTS:
+		return "FEAT_FDP_EVENTS";
 	}
 
 	return "ENOSYS";
@@ -164,6 +168,14 @@ xnvme_spec_log_lpi_str(enum xnvme_spec_log_lpi eval)
 		return "LOG_TELECTRLR";
 	case XNVME_SPEC_LOG_TELEHOST:
 		return "LOG_TELEHOST";
+	case XNVME_SPEC_LOG_FDPCONF:
+		return "LOG_FDPCONF";
+	case XNVME_SPEC_LOG_FDPRUHU:
+		return "LOG_FDPRUHU";
+	case XNVME_SPEC_LOG_FDPSTATS:
+		return "LOG_FDPSTATS";
+	case XNVME_SPEC_LOG_FDPEVENTS:
+		return "LOG_FDPEVENTS";
 	}
 
 	return "ENOSYS";
@@ -215,6 +227,10 @@ xnvme_spec_nvm_opc_str(enum xnvme_spec_nvm_opc eval)
 		return "XNVME_SPEC_NVM_OPC_DATASET_MANAGEMENT";
 	case XNVME_SPEC_NVM_OPC_FLUSH:
 		return "NVM_OPC_FLUSH";
+	case XNVME_SPEC_NVM_OPC_IO_MGMT_RECV:
+		return "XNVME_SPEC_NVM_OPC_IO_MGMT_RECV";
+	case XNVME_SPEC_NVM_OPC_IO_MGMT_SEND:
+		return "XNVME_SPEC_NVM_OPC_IO_MGMT_SEND";
 	}
 
 	return "ENOSYS";

--- a/lib/xnvmec.c
+++ b/lib/xnvmec.c
@@ -966,6 +966,12 @@ static struct xnvmec_opt_attr xnvmec_opts[] = {
 	},
 
 	{
+		.opt = XNVMEC_OPT_LSI,
+		.vtype = XNVMEC_OPT_VTYPE_HEX,
+		.name = "lsi",
+		.descr = "Log specific identifier",
+	},
+	{
 		.opt = XNVMEC_OPT_END,
 		.vtype = XNVMEC_OPT_VTYPE_NUM,
 		.name = "",
@@ -1569,6 +1575,10 @@ xnvmec_assign_arg(struct xnvmec *cli, struct xnvmec_opt_attr *opt_attr, char *ar
 	case XNVMEC_OPT_IDR:
 		args->idr = arg ? num : 1;
 		break;
+	case XNVMEC_OPT_LSI:
+		args->lsi = num;
+		break;
+
 	case XNVMEC_OPT_POSA_TITLE:
 	case XNVMEC_OPT_NON_POSA_TITLE:
 	case XNVMEC_OPT_ORCH_TITLE:

--- a/lib/xnvmec.c
+++ b/lib/xnvmec.c
@@ -972,6 +972,12 @@ static struct xnvmec_opt_attr xnvmec_opts[] = {
 		.descr = "Log specific identifier",
 	},
 	{
+		.opt = XNVMEC_OPT_PID,
+		.vtype = XNVMEC_OPT_VTYPE_HEX,
+		.name = "pid",
+		.descr = "Placement identifier",
+	},
+	{
 		.opt = XNVMEC_OPT_END,
 		.vtype = XNVMEC_OPT_VTYPE_NUM,
 		.name = "",
@@ -1577,6 +1583,9 @@ xnvmec_assign_arg(struct xnvmec *cli, struct xnvmec_opt_attr *opt_attr, char *ar
 		break;
 	case XNVMEC_OPT_LSI:
 		args->lsi = num;
+		break;
+	case XNVMEC_OPT_PID:
+		args->pid = num;
 		break;
 
 	case XNVMEC_OPT_POSA_TITLE:

--- a/python/xnvme-cy-bindings/auxiliary/autopxd_py.py
+++ b/python/xnvme-cy-bindings/auxiliary/autopxd_py.py
@@ -238,6 +238,7 @@ from libxnvme cimport {', '.join(enum_defs)}
                 "xnvme_spec_feat_fpr",  # Takes struct (not pointer) as argument
                 "xnvme_spec_feat_pr",  # Takes struct (not pointer) as argument
                 "xnvme_spec_drecv_sar_pr",  # Takes struct (not pointer) as argument
+                "xnvme_spec_feat_fdp_events_pr",  # Takes struct (not pointer) as argument
                 "xnvmec_cmd_to_file",  # Somehow causes linking issues
             ]
             if func_name in ignore_list:

--- a/python/xnvme-cy-header/auxiliary/generate_cython_header.py
+++ b/python/xnvme-cy-header/auxiliary/generate_cython_header.py
@@ -12,6 +12,11 @@ regex = [
     r"s/xnvme_ident entries\[\]/xnvme_ident entries[1]/g",
     r"s/uint8_t storage\[\]/uint8_t storage[1]/g",
     r"s/uint16_t sid\[\]/uint16_t sid[1]/g",
+    r"s/xnvme_spec_ruh_desc ruh_desc\[\]/xnvme_spec_ruh_desc ruh_desc[1]/g",
+    r"s/xnvme_spec_fdp_conf_desc conf_desc\[\]/xnvme_spec_fdp_conf_desc conf_desc[1]/g",
+    r"s/xnvme_spec_ruhu_desc ruhu_desc\[\]/xnvme_spec_ruhu_desc ruhu_desc[1]/g",
+    r"s/xnvme_spec_fdp_event event\[\]/xnvme_spec_fdp_event event[1]/g",
+    r"s/xnvme_spec_ruhs_desc desc\[\]/xnvme_spec_ruhs_desc desc[1]/g",
 ]
 
 

--- a/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/tools/test_fdp.py
+++ b/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/tools/test_fdp.py
@@ -1,0 +1,92 @@
+import pytest
+
+from ..conftest import XnvmeDriver, xnvme_parametrize
+
+pytest.skip(allow_module_level=True, reason="Not implemented")
+
+
+@xnvme_parametrize(labels=["fdp"], opts=["be", "admin"])
+def test_log_fdp(cijoe, device, be_opts, cli_args):
+
+    if be_opts["be"] == "linux" and be_opts["admin"] in ["block"]:
+        pytest.skip(reason="[admin=block] does not implement fdp log pages")
+
+    err, _ = cijoe.run(f"xnvme log-fdp-config {cli_args} --lsi 0x1 --data-nbytes 512")
+    assert not err
+
+    err, _ = cijoe.run(f"xnvme log-fdp-stats {cli_args} --lsi 0x1")
+    assert not err
+
+    err, _ = cijoe.run(f"xnvme log-ruhu {cli_args} --lsi 0x1 --limit 256")
+    assert not err
+
+    err, _ = cijoe.run(
+        # Get host events
+        f"xnvme log-fdp-events {cli_args} --nsid {device['nsid']} --lsi 0x1 --lsp 0x1 "
+        f"--limit 8"
+    )
+    assert not err
+
+
+@xnvme_parametrize(labels=["fdp"], opts=["be", "admin"])
+def test_feature_set_fdp_events(cijoe, device, be_opts, cli_args):
+
+    if be_opts["be"] == "linux" and be_opts["admin"] in ["block"]:
+        pytest.skip(reason="[admin=block] does not implement feature-get")
+
+    # Enable all FDP events (0xFF events on placement handle 0)
+    err, _ = cijoe.run(
+        f"xnvme set-fdp-events {cli_args} --fid 0x1e --feat 0xFF0000 --cdw12 0x1"
+    )
+    assert not err
+
+
+@xnvme_parametrize(labels=["fdp"], opts=["be", "admin"])
+def test_feature_get_fdp(cijoe, device, be_opts, cli_args):
+
+    if be_opts["be"] == "linux" and be_opts["admin"] in ["block"]:
+        pytest.skip(reason="[admin=block] does not implement feature-get")
+
+    # Get feature FDP (Endurance group id 0x1 on qemu)
+    err, _ = cijoe.run(f"xnvme feature-get {cli_args} --fid 0x1d --cdw11 0x1")
+    assert not err
+
+    # Get feature FDP events (0xFF events for placement handle 0)
+    err, _ = cijoe.run(
+        f"xnvme feature-get {cli_args} --fid 0x1e --cdw11 0xFF0000 --data-nbytes 512"
+    )
+    assert not err
+
+
+@xnvme_parametrize(labels=["fdp"], opts=["be", "admin", "sync"])
+def test_ruhs(cijoe, device, be_opts, cli_args):
+
+    if be_opts["be"] == "linux" and be_opts["sync"] in ["psync", "block"]:
+        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do mgmt send/receive")
+
+    err, _ = cijoe.run(f"xnvme fdp-ruhs {cli_args} --limit 256")
+    assert not err
+
+
+@xnvme_parametrize(labels=["fdp"], opts=["be", "admin", "sync"])
+def test_write_dir(cijoe, device, be_opts, cli_args):
+
+    if be_opts["be"] == "linux" and be_opts["sync"] in ["psync", "block"]:
+        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do write with directives")
+
+    # Write (DPD) to placement id 0x0
+    err, _ = cijoe.run(
+        f"lblk write-dir {cli_args} --slba 0x0 --nlb 2 --dtype 0x2 --dspec 0x0"
+    )
+    assert not err
+
+
+@xnvme_parametrize(labels=["fdp"], opts=["be", "admin", "sync"])
+def test_ruhu(cijoe, device, be_opts, cli_args):
+
+    if be_opts["be"] == "linux" and be_opts["sync"] in ["psync", "block"]:
+        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do mgmt send/receive")
+
+    # Reclaim unit handle update for Placement id 0x0)
+    err, _ = cijoe.run(f"xnvme fdp-ruhu {cli_args} --pid 0x0")
+    assert not err

--- a/tools/xnvme.c
+++ b/tools/xnvme.c
@@ -387,17 +387,33 @@ sub_gfeat(struct xnvmec *cli)
 	uint8_t fid = cli->args.fid;
 	uint8_t sel = cli->args.sel;
 	uint32_t nsid = cli->args.nsid;
+	uint32_t cdw11 = cli->args.cdw[11];
+	void *dbuf = NULL;
+	size_t dbuf_nbytes = cli->args.data_nbytes;
 	int err;
 
 	if (!cli->given[XNVMEC_OPT_NSID]) {
 		nsid = xnvme_dev_get_nsid(cli->args.dev);
 	}
 
+	if (dbuf_nbytes) {
+		dbuf = xnvme_buf_alloc(dev, dbuf_nbytes);
+		if (!dbuf) {
+			err = -errno;
+			xnvmec_perr("xnvme_buf_alloc()", err);
+			goto exit;
+		}
+		memset(dbuf, 0, dbuf_nbytes);
+	}
+
 	xnvmec_pinf("cmd_gfeat: {nsid: 0x%x, fid: 0x%x, sel: 0x%x}", nsid, fid, sel);
 
-	err = xnvme_adm_gfeat(&ctx, nsid, fid, sel, NULL, 0);
+	xnvme_prep_adm_gfeat(&ctx, nsid, fid, sel);
+	ctx.cmd.gfeat.cdw11 = cdw11;
+
+	err = xnvme_cmd_pass_admin(&ctx, dbuf, dbuf_nbytes, NULL, 0x0);
 	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
-		xnvmec_perr("xnvme_adm_gfeat()", err);
+		xnvmec_perr("xnvme_cmd_pass_admin()", err);
 		xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
 		err = err ? err : -EIO;
 		goto exit;
@@ -408,8 +424,18 @@ sub_gfeat(struct xnvmec *cli)
 		xnvme_spec_feat_pr(fid, feat, XNVME_PR_DEF);
 	}
 
+	if (cli->args.data_output) {
+		xnvmec_pinf("dumping to: '%s'", cli->args.data_output);
+		err = xnvmec_buf_to_file(dbuf, dbuf_nbytes, cli->args.data_output);
+		if (err) {
+			xnvmec_perr("xnvmec_buf_to_file()", err);
+		}
+	}
+
 exit:
-	return err;
+	if (dbuf)
+		xnvme_buf_free(dev, dbuf);
+	return 0;
 }
 
 static int
@@ -421,20 +447,52 @@ sub_sfeat(struct xnvmec *cli)
 	uint32_t feat = cli->args.feat;
 	uint8_t save = cli->args.save;
 	uint32_t nsid = cli->args.nsid;
+	uint32_t cdw12 = cli->args.cdw[12];
+	void *dbuf = NULL;
+	size_t dbuf_nbytes = 0;
 	int err;
 
 	if (!cli->given[XNVMEC_OPT_NSID]) {
 		nsid = xnvme_dev_get_nsid(cli->args.dev);
 	}
 
-	xnvmec_pinf("cmd_sfeat: {nsid: 0%x, fid: 0x%x, feat: 0x%x, 0x%x}", nsid, fid, feat, save);
+	if (cli->args.data_input) {
+		if (!cli->args.data_nbytes) {
+			err = -EINVAL;
+			xnvmec_perr("require data bytes", err);
+			goto exit;
+		}
 
-	err = xnvme_adm_sfeat(&ctx, 0, fid, feat, 0, NULL, 0);
+		dbuf_nbytes = cli->args.data_nbytes;
+		dbuf = xnvme_buf_alloc(dev, dbuf_nbytes);
+		if (!dbuf) {
+			err = -errno;
+			xnvmec_perr("xnvme_buf_alloc()", err);
+			goto exit;
+		}
+		err = xnvmec_buf_fill(dbuf, dbuf_nbytes, cli->args.data_input);
+		if (err) {
+			xnvmec_perr("xnvmec_buf_fill()", err);
+			goto exit;
+		}
+	}
+
+	xnvmec_pinf("cmd_sfeat: {nsid: 0%x, fid: 0x%x, save: 0x%x, feat: 0x%x, cdw12: 0x%x}", nsid,
+		    fid, save, feat, cdw12);
+
+	xnvme_prep_adm_sfeat(&ctx, 0, fid, feat, save);
+	ctx.cmd.sfeat.cdw12 = cdw12;
+
+	err = xnvme_cmd_pass_admin(&ctx, dbuf, dbuf_nbytes, NULL, 0x0);
 	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
-		xnvmec_perr("xnvme_adm_sfeat()", err);
+		xnvmec_perr("xnvme_cmd_pass_admin()", err);
 		xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
 		err = err ? err : -EIO;
 	}
+
+exit:
+	if (dbuf)
+		xnvme_buf_free(dev, dbuf);
 
 	return err;
 }
@@ -841,7 +899,9 @@ static struct xnvmec_sub g_subs[] = {
 			{XNVMEC_OPT_FID, XNVMEC_LREQ},
 			{XNVMEC_OPT_NSID, XNVMEC_LOPT},
 			{XNVMEC_OPT_SEL, XNVMEC_LOPT},
+			{XNVMEC_OPT_CDW11, XNVMEC_LOPT},
 			{XNVMEC_OPT_DATA_OUTPUT, XNVMEC_LOPT},
+			{XNVMEC_OPT_DATA_NBYTES, XNVMEC_LOPT},
 
 			XNVMEC_ADMIN_OPTS,
 		},
@@ -860,7 +920,9 @@ static struct xnvmec_sub g_subs[] = {
 			{XNVMEC_OPT_FEAT, XNVMEC_LREQ},
 			{XNVMEC_OPT_NSID, XNVMEC_LOPT},
 			{XNVMEC_OPT_SAVE, XNVMEC_LFLG},
+			{XNVMEC_OPT_CDW12, XNVMEC_LOPT},
 			{XNVMEC_OPT_DATA_INPUT, XNVMEC_LOPT},
+			{XNVMEC_OPT_DATA_NBYTES, XNVMEC_LOPT},
 
 			XNVMEC_ADMIN_OPTS,
 		},

--- a/tools/xnvme.c
+++ b/tools/xnvme.c
@@ -8,6 +8,9 @@
 #include <libxnvme_libconf.h>
 #include <libxnvmec.h>
 
+#define SET_EVENT_TYPES ((uint8_t[]){0x0, 0x1, 0x2, 0x3, 0x80, 0x81})
+#define SET_EVENT_BUF_SIZE sizeof(SET_EVENT_TYPES)
+
 int
 enumerate_cb(struct xnvme_dev *dev, void *cb_args)
 {
@@ -314,6 +317,201 @@ exit:
 }
 
 static int
+sub_log_fdp_config(struct xnvmec *cli)
+{
+	struct xnvme_dev *dev = cli->args.dev;
+	struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
+	uint32_t nsid = cli->args.nsid;
+	uint32_t egi = cli->args.lsi;
+
+	struct xnvme_spec_log_fdp_conf *log = NULL;
+	uint32_t log_nbytes = cli->args.data_nbytes;
+	int err;
+
+	if (!cli->given[XNVMEC_OPT_NSID]) {
+		nsid = xnvme_dev_get_nsid(cli->args.dev);
+	}
+
+	xnvmec_pinf("Allocating and clearing buffer...");
+	if (!log_nbytes) {
+		err = -EINVAL;
+		xnvmec_perr("!arg:data_nbytes", err);
+		goto exit;
+	}
+
+	log = xnvme_buf_alloc(dev, log_nbytes);
+	if (!log) {
+		err = -errno;
+		xnvmec_perr("xnvme_buf_alloc()", err);
+		goto exit;
+	}
+	memset(log, 0, log_nbytes);
+
+	xnvme_prep_adm_log(&ctx, XNVME_SPEC_LOG_FDPCONF, 0x0, 0, nsid, 0, log_nbytes);
+	ctx.cmd.log.lsi = egi;
+
+	xnvmec_pinf("Retrieving FDP configurations log page ...");
+	err = xnvme_cmd_pass_admin(&ctx, log, log_nbytes, NULL, 0x0);
+	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		xnvmec_perr("xnvme_adm_log(XNVME_SPEC_LOG_FDPCONF)", err);
+		xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
+		err = err ? err : -EIO;
+		goto exit;
+	}
+	xnvme_spec_log_fdp_conf_pr(log, XNVME_PR_DEF);
+
+exit:
+	xnvme_buf_free(dev, log);
+
+	return err;
+}
+
+static int
+sub_log_ruhu(struct xnvmec *cli)
+{
+	struct xnvme_dev *dev = cli->args.dev;
+	struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
+	uint32_t limit = cli->args.limit;
+	uint32_t nsid = cli->args.nsid;
+	uint32_t egi = cli->args.lsi;
+
+	struct xnvme_spec_log_ruhu *log = NULL;
+	uint32_t log_nbytes = 0;
+	int err;
+
+	if (!cli->given[XNVMEC_OPT_NSID]) {
+		nsid = xnvme_dev_get_nsid(cli->args.dev);
+	}
+
+	log_nbytes = sizeof(*log) + limit * sizeof(struct xnvme_spec_ruhu_desc);
+
+	xnvmec_pinf("Allocating and clearing buffer...");
+	log = xnvme_buf_alloc(dev, log_nbytes);
+	if (!log) {
+		err = -errno;
+		xnvmec_perr("xnvme_buf_alloc()", err);
+		goto exit;
+	}
+	memset(log, 0, log_nbytes);
+
+	xnvmec_pinf("Retrieving ruhu-log ...");
+	xnvme_prep_adm_log(&ctx, XNVME_SPEC_LOG_FDPRUHU, 0x0, 0, nsid, 0, log_nbytes);
+	ctx.cmd.log.lsi = egi;
+
+	err = xnvme_cmd_pass_admin(&ctx, log, log_nbytes, NULL, 0x0);
+	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		xnvmec_perr("xnvme_adm_log(XNVME_SPEC_LOG_FDPRUHU)", err);
+		xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
+		err = err ? err : -EIO;
+		goto exit;
+	}
+
+	printf("# %d reclaim unit handle usage:\n", limit);
+	xnvme_spec_log_ruhu_pr(log, limit, XNVME_PR_DEF);
+
+exit:
+	xnvme_buf_free(dev, log);
+
+	return err;
+}
+
+static int
+sub_log_fdp_stats(struct xnvmec *cli)
+{
+	struct xnvme_dev *dev = cli->args.dev;
+	struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
+	uint32_t nsid = cli->args.nsid;
+	uint32_t egi = cli->args.lsi;
+
+	struct xnvme_spec_log_fdp_stats *log = NULL;
+
+	const size_t log_nbytes = sizeof(*log);
+	int err;
+
+	if (!cli->given[XNVMEC_OPT_NSID]) {
+		nsid = xnvme_dev_get_nsid(cli->args.dev);
+	}
+
+	xnvmec_pinf("Allocating and clearing buffer...");
+	log = xnvme_buf_alloc(dev, log_nbytes);
+	if (!log) {
+		err = -errno;
+		xnvmec_perr("xnvme_buf_alloc()", err);
+		goto exit;
+	}
+	memset(log, 0, log_nbytes);
+
+	xnvme_prep_adm_log(&ctx, XNVME_SPEC_LOG_FDPSTATS, 0x0, 0, nsid, 0, log_nbytes);
+	ctx.cmd.log.lsi = egi;
+
+	xnvmec_pinf("Retrieving FDP statistics log page ...");
+	err = xnvme_cmd_pass_admin(&ctx, log, log_nbytes, NULL, 0x0);
+	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		xnvmec_perr("xnvme_adm_log(XNVME_SPEC_LOG_FDPSTATS)", err);
+		xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
+		err = err ? err : -EIO;
+		goto exit;
+	}
+	xnvme_spec_log_fdp_stats_pr(log, XNVME_PR_DEF);
+
+exit:
+	xnvme_buf_free(dev, log);
+
+	return err;
+}
+
+static int
+sub_log_fdp_events(struct xnvmec *cli)
+{
+	struct xnvme_dev *dev = cli->args.dev;
+	struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
+	uint32_t limit = cli->args.limit;
+	uint32_t nsid = cli->args.nsid;
+	uint32_t egi = cli->args.lsi;
+	uint32_t lsp = cli->args.lsp;
+
+	struct xnvme_spec_log_fdp_events *log = NULL;
+	uint32_t log_nbytes = 0;
+	int err;
+
+	if (!cli->given[XNVMEC_OPT_NSID]) {
+		nsid = xnvme_dev_get_nsid(cli->args.dev);
+	}
+
+	log_nbytes = sizeof(*log) + limit * sizeof(struct xnvme_spec_fdp_event);
+
+	xnvmec_pinf("Allocating and clearing buffer...");
+	log = xnvme_buf_alloc(dev, log_nbytes);
+	if (!log) {
+		err = -errno;
+		xnvmec_perr("xnvme_buf_alloc()", err);
+		goto exit;
+	}
+	memset(log, 0, log_nbytes);
+
+	xnvmec_pinf("Retrieving fdp-events-log ...");
+	xnvme_prep_adm_log(&ctx, XNVME_SPEC_LOG_FDPEVENTS, 0x0, 0, nsid, 0, log_nbytes);
+	ctx.cmd.log.lsi = egi;
+	ctx.cmd.log.lsp = lsp;
+
+	err = xnvme_cmd_pass_admin(&ctx, log, log_nbytes, NULL, 0x0);
+	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		xnvmec_perr("xnvme_adm_log(XNVME_SPEC_LOG_FDPEVENTS)", err);
+		xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
+		err = err ? err : -EIO;
+		goto exit;
+	}
+
+	printf("# %d fdp events log page entries:\n", limit);
+	xnvme_spec_log_fdp_events_pr(log, limit, XNVME_PR_DEF);
+
+exit:
+	xnvme_buf_free(dev, log);
+
+	return err;
+}
+
+static int
 sub_log(struct xnvmec *cli)
 {
 	struct xnvme_dev *dev = cli->args.dev;
@@ -422,6 +620,10 @@ sub_gfeat(struct xnvmec *cli)
 	{
 		struct xnvme_spec_feat feat = {.val = ctx.cpl.cdw0};
 		xnvme_spec_feat_pr(fid, feat, XNVME_PR_DEF);
+
+		if (fid == XNVME_SPEC_FEAT_FDP_EVENTS) {
+			xnvme_spec_feat_fdp_events_pr(dbuf, feat, XNVME_PR_DEF);
+		}
 	}
 
 	if (cli->args.data_output) {
@@ -498,6 +700,52 @@ exit:
 }
 
 static int
+sub_set_fdp_events(struct xnvmec *cli)
+{
+	struct xnvme_dev *dev = cli->args.dev;
+	struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
+	uint8_t fid = cli->args.fid;
+	uint32_t feat = cli->args.feat;
+	uint8_t save = cli->args.save;
+	uint32_t nsid = cli->args.nsid;
+	uint32_t cdw12 = cli->args.cdw[12];
+	uint8_t *dbuf = NULL;
+	int err;
+
+	if (!cli->given[XNVMEC_OPT_NSID]) {
+		nsid = xnvme_dev_get_nsid(cli->args.dev);
+	}
+
+	dbuf = xnvme_buf_alloc(dev, SET_EVENT_BUF_SIZE);
+	if (!dbuf) {
+		err = -errno;
+		xnvmec_perr("xnvme_buf_alloc()", err);
+		goto exit;
+	}
+
+	memcpy(dbuf, SET_EVENT_TYPES, SET_EVENT_BUF_SIZE);
+
+	xnvmec_pinf("cmd_sfeat: {nsid: 0%x, fid: 0x%x, save: 0x%x, feat: 0x%x, cdw12: 0x%x}", nsid,
+		    fid, save, feat, cdw12);
+
+	xnvme_prep_adm_sfeat(&ctx, nsid, fid, feat, save);
+	ctx.cmd.sfeat.cdw12 = cdw12;
+
+	err = xnvme_cmd_pass_admin(&ctx, (void *)dbuf, SET_EVENT_BUF_SIZE, NULL, 0x0);
+	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		xnvmec_perr("xnvme_cmd_pass_admin()", err);
+		xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
+		err = err ? err : -EIO;
+	}
+
+exit:
+	if (dbuf)
+		xnvme_buf_free(dev, dbuf);
+
+	return err;
+}
+
+static int
 sub_format(struct xnvmec *cli)
 {
 	struct xnvme_dev *dev = cli->args.dev;
@@ -553,6 +801,93 @@ sub_sanitize(struct xnvmec *cli)
 		xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
 		err = err ? err : -EIO;
 	}
+
+	return err;
+}
+
+static int
+sub_ruhs(struct xnvmec *cli)
+{
+	struct xnvme_dev *dev = cli->args.dev;
+	struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
+	uint32_t limit = cli->args.limit;
+	uint32_t nsid = cli->args.nsid;
+
+	struct xnvme_spec_ruhs *ruhs = NULL;
+	uint32_t ruhs_nbytes = 0;
+	int err;
+
+	if (!cli->given[XNVMEC_OPT_NSID]) {
+		nsid = xnvme_dev_get_nsid(cli->args.dev);
+	}
+
+	ruhs_nbytes = sizeof(*ruhs) + limit * sizeof(struct xnvme_spec_ruhs_desc);
+
+	xnvmec_pinf("Allocating and clearing buffer...");
+	ruhs = xnvme_buf_alloc(dev, ruhs_nbytes);
+	if (!ruhs) {
+		err = -errno;
+		xnvmec_perr("xnvme_buf_alloc()", err);
+		goto exit;
+	}
+	memset(ruhs, 0, ruhs_nbytes);
+
+	xnvmec_pinf("Retrieving ruhs ...");
+	err = xnvme_nvm_mgmt_recv(&ctx, nsid, XNVME_SPEC_IO_MGMT_RECV_RUHS, 0, ruhs, ruhs_nbytes);
+
+	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		xnvmec_perr("xnvme_nvm_mgmt_recv(XNVME_SPEC_IO_MGMT_RECV_RUHS)", err);
+		xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
+		err = err ? err : -EIO;
+		goto exit;
+	}
+
+	printf("# %d reclaim unit handle status:\n", limit);
+	xnvme_spec_ruhs_pr(ruhs, limit, XNVME_PR_DEF);
+
+exit:
+	xnvme_buf_free(dev, ruhs);
+
+	return err;
+}
+
+static int
+sub_ruhu(struct xnvmec *cli)
+{
+	struct xnvme_dev *dev = cli->args.dev;
+	struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
+	uint32_t pi = cli->args.pi;
+	uint32_t nsid = cli->args.nsid;
+	uint16_t *pid_list = NULL;
+	uint32_t npids = 1;
+
+	int err;
+
+	if (!cli->given[XNVMEC_OPT_NSID]) {
+		nsid = xnvme_dev_get_nsid(cli->args.dev);
+	}
+
+	pid_list = xnvme_buf_alloc(dev, npids * 2);
+	if (!pid_list) {
+		err = -errno;
+		xnvmec_perr("xnvme_buf_alloc()", err);
+		goto exit;
+	}
+	memcpy(pid_list, &pi, npids * 2);
+
+	xnvmec_pinf("Updating ruh ...");
+	err = xnvme_nvm_mgmt_send(&ctx, nsid, XNVME_SPEC_IO_MGMT_SEND_RUHU, npids - 1, pid_list,
+				  npids * 2);
+
+	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		xnvmec_perr("xnvme_nvm_mgmt_send(XNVME_SPEC_IO_MGMT_SEND_RUHU)", err);
+		xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
+		err = err ? err : -EIO;
+		goto exit;
+	}
+
+exit:
+	xnvme_buf_free(dev, pid_list);
 
 	return err;
 }
@@ -887,6 +1222,78 @@ static struct xnvmec_sub g_subs[] = {
 		},
 	},
 	{
+		"log-fdp-config",
+		"Retrieve the FDP configurations log",
+		"Retrieve and print log",
+		sub_log_fdp_config,
+		{
+			{XNVMEC_OPT_POSA_TITLE, XNVMEC_SKIP},
+			{XNVMEC_OPT_URI, XNVMEC_POSA},
+
+			{XNVMEC_OPT_NON_POSA_TITLE, XNVMEC_SKIP},
+			{XNVMEC_OPT_NSID, XNVMEC_LOPT},
+			{XNVMEC_OPT_DATA_NBYTES, XNVMEC_LREQ},
+			{XNVMEC_OPT_DATA_OUTPUT, XNVMEC_LOPT},
+			{XNVMEC_OPT_LSI, XNVMEC_LREQ},
+
+			XNVMEC_ADMIN_OPTS,
+		},
+	},
+	{
+		"log-ruhu",
+		"Retrieve the reclaim unit handle usage log",
+		"Retrieve and print log",
+		sub_log_ruhu,
+		{
+			{XNVMEC_OPT_POSA_TITLE, XNVMEC_SKIP},
+			{XNVMEC_OPT_URI, XNVMEC_POSA},
+
+			{XNVMEC_OPT_NON_POSA_TITLE, XNVMEC_SKIP},
+			{XNVMEC_OPT_NSID, XNVMEC_LOPT},
+			{XNVMEC_OPT_DATA_OUTPUT, XNVMEC_LOPT},
+			{XNVMEC_OPT_LIMIT, XNVMEC_LREQ},
+			{XNVMEC_OPT_LSI, XNVMEC_LREQ},
+
+			XNVMEC_ADMIN_OPTS,
+		},
+	},
+	{
+		"log-fdp-stats",
+		"Retrieve the FDP statistics log",
+		"Retrieve and print log",
+		sub_log_fdp_stats,
+		{
+			{XNVMEC_OPT_POSA_TITLE, XNVMEC_SKIP},
+			{XNVMEC_OPT_URI, XNVMEC_POSA},
+
+			{XNVMEC_OPT_NON_POSA_TITLE, XNVMEC_SKIP},
+			{XNVMEC_OPT_NSID, XNVMEC_LOPT},
+			{XNVMEC_OPT_DATA_OUTPUT, XNVMEC_LOPT},
+			{XNVMEC_OPT_LSI, XNVMEC_LREQ},
+
+			XNVMEC_ADMIN_OPTS,
+		},
+	},
+	{
+		"log-fdp-events",
+		"Retrieve the fdp-events log",
+		"Retrieve and print log",
+		sub_log_fdp_events,
+		{
+			{XNVMEC_OPT_POSA_TITLE, XNVMEC_SKIP},
+			{XNVMEC_OPT_URI, XNVMEC_POSA},
+
+			{XNVMEC_OPT_NON_POSA_TITLE, XNVMEC_SKIP},
+			{XNVMEC_OPT_NSID, XNVMEC_LOPT},
+			{XNVMEC_OPT_LIMIT, XNVMEC_LREQ},
+			{XNVMEC_OPT_DATA_OUTPUT, XNVMEC_LOPT},
+			{XNVMEC_OPT_LSI, XNVMEC_LREQ},
+			{XNVMEC_OPT_LSP, XNVMEC_LREQ},
+
+			XNVMEC_ADMIN_OPTS,
+		},
+	},
+	{
 		"feature-get",
 		"Execute a Get-Features Command",
 		"Execute a Get Features Command",
@@ -928,6 +1335,25 @@ static struct xnvmec_sub g_subs[] = {
 		},
 	},
 	{
+		"set-fdp-events",
+		"Enable or disable all events",
+		"Enable or disable all events",
+		sub_set_fdp_events,
+		{
+			{XNVMEC_OPT_POSA_TITLE, XNVMEC_SKIP},
+			{XNVMEC_OPT_URI, XNVMEC_POSA},
+
+			{XNVMEC_OPT_NON_POSA_TITLE, XNVMEC_SKIP},
+			{XNVMEC_OPT_FID, XNVMEC_LREQ},
+			{XNVMEC_OPT_FEAT, XNVMEC_LREQ},
+			{XNVMEC_OPT_NSID, XNVMEC_LOPT},
+			{XNVMEC_OPT_SAVE, XNVMEC_LFLG},
+			{XNVMEC_OPT_CDW12, XNVMEC_LREQ},
+
+			XNVMEC_ADMIN_OPTS,
+		},
+	},
+	{
 		"format",
 		"Format a NVM namespace",
 		"Format a NVM namespace",
@@ -956,6 +1382,38 @@ static struct xnvmec_sub g_subs[] = {
 		{
 			{XNVMEC_OPT_POSA_TITLE, XNVMEC_SKIP},
 			{XNVMEC_OPT_URI, XNVMEC_POSA},
+
+			XNVMEC_ADMIN_OPTS,
+		},
+	},
+	{
+		"fdp-ruhs",
+		"Retrieve the Reclaim Unit Handle Status",
+		"Retrieve and print log",
+		sub_ruhs,
+		{
+			{XNVMEC_OPT_POSA_TITLE, XNVMEC_SKIP},
+			{XNVMEC_OPT_URI, XNVMEC_POSA},
+
+			{XNVMEC_OPT_NON_POSA_TITLE, XNVMEC_SKIP},
+			{XNVMEC_OPT_NSID, XNVMEC_LOPT},
+			{XNVMEC_OPT_LIMIT, XNVMEC_LREQ},
+
+			XNVMEC_ADMIN_OPTS,
+		},
+	},
+	{
+		"fdp-ruhu",
+		"Reclaim Unit Handle Update for a Placement Identifier",
+		"Reclaim Unit Handle Update for a Placement Identifier",
+		sub_ruhu,
+		{
+			{XNVMEC_OPT_POSA_TITLE, XNVMEC_SKIP},
+			{XNVMEC_OPT_URI, XNVMEC_POSA},
+
+			{XNVMEC_OPT_NON_POSA_TITLE, XNVMEC_SKIP},
+			{XNVMEC_OPT_NSID, XNVMEC_LOPT},
+			{XNVMEC_OPT_PID, XNVMEC_LREQ},
 
 			XNVMEC_ADMIN_OPTS,
 		},


### PR DESCRIPTION
This series adds FDP support in xNVMe.
The initial 2 commits modify the log pages and set / get feature commands by adding a prep function. This is done to avoid changes to the existing api so that it does not become too bulky.
The next 4 commit introduces the required changes in spec, tools, cli and api.

This series is missing changes to toolbox (test) which I will update once Qemu changes are upstream