### PR TITLE
allow overriding library loading by env var

### DIFF
--- a/python/bindings/auxiliary/patch_ctypes_bindings.py
+++ b/python/bindings/auxiliary/patch_ctypes_bindings.py
@@ -35,7 +35,7 @@ SNIPPETS = {
         "   if is_loaded:\n"
         "       return\n"
         "\n"
-        '   print("FAILED: library is not loadable; perhaps install xNVMe?")\n'
+        '   print("FAILED: library is not loadable; perhaps set XNVME_LIBRARY_PATH to point to the library?")\n'
         "   sys.exit(1)\n"
     ),
 }

--- a/python/bindings/xnvme/ctypes_bindings/library_loader.py
+++ b/python/bindings/xnvme/ctypes_bindings/library_loader.py
@@ -47,6 +47,13 @@ def search_paths():
 def load():
     """Dynamically load the xNVMe shared library"""
 
+    path = os.getenv("XNVME_LIBRARY_PATH", None)
+    if path:
+        try:
+            return ctypes.CDLL(path)
+        except OSError:
+            pass
+
     for spath in search_paths():
         try:
             lib = ctypes.CDLL(spath)


### PR DESCRIPTION
**Use-case**
My system might differ from yours, I may not have pkg-config, or I may have a copy of xNVMe installed elsewhere.

This change permits me to override the library-loading logic by exporting `XNVME_LIBRARY_PATH`, pointing to the library file I want to load.
This change even allows users of any downstream applications to work around issues of locating the xNVMe library on their systems, without the application making special provisions.