### PR TITLE
xnvmec: rename xnvme_enumeration* to xnvmec_enumeration*

### DIFF
--- a/include/libxnvme_pp.h
+++ b/include/libxnvme_pp.h
@@ -6,7 +6,6 @@ extern "C" {
 #endif
 
 #include <libxnvme.h>
-#include <libxnvmec.h>
 
 /**
  * Options for pretty-printer (``*_pr``, ``*_fpr``) functions
@@ -143,37 +142,6 @@ xnvme_ident_fpr(FILE *stream, const struct xnvme_ident *ident, int opts);
  */
 int
 xnvme_ident_pr(const struct xnvme_ident *ident, int opts);
-
-struct xnvme_enumeration;
-
-/**
- * Prints the given ::xnvme_enumeration to the given output stream
- *
- * @param stream output stream used for printing
- * @param list pointer to structure to print
- * @param opts printer options, see ::xnvme_pr
- *
- * @return On success, the number of characters printed is returned.
- */
-int
-xnvme_enumeration_fpr(FILE *stream, struct xnvme_enumeration *list, int opts);
-
-int
-xnvme_enumeration_fpp(FILE *stream, struct xnvme_enumeration *list, int opts);
-
-int
-xnvme_enumeration_pp(struct xnvme_enumeration *list, int opts);
-
-/**
- * Prints the given ::xnvme_enumeration to stdout
- *
- * @param list pointer to structure to print
- * @param opts printer options, see ::xnvme_pr
- *
- * @return On success, the number of characters printed is returned.
- */
-int
-xnvme_enumeration_pr(struct xnvme_enumeration *list, int opts);
 
 /**
  * Prints the given ::xnvme_dev to the given output stream

--- a/include/libxnvmec.h
+++ b/include/libxnvmec.h
@@ -509,22 +509,51 @@ enum xnvmec_opts {
 /**
  * List of devices found on the system usable with xNVMe
  *
- * @struct xnvme_enumeration
+ * @struct xnvmec_enumeration
  */
-struct xnvme_enumeration {
+struct xnvmec_enumeration {
 	uint32_t capacity;            ///< Remaining unused entries
 	uint32_t nentries;            ///< Used entries
 	struct xnvme_ident entries[]; ///< Device entries
 };
 
 int
-xnvme_enumeration_alloc(struct xnvme_enumeration **list, uint32_t capacity);
+xnvmec_enumeration_alloc(struct xnvmec_enumeration **list, uint32_t capacity);
 
 void
-xnvme_enumeration_free(struct xnvme_enumeration *list);
+xnvmec_enumeration_free(struct xnvmec_enumeration *list);
 
 int
-xnvme_enumeration_append(struct xnvme_enumeration *list, const struct xnvme_ident *entry);
+xnvmec_enumeration_append(struct xnvmec_enumeration *list, const struct xnvme_ident *entry);
+
+/**
+ * Prints the given ::xnvmec_enumeration to the given output stream
+ *
+ * @param stream output stream used for printing
+ * @param list pointer to structure to print
+ * @param opts printer options, see ::xnvme_pr
+ *
+ * @return On success, the number of characters printed is returned.
+ */
+int
+xnvmec_enumeration_fpr(FILE *stream, struct xnvmec_enumeration *list, int opts);
+
+int
+xnvmec_enumeration_fpp(FILE *stream, struct xnvmec_enumeration *list, int opts);
+
+int
+xnvmec_enumeration_pp(struct xnvmec_enumeration *list, int opts);
+
+/**
+ * Prints the given ::xnvmec_enumeration to stdout
+ *
+ * @param list pointer to structure to print
+ * @param opts printer options, see ::xnvme_pr
+ *
+ * @return On success, the number of characters printed is returned.
+ */
+int
+xnvmec_enumeration_pr(struct xnvmec_enumeration *list, int opts);
 
 static inline uint64_t
 xnvmec_timer_start(struct xnvmec *cli)

--- a/lib/xnvmec.c
+++ b/lib/xnvmec.c
@@ -1979,13 +1979,13 @@ xnvmec_cli_to_opts(const struct xnvmec *cli, struct xnvme_opts *opts)
 }
 
 void
-xnvme_enumeration_free(struct xnvme_enumeration *list)
+xnvmec_enumeration_free(struct xnvmec_enumeration *list)
 {
 	free(list);
 }
 
 int
-xnvme_enumeration_alloc(struct xnvme_enumeration **list, uint32_t capacity)
+xnvmec_enumeration_alloc(struct xnvmec_enumeration **list, uint32_t capacity)
 {
 	*list = malloc(sizeof(**list) + sizeof(*(*list)->entries) * capacity);
 	if (!(*list)) {
@@ -1999,7 +1999,7 @@ xnvme_enumeration_alloc(struct xnvme_enumeration **list, uint32_t capacity)
 }
 
 int
-xnvme_enumeration_append(struct xnvme_enumeration *list, const struct xnvme_ident *entry)
+xnvmec_enumeration_append(struct xnvmec_enumeration *list, const struct xnvme_ident *entry)
 {
 	if (!list->capacity) {
 		XNVME_DEBUG("FAILED: syslist->capacity: %u", list->capacity);
@@ -2012,7 +2012,7 @@ xnvme_enumeration_append(struct xnvme_enumeration *list, const struct xnvme_iden
 }
 
 int
-xnvme_enumeration_fpr(FILE *stream, struct xnvme_enumeration *list, int opts)
+xnvmec_enumeration_fpr(FILE *stream, struct xnvmec_enumeration *list, int opts)
 {
 	int wrtn = 0;
 
@@ -2026,7 +2026,7 @@ xnvme_enumeration_fpr(FILE *stream, struct xnvme_enumeration *list, int opts)
 		break;
 	}
 
-	wrtn += fprintf(stream, "xnvme_enumeration:");
+	wrtn += fprintf(stream, "xnvmec_enumeration:");
 
 	if (!list) {
 		wrtn += fprintf(stream, " ~\n");
@@ -2056,9 +2056,9 @@ xnvme_enumeration_fpr(FILE *stream, struct xnvme_enumeration *list, int opts)
 }
 
 int
-xnvme_enumeration_pr(struct xnvme_enumeration *list, int opts)
+xnvmec_enumeration_pr(struct xnvmec_enumeration *list, int opts)
 {
-	return xnvme_enumeration_fpr(stdout, list, opts);
+	return xnvmec_enumeration_fpr(stdout, list, opts);
 }
 
 /**
@@ -2067,7 +2067,7 @@ xnvme_enumeration_pr(struct xnvme_enumeration *list, int opts)
  * @return Returns 1 it is exist, 0 otherwise.
  */
 static int
-enumeration_has_ident(struct xnvme_enumeration *list, struct xnvme_ident *ident, uint32_t idx)
+enumeration_has_ident(struct xnvmec_enumeration *list, struct xnvme_ident *ident, uint32_t idx)
 {
 	uint32_t bound = XNVME_MIN(list->nentries, idx);
 
@@ -2092,7 +2092,7 @@ enumeration_has_ident(struct xnvme_enumeration *list, struct xnvme_ident *ident,
 }
 
 int
-xnvme_enumeration_fpp(FILE *stream, struct xnvme_enumeration *list, int opts)
+xnvmec_enumeration_fpp(FILE *stream, struct xnvmec_enumeration *list, int opts)
 {
 	int wrtn = 0;
 
@@ -2106,7 +2106,7 @@ xnvme_enumeration_fpp(FILE *stream, struct xnvme_enumeration *list, int opts)
 		break;
 	}
 
-	wrtn += fprintf(stream, "xnvme_enumeration:");
+	wrtn += fprintf(stream, "xnvmec_enumeration:");
 
 	if (!list) {
 		wrtn += fprintf(stream, " ~\n");
@@ -2133,7 +2133,7 @@ xnvme_enumeration_fpp(FILE *stream, struct xnvme_enumeration *list, int opts)
 }
 
 int
-xnvme_enumeration_pp(struct xnvme_enumeration *list, int opts)
+xnvmec_enumeration_pp(struct xnvmec_enumeration *list, int opts)
 {
-	return xnvme_enumeration_fpp(stdout, list, opts);
+	return xnvmec_enumeration_fpp(stdout, list, opts);
 }

--- a/python/xnvme-cy-bindings/auxiliary/autopxd_py.py
+++ b/python/xnvme-cy-bindings/auxiliary/autopxd_py.py
@@ -224,7 +224,7 @@ from libxnvme cimport {', '.join(enum_defs)}
                 "xnvme_lba_pr",  # uint64_t* supported yet
                 "xnvme_lba_fprn",  # uint64_t* supported yet
                 "xnvme_lba_prn",  # uint64_t* supported yet
-                "xnvme_enumeration_alloc",  # Cannot assign type 'xnvme_enumeration *' to 'xnvme_enumeration **'
+                "xnvmec_enumeration_alloc",  # Cannot assign type 'xnvmec_enumeration *' to 'xnvmec_enumeration **'
                 "xnvmec_get_opt_attr",
                 "xnvmec",
                 "xnvmec_sub",

--- a/tests/enum.c
+++ b/tests/enum.c
@@ -12,10 +12,10 @@
 int
 enumerate_cb(struct xnvme_dev *dev, void *cb_args)
 {
-	struct xnvme_enumeration *list = cb_args;
+	struct xnvmec_enumeration *list = cb_args;
 	const struct xnvme_ident *ident = xnvme_dev_get_ident(dev);
 
-	if (xnvme_enumeration_append(list, ident)) {
+	if (xnvmec_enumeration_append(list, ident)) {
 		XNVME_DEBUG("FAILED: adding ident");
 	}
 
@@ -25,7 +25,7 @@ enumerate_cb(struct xnvme_dev *dev, void *cb_args)
 static int
 test_enum(struct xnvmec *cli)
 {
-	struct xnvme_enumeration *listing[MAX_LISTINGS] = {0};
+	struct xnvmec_enumeration *listing[MAX_LISTINGS] = {0};
 	struct xnvme_opts opts = {0};
 	uint64_t nlistings = 2;
 	int nerr = 0, err;
@@ -44,9 +44,9 @@ test_enum(struct xnvmec *cli)
 	xnvmec_pinf("Will enumerate %ld times", nlistings);
 
 	for (uint64_t i = 0; i < nlistings; ++i) {
-		err = xnvme_enumeration_alloc(&listing[i], 100);
+		err = xnvmec_enumeration_alloc(&listing[i], 100);
 		if (err) {
-			XNVME_DEBUG("FAILED: xnvme_enumeration_alloc()");
+			XNVME_DEBUG("FAILED: xnvmec_enumeration_alloc()");
 			return err;
 		}
 
@@ -61,8 +61,8 @@ test_enum(struct xnvmec *cli)
 			nerr += 1;
 			xnvmec_pinf("The enumeration %ld did not match the prev", i);
 
-			xnvme_enumeration_pr(listing[i], XNVME_PR_DEF);
-			xnvme_enumeration_pr(listing[i - 1], XNVME_PR_DEF);
+			xnvmec_enumeration_pr(listing[i], XNVME_PR_DEF);
+			xnvmec_enumeration_pr(listing[i - 1], XNVME_PR_DEF);
 		}
 	}
 	if (nerr) {
@@ -85,7 +85,7 @@ exit:
 static int
 test_enum_open(struct xnvmec *cli)
 {
-	struct xnvme_enumeration *listing = NULL;
+	struct xnvmec_enumeration *listing = NULL;
 	struct xnvme_opts enum_opts = {0};
 	int count = 1;
 	int nerr = 0, err;
@@ -96,9 +96,9 @@ test_enum_open(struct xnvmec *cli)
 		return err;
 	}
 
-	err = xnvme_enumeration_alloc(&listing, 100);
+	err = xnvmec_enumeration_alloc(&listing, 100);
 	if (err) {
-		XNVME_DEBUG("FAILED: xnvme_enumeration_alloc()");
+		XNVME_DEBUG("FAILED: xnvmec_enumeration_alloc()");
 		return err;
 	}
 
@@ -108,7 +108,7 @@ test_enum_open(struct xnvmec *cli)
 		xnvmec_perr("xnvme_enumerate()", err);
 		goto exit;
 	}
-	xnvme_enumeration_pr(listing, XNVME_PR_DEF);
+	xnvmec_enumeration_pr(listing, XNVME_PR_DEF);
 
 	if (cli->args.count) {
 		count = cli->args.count > MAX_HANDLES ? MAX_HANDLES : cli->args.count;

--- a/tools/lblk.c
+++ b/tools/lblk.c
@@ -46,7 +46,7 @@ sub_enumerate(struct xnvmec *cli)
 		return err;
 	}
 
-	fprintf(stdout, "xnvme_enumeration:");
+	fprintf(stdout, "xnvmec_enumeration:");
 
 	err = xnvme_enumerate(cli->args.sys_uri, &opts, *enumerate_cb, &ns_count);
 	if (err) {

--- a/tools/xnvme.c
+++ b/tools/xnvme.c
@@ -31,11 +31,11 @@ enumerate_cb(struct xnvme_dev *dev, void *cb_args)
 int
 listing_cb(struct xnvme_dev *dev, void *cb_args)
 {
-	struct xnvme_enumeration *list = cb_args;
+	struct xnvmec_enumeration *list = cb_args;
 	const struct xnvme_ident *ident;
 
 	ident = xnvme_dev_get_ident(dev);
-	if (xnvme_enumeration_append(list, ident)) {
+	if (xnvmec_enumeration_append(list, ident)) {
 		XNVME_DEBUG("FAILED: adding ident");
 	}
 
@@ -45,7 +45,7 @@ listing_cb(struct xnvme_dev *dev, void *cb_args)
 static int
 sub_listing(struct xnvmec *cli)
 {
-	struct xnvme_enumeration *listing = NULL;
+	struct xnvmec_enumeration *listing = NULL;
 	struct xnvme_opts opts = {0};
 	int err;
 
@@ -55,9 +55,9 @@ sub_listing(struct xnvmec *cli)
 		return err;
 	}
 
-	err = xnvme_enumeration_alloc(&listing, 100);
+	err = xnvmec_enumeration_alloc(&listing, 100);
 	if (err) {
-		XNVME_DEBUG("FAILED: xnvme_enumeration_alloc()");
+		XNVME_DEBUG("FAILED: xnvmec_enumeration_alloc()");
 		return err;
 	}
 
@@ -67,7 +67,7 @@ sub_listing(struct xnvmec *cli)
 		goto exit;
 	}
 
-	xnvme_enumeration_pp(listing, XNVME_PR_DEF);
+	xnvmec_enumeration_pp(listing, XNVME_PR_DEF);
 
 exit:
 	free(listing);
@@ -88,7 +88,7 @@ sub_enumerate(struct xnvmec *cli)
 		return err;
 	}
 
-	fprintf(stdout, "xnvme_enumeration:");
+	fprintf(stdout, "xnvmec_enumeration:");
 
 	err = xnvme_enumerate(cli->args.sys_uri, &opts, *enumerate_cb, &ns_count);
 	if (err) {

--- a/tools/zoned.c
+++ b/tools/zoned.c
@@ -47,7 +47,7 @@ cmd_enumerate(struct xnvmec *cli)
 		return err;
 	}
 
-	fprintf(stdout, "xnvme_enumeration:");
+	fprintf(stdout, "xnvmec_enumeration:");
 
 	err = xnvme_enumerate(cli->args.sys_uri, &opts, *enumerate_cb, &ns_count);
 	if (err) {


### PR DESCRIPTION
xnvme_enumeration belongs to libxnvmec, thus it has the wrong prefix. This commit corrects this prefix.
