### PR TITLE
Fix KVS test

### DIFF
--- a/cijoe/tests/logic/test_xnvme_tests_kvs.py
+++ b/cijoe/tests/logic/test_xnvme_tests_kvs.py
@@ -12,3 +12,12 @@ def test_kvs_io(cijoe, device, be_opts, cli_args):
 
     err, _ = cijoe.run(f"xnvme_tests_kvs kvs_io {cli_args}")
     assert not err
+
+
+@xnvme_parametrize(labels=["kvs"], opts=["be", "admin"])
+def test_kvs_io_custom_kv(cijoe, device, be_opts, cli_args):
+    if be_opts["sync"] in ["block", "psync"]:
+        pytest.skip(reason="Linux Block layer does not support simple-copy")
+
+    err, _ = cijoe.run(f"xnvme_tests_kvs kvs_io {cli_args} --key tango --value charlie")
+    assert not err

--- a/cijoe/tests/logic/test_xnvme_tests_kvs.py
+++ b/cijoe/tests/logic/test_xnvme_tests_kvs.py
@@ -7,17 +7,11 @@ pytest.skip(allow_module_level=True, reason="Not implemented")
 
 @xnvme_parametrize(labels=["kvs"], opts=["be", "admin"])
 def test_kvs_io(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] in ["block", "psync"]:
-        pytest.skip(reason="Linux Block layer does not support simple-copy")
-
     err, _ = cijoe.run(f"xnvme_tests_kvs kvs_io {cli_args}")
     assert not err
 
 
 @xnvme_parametrize(labels=["kvs"], opts=["be", "admin"])
 def test_kvs_io_custom_kv(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] in ["block", "psync"]:
-        pytest.skip(reason="Linux Block layer does not support simple-copy")
-
     err, _ = cijoe.run(f"xnvme_tests_kvs kvs_io {cli_args} --key tango --value charlie")
     assert not err

--- a/tests/kvs.c
+++ b/tests/kvs.c
@@ -11,19 +11,23 @@ kvs_io(struct xnvme_cli *cli)
 	struct xnvme_dev *dev = cli->args.dev;
 	struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
 	uint8_t nsid = cli->args.nsid;
-	void *kv_key = NULL;
-	void *kv_val = NULL;
+	const void *kv_key;
+	const void *kv_val;
 	void *dbuf = NULL;
 	void *rbuf = NULL;
 	uint8_t kv_key_nbytes = 0;
 	size_t kv_val_nbytes = 0;
 	int err;
 
-	if (!cli->given[XNVME_CLI_OPT_KV_KEY]) {
+	if (cli->given[XNVME_CLI_OPT_KV_KEY]) {
+		kv_key = cli->args.kv_key;
+	} else {
 		kv_key = "marco";
 	}
 
-	if (!cli->given[XNVME_CLI_OPT_KV_VAL]) {
+	if (cli->given[XNVME_CLI_OPT_KV_VAL]) {
+		kv_val = cli->args.kv_val;
+	} else {
 		kv_val = "polo";
 	}
 

--- a/tests/kvs.c
+++ b/tests/kvs.c
@@ -10,7 +10,7 @@ kvs_io(struct xnvme_cli *cli)
 {
 	struct xnvme_dev *dev = cli->args.dev;
 	struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
-	uint8_t nsid = cli->args.nsid;
+	uint8_t nsid = cli->args.dev_nsid;
 	const void *kv_key;
 	const void *kv_val;
 	void *dbuf = NULL;
@@ -34,7 +34,7 @@ kvs_io(struct xnvme_cli *cli)
 	kv_key_nbytes = strlen(kv_key);
 	kv_val_nbytes = strlen(kv_val) + 1;
 
-	if (!cli->given[XNVME_CLI_OPT_NSID]) {
+	if (!cli->given[XNVME_CLI_OPT_DEV_NSID]) {
 		nsid = xnvme_dev_get_nsid(cli->args.dev);
 	}
 


### PR DESCRIPTION
There were two oversights in the kvs test, these have been corrected.

Additionally, a cijoe test has been added using the functionality that previously failed.
This should resolve #310 