### PR TITLE
meson:build:win: fix meson 'sandbox violation' warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -147,12 +147,6 @@ fio_dep = dependency(
   'fio',
   required: get_option('with-fio')
 )
-# Fio Windows Posix Headers
-if is_windows and get_option('with-fio')
-    fio_winposix_inc = include_directories('subprojects'/'fio'/'os'/'windows'/'posix'/'include')
-else
-    fio_winposix_inc = include_directories()
-endif
 
 setupapi_dep = cc.find_library(
   'setupapi',

--- a/subprojects/packagefiles/fio/meson.build
+++ b/subprojects/packagefiles/fio/meson.build
@@ -29,9 +29,12 @@ if get_option('build_subprojects') and not fs.exists('fio')
   )
 endif
 
-fio_inc = include_directories('.')
+fio_inc = [ include_directories('.') ]
+if (host_machine.system() == 'windows')
+  fio_inc += [ include_directories('os'/'windows'/'posix'/'include') ]
+endif
 fio_dep = declare_dependency(
-  include_directories: fio_inc
+  include_directories: [ fio_inc ]
 )
 
 meson.override_dependency('fio', fio_dep)

--- a/tools/fio-engine/meson.build
+++ b/tools/fio-engine/meson.build
@@ -1,5 +1,4 @@
 xnvmefioe_inc = is_windows ? [
-  fio_winposix_inc,
   conf_inc,
   xnvme_inc
 ] : [ xnvme_inc ]


### PR DESCRIPTION
adding fix to remove the meson 'sandbox voilation' warning due to direct access of subprojects headers files inside the xNVMe main meson.build file.