### PR TITLE
rpmbuild: fix directory conflicts error

### DIFF
--- a/xnvme.spec.in
+++ b/xnvme.spec.in
@@ -30,7 +30,9 @@ meson install -C build --destdir %{buildroot}
 
 %files
 %attr(0644,root,root) %{_includedir}/*
-%attr(0644,root,root) %{_libdir}/*
+%dir %attr(0755,root,root) %{_libdir}/pkgconfig
+%attr(0644,root,root) %{_libdir}/pkgconfig/*
+%attr(0755,root,root) %{_libdir}/*.*
 %attr(0644,root,root) %{_mandir}/man1/*
-%attr(0644,root,root) %{_bindir}/*
+%attr(0755,root,root) %{_bindir}/*
 %attr(0644,root,root) %{_datadir}/xnvme/*


### PR DESCRIPTION
when directory is created in some other package it occur below error file /usr/local/lib64/pkgconfig from install of xnvme-0.6.0-0.x86_64 conflicts

Add executable permission for library, bin files