### PR TITLE
rust: add a skeleton for xNVMe crates

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,3 @@
+Cargo.lock
+xnvme/target
+xnvme-sys/target

--- a/rust/README.rst
+++ b/rust/README.rst
@@ -1,0 +1,12 @@
+Rust xNVMe Bindings
+===================
+
+* The ``xnvme-sys`` crate contains unsafe/direct/raw bindings to the xNVMe C Library
+
+  * This is intended to provide data-structure-definitons and function-callables
+
+* The ``xnvme`` crate contains idiomatic xNVMe bindings
+
+  * Built on top of 'xnvme-sys'
+  * Provide a safe interface for consuming xNVMe
+  * Envelop the ``xnvme-sys`` primitives in Rust idomatic constructs

--- a/rust/xnvme-sys/Cargo.toml
+++ b/rust/xnvme-sys/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "xnvme-sys"
+version = "0.0.0"
+edition = "2021"
+description = "Raw/direct/unsafe bindings to the xNVMe C Library. NOTE: This is a crate-namespace-reservation"
+license = "BSD-3-Clause"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/rust/xnvme-sys/src/main.rs
+++ b/rust/xnvme-sys/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello! I am a namesquat for the 'xnvme-sys' crate");
+}

--- a/rust/xnvme/Cargo.toml
+++ b/rust/xnvme/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "xnvme"
+version = "0.0.0"
+edition = "2021"
+description = "Safe and idiomatic xNVMe-bindings built on top of xnvme-sys. NOTE: This is a crate-namespace-reservation"
+license = "BSD-3-Clause"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/rust/xnvme/src/main.rs
+++ b/rust/xnvme/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello! I am a namesquat for the 'xnvme' crate");
+}


### PR DESCRIPTION
This is what is used when name-squatting xNVMe on crates.io:

- https://crates.io/crates/xnvme-sys
- https://crates.io/crates/xnvme