### PR TITLE
ci/build_and_test: kill qemu and remove guest-directory 

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -870,12 +870,17 @@ jobs:
         path: toolbox/workflow/provision-${{ matrix.guest.os }}-${{ matrix.guest.ver }}/*
         if-no-files-found: error
 
+    - name: CIJOE, compress workflow-report-test
+      if: always()
+      run: |
+        tar czf test-results-${{ matrix.guest.os }}-${{ matrix.guest.ver }}.tar.gz toolbox/workflow/test-${{ matrix.guest.os }}-${{ matrix.guest.ver }}/* 
+
     - name: CIJOE, upload workflow-report-test
       uses: actions/upload-artifact@v3.1.1
       if: always()
       with:
         name: test-results-${{ matrix.guest.os }}-${{ matrix.guest.ver }}
-        path: toolbox/workflow/test-${{ matrix.guest.os }}-${{ matrix.guest.ver }}/*
+        path: test-results-${{ matrix.guest.os }}-${{ matrix.guest.ver }}.tar.gz
         if-no-files-found: error
 
   # This is a lot of effort to generate documentation, however, it ensures that command-line

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -782,6 +782,8 @@ jobs:
     steps:
     - name: Runnner-prep, clean up self-hosted left-overs
       run: |
+        pkill -f qemu || true
+        rm -r $HOME/guests || true
         rm -rf *
         ls -lh
 


### PR DESCRIPTION
When switching runners from one to six per host, then the left-over
state of qemu-guests collides.

This change prevents this by first killing qemu and then removing
$HOME/guests before provisioning+starting the qemu-guest.
Thereby ensuring that no previous qemu instance is running and no
auxilary files are left over.