### PR TITLE
Refactor build of xNVMe

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -424,6 +424,13 @@ jobs:
       run: |
         if [[ -f "${BSCRIPT}" ]]; then source ${BSCRIPT}; else source ${BSCRIPT_DEF}; fi
 
+    - name: Execute 'ldconfig'
+      # ldconfig doesn't work on alpine
+      # centos7 needs "ldconfig /usr/lib/local" for python3 to work
+      if: ${{!contains(matrix.container.os, 'alpine') && !contains(matrix.container.ver, 'centos7') && !contains(matrix.container.ver,
+        'stream8')}}
+      run: ldconfig
+
     - name: meson-log-dump
       if: always()
       run: |

--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ gen-src-archive:
 	$(MESON) dist -C $(BUILD_DIR) --include-subprojects --no-tests --formats gztar
 	@echo "## xNVMe: make gen-src-archive [DONE]"
 
-define gen-artifacts
+define gen-artifacts-help
 # Generate artifacts in "/tmp/artifacts" for local guest provisoning
 #
 # This is a helper to produce the set of files used by toolbox/workflows/provision.workflow
@@ -397,6 +397,9 @@ tags-xnvme-public:
 	@$(CTAGS) --c-kinds=dfpgs -R include/lib*.h || true
 	@echo "## xNVMe: make tags-xnvme-public [DONE]"
 
+define _require_builddir-help
+# This helper is not intended to be invoked via the command-line-interface.
+endef
 .PHONY: _require_builddir
 _require_builddir:
 	@if [ ! -d "$(BUILD_DIR)" ]; then				\

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,15 @@ config-slim:
 	   -Dwith-libvfn=false
 	@echo "## xNVMe: make config-slim [DONE]"
 
+define docker-help
+# drop into a docker instance with the repository bind-mounted at /tmp/xnvme
+endef
+.PHONY: docker
+docker:
+	@echo "## xNVMe: docker"
+	@docker run -it -w /tmp/xnvme --mount type=bind,source="$(shell pwd)",target=/tmp/xnvme ghcr.io/xnvme/xnvme-deps-debian-bullseye:next bash
+	@echo "## xNVME: docker [DONE]"
+
 define git-setup-help
 # Do git config for: 'core.hooksPath' and 'blame.ignoreRevsFile'
 endef

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -73,49 +73,21 @@ xnvmelib_source = [
   'xnvmec.c'
 ]
 
-xnvmelib_deps_shared = [
-  thread_dep,
-  rt_dep,
-  ssl_dep,
-  dlfcn_dep,
-  math_dep,
-  numa_dep,
-  uuid_dep,
-  execinfo_dep,
-  elf_dep,
-  aio_dep,
+xnvmelib_deps = [
   setupapi_dep,
   corefoundation_dep,
   iokit_dep,
   libvfn_dep,
   uring_dep,
-]
-
-xnvmelib_deps_static = []
-xnvmelib_deps_static += [spdk_dep, uring_dep, corefoundation_dep, iokit_dep, libvfn_dep]
-xnvmelib_deps = xnvmelib_deps_shared + xnvmelib_deps_static
-
-xnvmelib_deps_bundle = [
+  aio_dep,
   spdk_dep,
+  thread_dep,
+  rt_dep,
 ]
 
-# We are not relying on meson to control whether or not static/shared libraries are built, this is
-# since we need the static library for constructing the bundled library, and we want the
-# 'non-bundled' shared library to be named 'libxnvme-static.' and the bundled to be 'libxnvme'.
-# This naming is not possible when delegating via default_library
-if get_option('shared_library')
-  xnvmelib_shared = shared_library(
-    'xnvme-shared',
-    xnvmelib_source,
-    dependencies: xnvmelib_deps,
-    include_directories: [conf_inc, xnvme_inc],
-    install_dir: xnvmelib_libdir,
-    install: true,
-  )
-endif
-
-xnvmelib_static = static_library(
-  'xnvme-static',
+# We always build both the shared and static libraries
+xnvmelib_shared = shared_library(
+  'xnvme',
   xnvmelib_source,
   dependencies: xnvmelib_deps,
   include_directories: [conf_inc, xnvme_inc],
@@ -123,56 +95,21 @@ xnvmelib_static = static_library(
   install: true,
 )
 
-# Produce a static library containing xNVMe, liburing, and SPDK
-bundle_lib_paths = []
-bundle_lib_paths += [ 'lib' / 'libxnvme-static.a' ]
-
-if conf_data.get('XNVME_BE_LINUX_VFIO_ENABLED')
-  bundle_lib_paths += ['subprojects' / 'libvfn' / 'src' / 'libvfn.a']
-endif
-
-foreach blib : xnvmelib_deps_bundle
-  if get_option('build_subprojects') and blib.found()
-    bundle_lib_paths += blib.get_variable(internal: 'lib_paths').split(' ')
-  endif
-endforeach
-
-xnvmelib_bundle_depends = [xnvmelib_static]
-
-if conf_data.get('XNVME_BE_LINUX_VFIO_ENABLED')
-  # custom targets cannot depend on dependency() objects, so depend on the
-  # library build target from the subproject.
-  xnvmelib_bundle_depends += subproject('libvfn').get_variable('vfn_lib')
-endif
-
-# missing xnvme and liburing, howto find / produce absolute paths to these?
-xnvmelib_bundle = custom_target(
+xnvmelib_static = static_library(
   'xnvme',
-  build_by_default: true,
-  depends: xnvmelib_bundle_depends,
-  command: [ prog_python, '@INPUT@', '--output', '@OUTPUT@', '--libs' ] + bundle_lib_paths,
-  input: tb_library_bundler,
-  output: 'libxnvme.a',
+  xnvmelib_source,
+  dependencies: xnvmelib_deps,
+  include_directories: [conf_inc, xnvme_inc],
   install_dir: xnvmelib_libdir,
   install: true,
 )
 
-# We create this as a target to be consumed by pkgconfig, potentially also for the xnvme-cli-tools,
-# although they currently link "directly" to the regular static library
-xnvmelib_bundle_dep = declare_dependency(
-  dependencies: xnvmelib_deps,
-  link_args: conf_data.get('XNVME_BE_SPDK_ENABLED') ? [
-    '-Wl,--whole-archive',
-    '-Wl,--no-as-needed',
-    '-lxnvme',
-    '-Wl,--no-whole-archive',
-    '-Wl,--as-needed',
-  ] : [ '-lxnvme' ]
-)
 
 # pkg-config -- describing how to consume the xNVMe library
 pconf.generate(
-  libraries: [xnvmelib_bundle_dep] + [xnvmelib_deps_shared],
+  xnvmelib_shared,
+  install_dir: is_freebsd ? 'libdata/pkgconfig' : xnvmelib_libdir + '/pkgconfig',
+  libraries_private: xnvmelib_deps,
   version: meson.project_version(),
   variables: [
     'datadir=' + get_option('prefix') / get_option('datadir') / meson.project_name()

--- a/meson.build
+++ b/meson.build
@@ -33,7 +33,6 @@ foreach sys : system_support
     set_variable('is_' + sys, system == sys)
 endforeach
 
-is_centos7 = is_linux ? run_command('cat', '/etc/os-release', check: false).stdout().contains('CentOS Linux 7') : false
 
 cc = meson.get_compiler('c')
 cc_flags = [
@@ -47,7 +46,6 @@ add_project_arguments(
 prog_python = import('python').find_installation('python3')
 message('python.language_version:', prog_python.language_version())
 
-#xnvmelib_libdir = 'lib'
 xnvmelib_libdir = get_option('libdir')
 
 #
@@ -151,8 +149,7 @@ subdir('toolbox')
 tb_library_bundler = files('toolbox'/'library_bundler.py')
 
 #
-# Third-party dependencies -- this is actually lib-specific... should probably be moved into
-# 'lib/meson.build'?
+# Third-party dependencies
 #
 thread_dep = dependency('threads')
 
@@ -182,49 +179,11 @@ if conf_data.get('XNVME_BE_LINUX_LIBURING_ENABLED') and not uring_dep.found()
   error('missing liburing >= 2.2; install it or point PKG_CONFIG_PATH to where it is located')
 endif
 
-math_dep = cc.find_library(
-  'm',
-  has_headers: ['math.h'],
-  required: conf_data.get('XNVME_BE_SPDK_ENABLED'),
-)
-
-ssl_dep = dependency(
-  is_centos7 ? 'openssl11' : 'openssl', version: '>=1.1.1',
-  required: conf_data.get('XNVME_BE_SPDK_ENABLED'),
-)
-
-dlfcn_dep = cc.find_library(
-  'dl',
-  has_headers: ['dlfcn.h'],
-  required: conf_data.get('XNVME_BE_SPDK_ENABLED'),
-)
-
-uuid_dep = cc.find_library(
-  'uuid',
-  dirs: is_freebsd ? [ '/usr/local/lib' ] : [],
-  header_include_directories: is_freebsd ? [ include_directories('/usr/local/include') ] : [],
-  has_headers: ['uuid/uuid.h'],
-  required: conf_data.get('XNVME_BE_SPDK_ENABLED'),
-)
-numa_dep = cc.find_library(
-  'numa',
-  has_headers: ['numaif.h'],
-  required: conf_data.get('XNVME_BE_SPDK_ENABLED') and is_linux,
-)
-execinfo_dep = cc.find_library(
-  'execinfo',
-  has_headers: ['execinfo.h'],
-  required: conf_data.get('XNVME_BE_SPDK_ENABLED') and is_freebsd,
-)
-elf_dep = cc.find_library(
-  'elf',
-  has_headers: ['sys/elf_common.h'],
-  required: conf_data.get('XNVME_BE_SPDK_ENABLED') and is_freebsd,
-)
 spdk_dep = dependency(
-  'spdk',
+  '_spdk',
   required: conf_data.get('XNVME_BE_SPDK_ENABLED')
 )
+
 corefoundation_dep = dependency(
   'appleframeworks',
   modules: 'CoreFoundation',

--- a/python/xnvme-core/requirements.txt
+++ b/python/xnvme-core/requirements.txt
@@ -1,5 +1,6 @@
 # For ctypes-bindings
 black
+clang>=11,<=14.0.6
 ctypeslib2
 # All
 pytest

--- a/python/xnvme-core/xnvme/ctypes_bindings/library_loader.py
+++ b/python/xnvme-core/xnvme/ctypes_bindings/library_loader.py
@@ -24,7 +24,7 @@ SHARED_EXT = {
 def search_paths():
     """Search the system for the shared library emitting paths for ctypes.CDLL()"""
 
-    for search in ["xnvme-shared", "xnvme_shared"]:
+    for search in ["xnvme"]:
         path = ctypes.util.find_library(search)
         if path:
             yield path
@@ -39,9 +39,7 @@ def search_paths():
         if not proc.returncode:
             ext = SHARED_EXT.get(platform.system().lower(), "so")
 
-            yield os.path.join(
-                proc.stdout.decode("utf-8").strip(), f"libxnvme-shared.{ext}"
-            )
+            yield os.path.join(proc.stdout.decode("utf-8").strip(), f"libxnvme.{ext}")
     except subprocess.CalledProcessError:
         pass
 

--- a/python/xnvme-cy-bindings/setup.py
+++ b/python/xnvme-cy-bindings/setup.py
@@ -70,7 +70,9 @@ if os.path.isdir(includedir):
         f_out.write(generate_pyx(pxd_contents).read())
 else:
     # Assuming installation from PyPi package
-    os.environ["CFLAGS"] = os.environ.get("CFLAGS", "") + pkg_config("xnvme", "--libs")
+    os.environ["CFLAGS"] = os.environ.get("CFLAGS", "") + pkg_config(
+        "xnvme", "--cflags"
+    )
 
     includedir = pkg_config("xnvme", "--variable=includedir")
     assert (

--- a/python/xnvme-cy-header/xnvme/cython_header/tests/setup.py
+++ b/python/xnvme-cy-header/xnvme/cython_header/tests/setup.py
@@ -20,7 +20,7 @@ def pkg_config(*args):
         return ""
 
 
-os.environ["CFLAGS"] = os.environ.get("CFLAGS", "") + pkg_config("xnvme", "--libs")
+os.environ["CFLAGS"] = os.environ.get("CFLAGS", "") + pkg_config("xnvme", "--cflags")
 
 includedir = pkg_config("xnvme", "--variable=includedir")
 assert includedir, "pkg-config returned an empty string as includedir. This won't work."

--- a/subprojects/packagefiles/spdk/meson.build
+++ b/subprojects/packagefiles/spdk/meson.build
@@ -5,6 +5,56 @@ project(
 )
 fs = import('fs')
 
+system_support = ['freebsd', 'linux', 'windows', 'darwin']
+system = host_machine.system()
+message('host_machine.system:', system)
+if not system_support.contains(system)
+    error('Unsupported system type "@0@"'.format(exec_env))
+endif
+foreach sys : system_support
+    set_variable('is_' + sys, system == sys)
+endforeach
+
+is_centos7 = is_linux ? run_command('cat', '/etc/os-release', check: false).stdout().contains('CentOS Linux 7') : false
+
+cc = meson.get_compiler('c')
+
+math_dep = cc.find_library(
+  'm',
+  has_headers: ['math.h'],
+)
+
+ssl_dep = dependency(
+  is_centos7 ? 'openssl11' : 'openssl', version: '>=1.1.1',
+)
+
+dlfcn_dep = cc.find_library(
+  'dl',
+  has_headers: ['dlfcn.h'],
+)
+
+uuid_dep = cc.find_library(
+  'uuid',
+  dirs: is_freebsd ? [ '/usr/local/lib' ] : [],
+  header_include_directories: is_freebsd ? [ include_directories('/usr/local/include') ] : [],
+  has_headers: ['uuid/uuid.h'],
+)
+numa_dep = cc.find_library(
+  'numa',
+  has_headers: ['numaif.h'],
+  required: is_linux,
+)
+execinfo_dep = cc.find_library(
+  'execinfo',
+  has_headers: ['execinfo.h'],
+  required: is_freebsd,
+)
+elf_dep = cc.find_library(
+  'elf',
+  has_headers: ['sys/elf_common.h'],
+  required: is_freebsd,
+)
+
 if get_option('build_subprojects') and not fs.exists('build')
   message('Patching ..')
   run_command('spdk_patches.sh', capture: true, check: true)
@@ -74,9 +124,9 @@ isal_libnames = get_option('build_subprojects') ? [
   'isal',
 ] : []
 
-cc = meson.get_compiler('c')
+spdk_deps = [dlfcn_dep, math_dep, numa_dep, uuid_dep, ssl_dep, ssl_dep, execinfo_dep, elf_dep,]
+
 spdk_paths = []
-spdk_libs = []
 foreach libname : spdk_libnames + dpdk_libnames + isal_libnames
   lib_dep = cc.find_library(
     libname,
@@ -87,7 +137,6 @@ foreach libname : spdk_libnames + dpdk_libnames + isal_libnames
     ],
     static: true
   )
-  spdk_libs += lib_dep
 
   # Create a bunch of paths
   paths = [
@@ -106,14 +155,11 @@ spdk_inc = get_option('build_subprojects') ? include_directories(
   'dpdk' / 'build' / 'include',
   'build' / 'include'
 ) : include_directories('.')
-spdk_link_args = ['-Wl,--whole-archive', '-Wl,--no-as-needed'] + spdk_paths + ['-Wl,--no-whole-archive', '-Wl,--as-needed']
+spdk_link_args = ['-Wl,--whole-archive'] + spdk_paths + ['-Wl,--no-whole-archive']
 
 # Construct link_args based on the above
 spdk_dep = declare_dependency(
-  dependencies: spdk_libs,
+  dependencies: spdk_deps,
   link_args: spdk_link_args,
   include_directories: spdk_inc,
-  variables: {'lib_paths': get_option('build_subprojects') ? ' '.join(spdk_paths) : '.'}
 )
-
-meson.override_dependency('spdk', spdk_dep)

--- a/subprojects/spdk.wrap
+++ b/subprojects/spdk.wrap
@@ -9,5 +9,4 @@ patch_directory = spdk
 clone-recursive = true
 
 [provide]
-spdk = spdk
-dependency_names = spdk
+_spdk = spdk_dep

--- a/toolbox/pkgs/centos-stream9-build.sh
+++ b/toolbox/pkgs/centos-stream9-build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# configure xNVMe and build dependencies (fio, libvfn, and SPDK)
+meson setup builddir --prefix=/usr
+
+# build xNVMe
+meson compile -C builddir
+
+# install xNVMe
+meson install -C builddir
+
+# uninstall xNVMe
+# cd builddir && meson --internal uninstall

--- a/toolbox/pkgs/fedora-36-build.sh
+++ b/toolbox/pkgs/fedora-36-build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# configure xNVMe and build dependencies (fio, libvfn, and SPDK)
+meson setup builddir --prefix=/usr
+
+# build xNVMe
+meson compile -C builddir
+
+# install xNVMe
+meson install -C builddir
+
+# uninstall xNVMe
+# cd builddir && meson --internal uninstall

--- a/toolbox/pkgs/fedora-37-build.sh
+++ b/toolbox/pkgs/fedora-37-build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# configure xNVMe and build dependencies (fio, libvfn, and SPDK)
+meson setup builddir --prefix=/usr
+
+# build xNVMe
+meson compile -C builddir
+
+# install xNVMe
+meson install -C builddir
+
+# uninstall xNVMe
+# cd builddir && meson --internal uninstall

--- a/toolbox/pkgs/fedora-38-build.sh
+++ b/toolbox/pkgs/fedora-38-build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# configure xNVMe and build dependencies (fio, libvfn, and SPDK)
+meson setup builddir --prefix=/usr
+
+# build xNVMe
+meson compile -C builddir
+
+# install xNVMe
+meson install -C builddir
+
+# uninstall xNVMe
+# cd builddir && meson --internal uninstall


### PR DESCRIPTION
A refactoring of the build system for xNVMe is required to get closer to the goal of distributing xNVMe in the native package system of linux distros, like Fedora and Debian.

The main goal is to move away from bundling libraries into xNVMe by default. Instead, xNVMe should produce a "clean" library by default and only allow for bundling when building from source.
A consequence of this is that SPDK will only be available when using the bundled library built from source. 