### PR TITLE
meson: only check for CentOS 7 if sys == "linux"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,7 @@ foreach sys : system_support
     set_variable('is_' + sys, system == sys)
 endforeach
 
-is_centos7 = run_command('cat', '/etc/os-release', check: false).stdout().contains('CentOS Linux 7')
+is_centos7 = is_linux ? run_command('cat', '/etc/os-release', check: false).stdout().contains('CentOS Linux 7') : false
 
 cc = meson.get_compiler('c')
 cc_flags = [


### PR DESCRIPTION
Currently this check is run regardless of the system, however on some systems the command either fails or doesn't exist. This can cause the build to fail.

Instead this should only be run if the system is linux.