### PR TITLE
Add KV and FDP enabled namespaces

### DIFF
--- a/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/logic/test_xnvme_tests_kvs.py
+++ b/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/tests/logic/test_xnvme_tests_kvs.py
@@ -2,6 +2,8 @@ import pytest
 
 from ..conftest import xnvme_parametrize
 
+pytest.skip(allow_module_level=True, reason="Not implemented")
+
 
 @xnvme_parametrize(labels=["kvs"], opts=["be", "admin"])
 def test_kvs_io(cijoe, device, be_opts, cli_args):

--- a/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/worklets/guest_start_nvme.py
+++ b/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/worklets/guest_start_nvme.py
@@ -3,6 +3,21 @@
 Start a qemu-guest with NVMe devices
 ====================================
 
+This creates a configuration, which on a recent Linux installation would be
+something like:
+
+* /dev/ng0n1 -- nvm
+* /dev/ng0n2 -- zns
+* /dev/ng0n3 -- kv
+
+* /dev/ng1n1 -- nvm
+
+* /dev/ng2n1 -- nvm (mdts=0 / unlimited)
+
+Using the the 'ng' device-handle, as it is always available, whereas 'nvme' are
+only for block-devices. Regardless, the above is just to illustrate one
+possible "appearance" of the devices in Linux.
+
 Retargetable: false
 -------------------
 """

--- a/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/worklets/guest_start_nvme.py
+++ b/toolbox/cijoe-pkg-xnvme/src/cijoe/xnvme/worklets/guest_start_nvme.py
@@ -13,6 +13,7 @@ something like:
 * /dev/ng1n1 -- nvm
 
 * /dev/ng2n1 -- nvm (mdts=0 / unlimited)
+* /dev/ng3n1 -- fdp-enabled subsystem and nvm namespace
 
 Using the the 'ng' device-handle, as it is always available, whereas 'nvme' are
 only for block-devices. Regardless, the above is just to illustrate one
@@ -181,6 +182,35 @@ def qemu_nvme_args(nvme_img_root):
     drive4, qemu_nvme_dev4 = namespace(controller_id3, 1)
     nvme += qemu_nvme_dev4
     drives.append(drive4)
+
+    #
+    # Nvme3 - Controller with FDP enabled subsystem
+    #
+    subsys_name = "subsys0"
+    subsys_attributes = {
+        "fdp": "on",
+        "fdp.nruh": "8",
+        "fdp.nrg": "32",
+        "fdp.runs": "40960",
+    }
+    nvme += subsystem(subsys_name, aux=subsys_attributes)
+
+    controller_id4 = "nvme3"
+    controller_bus4 = "pcie_downstream_port4"
+    controller_slot4 = 4
+    nvme += controller(
+        controller_id4,
+        "beefcace",
+        0,
+        controller_bus4,
+        upstream_bus,
+        controller_slot4,
+        subsys_name,
+    )
+
+    drv_fdp, qemu_nvme_dev_fdp = namespace(controller_id4, 1, {"fdp.ruhs": "'0;5;6;7'"})
+    nvme += qemu_nvme_dev_fdp
+    drives.append(drv_fdp)
 
     return drives, nvme
 

--- a/toolbox/workflow/configs/debian-bullseye.config
+++ b/toolbox/workflow/configs/debian-bullseye.config
@@ -123,6 +123,17 @@ devices:
   driver_attachment: "userspace"
   spdk_conf:
 
+- uri: "/dev/ng0n3"
+  nsid: 3
+  labels: ["dev", "cdev", "kvs"]
+  driver_attachment: "kernel"
+  spdk_conf:
+- uri: "0000:03:00.0"
+  nsid: 3
+  labels: ["dev", "pcie", "kvs"]
+  driver_attachment: "userspace"
+  spdk_conf:
+
 - uri: "/dev/nvme1n1"
   nsid: 1
   labels: ["dev", "bdev", "nvm", "scc", "write_zeroes"]

--- a/toolbox/workflow/configs/debian-bullseye.config
+++ b/toolbox/workflow/configs/debian-bullseye.config
@@ -145,6 +145,22 @@ devices:
   driver_attachment: "kernel"
   spdk_conf:
 
+- uri: "/dev/nvme3n1"
+  nsid: 1
+  labels: ["dev", "bdev", "nvm", "scc", "fdp"]
+  driver_attachment: "kernel"
+  spdk_conf:
+- uri: "/dev/ng3n1"
+  nsid: 1
+  labels: ["dev", "cdev", "nvm", "scc", "fdp"]
+  driver_attachment: "kernel"
+  spdk_conf:
+- uri: "0000:06:00.0"
+  nsid: 1
+  labels: ["dev", "pcie", "nvm", "scc", "fdp"]
+  driver_attachment: "userspace"
+  spdk_conf:
+
 - uri: "127.0.0.1:4420"
   nsid: 1
   labels: ["dev", "fabrics", "nvm", "write_zeroes"]


### PR DESCRIPTION
@ankit-sam this should be what is needed for the ``build-and-test`` to have an NVMe-namespace with FDP enabled to use for testing. When writing this, I realize a short-coming/todo:

- [x] Split commit for readability
  - [x] Re-factor of the guest_start_nvme script
  - [x] Add the FDP / subsystem stuff
- [x] Add device-definitions in the **cijoe** configs for the FDP-enabled namespace
- [x] Add device-definitions in the **cijoe** configs for the KV-enabled namespace