### PR TITLE
ci,toolbox/cijoe: Don't try to save non-saveable feat

### DIFF
--- a/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/tools/test_xnvme.py
+++ b/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/tools/test_xnvme.py
@@ -166,7 +166,7 @@ def test_feature_set(cijoe, device, be_opts, cli_args):
     if "ramdisk" in device["labels"]:
         pytest.skip(reason="[be=ramdisk] does not implement feature-set")
 
-    err, _ = cijoe.run(f"xnvme feature-set {cli_args} --fid 0x4 --feat 0x1 --save")
+    err, _ = cijoe.run(f"xnvme feature-set {cli_args} --fid 0x4 --feat 0x1")
 
     if be_opts["admin"] == "block":
         assert err


### PR DESCRIPTION
The test is trying to set a Temperature Threshold, which is a non-saveable feature. As such, it should not try to save it.

The only reason this is not failing currently is because the `xnvme` cli is hardcoded to never save. However, #221 changes this to be implemented correctly and then the test fails.