### PR TITLE
be/linux: Use io_uring_free_probe instead of free

### DIFF
--- a/lib/xnvme_be_linux_async_ucmd.c
+++ b/lib/xnvme_be_linux_async_ucmd.c
@@ -41,7 +41,7 @@ _linux_liburing_noptional_missing(void)
 		}
 	}
 
-	free(probe);
+	io_uring_free_probe(probe);
 
 	return missing;
 }


### PR DESCRIPTION
Liburing uses nolibc by default in some architecture. This means that it might have its own version of free. Use the liburing free version for the uring probe so we do not run into incompatibilities
