### PR TITLE
be:spdk: Add option to control admin and io command timeout

### DIFF
--- a/include/libxnvme.h
+++ b/include/libxnvme.h
@@ -68,15 +68,17 @@ struct xnvme_opts {
 	struct {
 		uint32_t value : 31;
 		uint32_t given : 1;
-	} css;                 ///< SPDK controller-setup: do command-set-selection
-	uint32_t use_cmb_sqs;  ///< SPDK controller-setup: use controller-memory-buffer for sq
-	uint32_t shm_id;       ///< SPDK multi-processing: shared-memory-id
-	uint32_t main_core;    ///< SPDK multi-processing: main-core
-	const char *core_mask; ///< SPDK multi-processing: core-mask
-	const char *adrfam;    ///< SPDK fabrics: address-family, IPv4/IPv6
-	const char *subnqn;    ///< SPDK fabrics: Subsystem NQN
-	const char *hostnqn;   ///< SPDK fabrics: Host NQN
-	uint32_t spdk_fabrics; ///< Is assigned a value by backend if SPDK uses fabrics
+	} css;                    ///< SPDK controller-setup: do command-set-selection
+	uint32_t use_cmb_sqs;     ///< SPDK controller-setup: use controller-memory-buffer for sq
+	uint32_t shm_id;          ///< SPDK multi-processing: shared-memory-id
+	uint32_t main_core;       ///< SPDK multi-processing: main-core
+	const char *core_mask;    ///< SPDK multi-processing: core-mask
+	const char *adrfam;       ///< SPDK fabrics: address-family, IPv4/IPv6
+	const char *subnqn;       ///< SPDK fabrics: Subsystem NQN
+	const char *hostnqn;      ///< SPDK fabrics: Host NQN
+	uint32_t admin_timeout;   ///< SPDK fabrics: enable admin command timeout
+	uint32_t command_timeout; ///< SPDK fabrics: enable io command timeout
+	uint32_t spdk_fabrics;    ///< Is assigned a value by backend if SPDK uses fabrics
 };
 
 /**

--- a/lib/xnvme_be_spdk_dev.c
+++ b/lib/xnvme_be_spdk_dev.c
@@ -26,8 +26,6 @@
 #define XNVME_BE_SPDK_AVLB_TRANSPORTS 3
 
 #define XNVME_BE_SPDK_CREFS_LEN 100
-#define XNVME_BE_SPDK_ADMIN_TIMEOUT 60000000
-#define XNVME_BE_SPDK_COMMAND_TIMEOUT 30000000
 static struct xnvme_be_spdk_ctrlr_ref g_cref[XNVME_BE_SPDK_CREFS_LEN];
 
 /**
@@ -474,8 +472,10 @@ attach_cb(void *cb_ctx, const struct spdk_nvme_transport_id *trid, struct spdk_n
 		XNVME_DEBUG("FAILED: _cref_insert(), err: %d", err);
 		return;
 	}
-	spdk_nvme_ctrlr_register_timeout_callback(ctrlr, XNVME_BE_SPDK_COMMAND_TIMEOUT,
-						  XNVME_BE_SPDK_ADMIN_TIMEOUT, timeout_cb_func, 0);
+	if (opts->command_timeout > 0 && opts->admin_timeout > 0) {
+		spdk_nvme_ctrlr_register_timeout_callback(ctrlr, opts->command_timeout,
+							  opts->admin_timeout, timeout_cb_func, 0);
+	}
 }
 
 void

--- a/lib/xnvme_opts.c
+++ b/lib/xnvme_opts.c
@@ -16,6 +16,8 @@ xnvme_opts_default(void)
 
 	opts.rdwr = 1;
 	opts.nsid = 1;
+	opts.admin_timeout = 60000000;
+	opts.command_timeout = 30000000;
 
 	// Value is only applicable if the user also sets opts.create = 1
 	opts.create_mode = S_IRUSR | S_IWUSR;


### PR DESCRIPTION
We have found that for certain applications, we would want to change/remove the timeout on admin commands and io commands. This commit allows to choose the command timeout from the xnvme_opts