### PR TITLE
py/cython-bindings: handle const qualifiers in function signatures

### DIFF
--- a/python/xnvme-cy-bindings/auxiliary/autopxd_py.py
+++ b/python/xnvme-cy-bindings/auxiliary/autopxd_py.py
@@ -54,7 +54,7 @@ def get_definitions(pxd_f):
 
         args = []
         for arg in re.finditer(
-            r"([_a-zA-Z0-9\*]+) ([_a-zA-Z0-9]+)(?:, )?", arg_body.strip("()")
+            r"(?:const )?([_a-zA-Z0-9\*]+) ([_a-zA-Z0-9]+)(?:, )?", arg_body.strip("()")
         ):
             arg_type, arg_name = arg.groups()
             args.append((arg_type, arg_name))


### PR DESCRIPTION
autopxd2 v2.3.0 added support for `const` qualifiers. These caused the auto-generation of the `.pyx` files to fail. This has been resolved now.
Unfortunately, this does not resolve any of the `[-Wdiscarded-qualifiers]` warnings.

Currently the only `const` qualifiers that end up in the `.pyx` files are `const char *`, this is because python/cython complains if I put them in front of pyObjects, i.e. `xnvme_void_p`. 
Unless we can find a way to do that, perhaps it is better to just discard the const qualifiers instead, to keep the complexity of `autopxd_py.py` down.

@Baekalfen @safl can I get your opinion on this? 