### PR TITLE
be/vfio: bump libvfn to v2.0.0

### DIFF
--- a/lib/xnvme_be_vfio_async.c
+++ b/lib/xnvme_be_vfio_async.c
@@ -94,7 +94,7 @@ xnvme_be_vfio_queue_poke(struct xnvme_queue *queue, uint32_t max)
 
 int
 xnvme_be_vfio_async_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes, void *mbuf,
-			   size_t XNVME_UNUSED(mbuf_nbytes))
+			   size_t mbuf_nbytes)
 {
 	struct xnvme_queue_vfio *q = (struct xnvme_queue_vfio *)ctx->async.queue;
 	struct xnvme_be_vfio_state *state = (void *)q->base.dev->be.state;
@@ -122,7 +122,7 @@ xnvme_be_vfio_async_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nb
 	rq->opaque = ctx;
 
 	if (dbuf) {
-		if (!vfio_iommu_vaddr_to_iova(&state->ctrl->pci.vfio.iommu, dbuf, &iova)) {
+		if (!vfio_map_vaddr(state->ctrl->pci.dev.vfio, dbuf, dbuf_nbytes, &iova)) {
 			XNVME_DEBUG("FAILED: vfio_iommu_vaddr_to_iova()");
 			goto err;
 		}
@@ -131,7 +131,7 @@ xnvme_be_vfio_async_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nb
 	}
 
 	if (mbuf) {
-		if (!vfio_iommu_vaddr_to_iova(&state->ctrl->pci.vfio.iommu, mbuf, &iova)) {
+		if (!vfio_map_vaddr(state->ctrl->pci.dev.vfio, mbuf, mbuf_nbytes, &iova)) {
 			XNVME_DEBUG("FAILED: vfio_iommu_vaddr_to_iova()");
 			goto err;
 		}

--- a/lib/xnvme_be_vfio_sync.c
+++ b/lib/xnvme_be_vfio_sync.c
@@ -12,7 +12,7 @@
 
 int
 xnvme_be_vfio_sync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nbytes, void *mbuf,
-			  size_t XNVME_UNUSED(mbuf_nbytes))
+			  size_t mbuf_nbytes)
 {
 	struct xnvme_be_vfio_state *state = (void *)ctx->dev->be.state;
 	struct nvme_ctrl *ctrl = state->ctrl;
@@ -44,7 +44,7 @@ xnvme_be_vfio_sync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nby
 	}
 
 	if (dbuf) {
-		if (!vfio_iommu_vaddr_to_iova(&ctrl->pci.vfio.iommu, dbuf, &iova)) {
+		if (!vfio_map_vaddr(ctrl->pci.dev.vfio, dbuf, dbuf_nbytes, &iova)) {
 			XNVME_DEBUG("FAILED: vfio_iommu_vaddr_to_iova()");
 			ret = -EINVAL;
 			goto out;
@@ -54,7 +54,7 @@ xnvme_be_vfio_sync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nby
 	}
 
 	if (mbuf) {
-		if (!vfio_iommu_vaddr_to_iova(&state->ctrl->pci.vfio.iommu, mbuf, &iova)) {
+		if (!vfio_map_vaddr(state->ctrl->pci.dev.vfio, mbuf, mbuf_nbytes, &iova)) {
 			XNVME_DEBUG("FAILED: vfio_iommu_vaddr_to_iova()");
 			ret = -EINVAL;
 			goto out;

--- a/meson.build
+++ b/meson.build
@@ -196,6 +196,7 @@ iokit_dep = dependency(
 )
 libvfn_dep = dependency(
   'libvfn',
+  version: '>=2.0.2',
   required: conf_data.get('XNVME_BE_LINUX_VFIO_ENABLED')
 )
 

--- a/toolbox/pkgs/archlinux-latest.sh
+++ b/toolbox/pkgs/archlinux-latest.sh
@@ -41,7 +41,7 @@ pacman -S --noconfirm \
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir

--- a/toolbox/pkgs/centos-centos7.sh
+++ b/toolbox/pkgs/centos-centos7.sh
@@ -79,7 +79,7 @@ python3 -m pip install \
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 
 # Source in the newer gcc-toolchain before building
 source /opt/rh/devtoolset-8/enable

--- a/toolbox/pkgs/centos-stream8.sh
+++ b/toolbox/pkgs/centos-stream8.sh
@@ -76,7 +76,7 @@ python3 -m pip install \
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir

--- a/toolbox/pkgs/centos-stream9.sh
+++ b/toolbox/pkgs/centos-stream9.sh
@@ -62,7 +62,7 @@ cd ..
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir

--- a/toolbox/pkgs/debian-bookworm.sh
+++ b/toolbox/pkgs/debian-bookworm.sh
@@ -50,7 +50,7 @@ apt-get -qy install \
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir

--- a/toolbox/pkgs/debian-bullseye.sh
+++ b/toolbox/pkgs/debian-bullseye.sh
@@ -63,7 +63,7 @@ cd ..
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir

--- a/toolbox/pkgs/debian-buster.sh
+++ b/toolbox/pkgs/debian-buster.sh
@@ -63,7 +63,7 @@ cd ..
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir

--- a/toolbox/pkgs/emitter/templates/src-libvfn-centos-centos7.sh.jinja
+++ b/toolbox/pkgs/emitter/templates/src-libvfn-centos-centos7.sh.jinja
@@ -7,7 +7,7 @@
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 
 # Source in the newer gcc-toolchain before building
 source /opt/rh/devtoolset-8/enable

--- a/toolbox/pkgs/emitter/templates/src-libvfn.sh.jinja
+++ b/toolbox/pkgs/emitter/templates/src-libvfn.sh.jinja
@@ -7,7 +7,7 @@
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir

--- a/toolbox/pkgs/fedora-36.sh
+++ b/toolbox/pkgs/fedora-36.sh
@@ -42,7 +42,7 @@ dnf install -y \
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir

--- a/toolbox/pkgs/fedora-37.sh
+++ b/toolbox/pkgs/fedora-37.sh
@@ -44,7 +44,7 @@ dnf install -y \
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir

--- a/toolbox/pkgs/fedora-38.sh
+++ b/toolbox/pkgs/fedora-38.sh
@@ -44,7 +44,7 @@ dnf install -y \
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir

--- a/toolbox/pkgs/gentoo-latest.sh
+++ b/toolbox/pkgs/gentoo-latest.sh
@@ -37,7 +37,7 @@ emerge \
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir

--- a/toolbox/pkgs/opensuse-leap-15.3.sh
+++ b/toolbox/pkgs/opensuse-leap-15.3.sh
@@ -59,7 +59,7 @@ cd ..
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir

--- a/toolbox/pkgs/opensuse-leap-15.4.sh
+++ b/toolbox/pkgs/opensuse-leap-15.4.sh
@@ -59,7 +59,7 @@ cd ..
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir

--- a/toolbox/pkgs/opensuse-tumbleweed-latest.sh
+++ b/toolbox/pkgs/opensuse-tumbleweed-latest.sh
@@ -45,7 +45,7 @@ zypper --non-interactive install -y --allow-downgrade \
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir

--- a/toolbox/pkgs/ubuntu-focal.sh
+++ b/toolbox/pkgs/ubuntu-focal.sh
@@ -63,7 +63,7 @@ cd ..
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir

--- a/toolbox/pkgs/ubuntu-jammy.sh
+++ b/toolbox/pkgs/ubuntu-jammy.sh
@@ -63,7 +63,7 @@ cd ..
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir

--- a/toolbox/pkgs/ubuntu-kinetic.sh
+++ b/toolbox/pkgs/ubuntu-kinetic.sh
@@ -50,7 +50,7 @@ apt-get -qy install \
 #
 git clone https://github.com/OpenMPDK/libvfn.git
 cd libvfn
-git checkout v1.0.0
+git checkout v2.0.2
 meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
 meson compile -C builddir
 meson install -C builddir


### PR DESCRIPTION
Update the libvfn-based backend to libvfn v2.0.0.