### PR TITLE
catch exc iff pkg-config is not in path

### DIFF
--- a/python/bindings/xnvme/ctypes_bindings/library_loader.py
+++ b/python/bindings/xnvme/ctypes_bindings/library_loader.py
@@ -40,7 +40,7 @@ def search_paths():
             ext = SHARED_EXT.get(platform.system().lower(), "so")
 
             yield os.path.join(proc.stdout.decode("utf-8").strip(), f"libxnvme.{ext}")
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         pass
 
 


### PR DESCRIPTION
`subprocess.run` raises FileNotFoundError iff. binary (pkg-config) is not in PATH.
Catch this error, same as if pkg-config returned a non-zero exit code.