### PR TITLE
fix(gha): adjust conditions for build-and-test

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -118,154 +118,6 @@ jobs:
       run: make gen-man-pages
 
   #
-  # Code-analysis using scan-build
-  #
-  analyze-scan-build:
-    needs: source-archive
-    runs-on: ubuntu-latest
-    container: ghcr.io/xnvme/xnvme-deps-citools-latest:next
-    if: ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'analyze'))
-
-    steps:
-    - name: Retrieve the xNVMe source archive
-      uses: actions/download-artifact@v3.0.1
-      with:
-        name: xnvme-src-archive
-    - name: Extract, and then remove, the xNVMe source archive
-      run: |
-        tar xzf xnvme-src.tar.gz --strip 1
-        rm xnvme-src.tar.gz
-
-    - name: Run config-debug
-      run: scan-build make config-debug
-
-    - name: Run scan-build
-      run: scan-build --exclude subprojects -o /tmp/scan-build-report make
-
-    - name: Upload scan-build report
-      uses: actions/upload-artifact@v3.1.1
-      if: always()
-      with:
-        name: scan-build-report
-        path: /tmp/scan-build-report/*
-        if-no-files-found: error
-
-  #
-  # Code-analysis using GitHUB CodeQL
-  #
-  analyze-codeql:
-    needs: source-archive
-    runs-on: ubuntu-latest
-    container: debian:bullseye
-    if: ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'analyze'))
-
-    steps:
-    - name: Retrieve the xNVMe source archive
-      uses: actions/download-artifact@v3.0.1
-      with:
-        name: xnvme-src-archive
-    - name: Extract, and then remove, the xNVMe source archive
-      run: |
-        tar xzf xnvme-src.tar.gz --strip 1
-        rm xnvme-src.tar.gz
-
-    - name: Install build-requirements
-      run: source toolbox/pkgs/debian-bullseye.sh
-
-    - name: Configure, the build
-      run: make config
-
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: 'cpp'
-        config-file: ./.github/codeql/codeql-config.yml
-
-    - name: Build
-      run: make -j $(nproc)
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
-
-  #
-  # Code-analysis using Coverity
-  #
-  analyze-coverity:
-    needs: source-archive
-    runs-on: ubuntu-latest
-    if: ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'analyze'))
-
-    container: debian:buster
-    env:
-      COVERITY_TGZ_PATH: "/tmp/cov-analysis-linux64.tar.gz"
-      COVERITY_ROOT: "/tmp/cov-analysis-linux64"
-      PROJECT_NAME: "xNVMe"
-
-    steps:
-    - name: Retrieve the xNVMe source archive
-      uses: actions/download-artifact@v3.0.1
-      with:
-        name: xnvme-src-archive
-    - name: Extract, and then remove, the xNVMe source archive
-      run: |
-        tar xzf xnvme-src.tar.gz --strip 1
-        rm xnvme-src.tar.gz
-
-    - name: xNVMe, install build-requirements
-      run: |
-        source toolbox/pkgs/debian-buster.sh
-
-    - name: xNVMe, configure the build
-      run: |
-        make config
-
-    - name: xNVMe, dump the compile-commands and machine
-      run: |
-        cat /proc/cpuinfo || true
-        cat build/compile_commands.json || true
-
-    - name: Project, define version env. var.
-      run: |
-        PROJECT_VERSION=$(python3 toolbox/xnvme_ver.py --path meson.build)
-        echo "PROJECT_VERSION=${PROJECT_VERSION}" >> $GITHUB_ENV
-
-    - name: Coverity, install requirements
-      run: |
-        apt-get install -qy wget curl
-
-    - name: Coverity, download
-      run: |
-        wget -q https://scan.coverity.com/download/cxx/linux64 \
-         --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=${PROJECT_NAME}" \
-         -O ${COVERITY_TGZ_PATH}
-
-    - name: Coverity, unpack
-      run: |
-        mkdir -p "${COVERITY_ROOT}"
-        tar xzf "${COVERITY_TGZ_PATH}" --strip 1 -C "${COVERITY_ROOT}"
-
-    - name: Coverity, configure compiler/gcc
-      run: |
-        export PATH="${COVERITY_ROOT}/bin:$PATH"
-        cov-configure --gcc
-
-    - name: Coverity, build xNVMe
-      run: |
-        export PATH="${COVERITY_ROOT}/bin:$PATH"
-        make clean config
-        cov-build --dir cov-int make
-
-    - name: Coverity, submit results for analysis
-      run: |
-        tar czvf "${PROJECT_NAME}_cov.tgz" cov-int
-        curl --form token=${{ secrets.COVERITY_SCAN_TOKEN }} \
-        --form email=${{ secrets.COVERITY_SCAN_EMAIL }} \
-        --form file=@${PROJECT_NAME}_cov.tgz \
-        --form version="v${PROJECT_VERSION}" \
-        --form description="xNVMe libraries and tools for NVMe" \
-        "https://scan.coverity.com/builds?project=${PROJECT_NAME}"
-
-  #
   # Build xNVMe Python packages
   #
   build-python:
@@ -744,12 +596,29 @@ jobs:
         path: test-results-${{ matrix.guest.os }}-${{ matrix.guest.ver }}.tar.gz
         if-no-files-found: error
 
-  # This is a lot of effort to generate documentation, however, it ensures that command-line
-  # utilities, build-examples, commands-output of various kinds are up-to-date.
-  # It pushes branches to: docs/<branch>
-  # It pushes tags to: docs/<tag>
-  # and to: docs/latest
-  # The event only triggers on manual request via 'workflow_dispatch'
+
+  #
+  # Documentation: generate documentation and deploy it to githubpages (xnvme.io)
+  #
+  # This is triggered upon:
+  #
+  # * push of branches and tags
+  # * manual 'workflow_dispatch'
+  #
+  # When triggered on push to branch, then the documentation is deployed to:
+  #
+  #   githubpages/docs/<branch>
+  #
+  # For example: githubpages/docs/next
+  #
+  # When triggered on push of tag, then the documentation is deployed to:
+  #
+  #   githubpages/docs/<tag>
+  #   githubpages/docs/latest
+  #
+  # For example: githubpages/docs/v0.5.0
+  # Note that latest is always populated when pushing as tag. It is assumed
+  # that tags are used exclusively for releases
   docgen:
     needs: [source-archive, source-format-check, build-python]
     runs-on: self-hosted
@@ -858,3 +727,155 @@ jobs:
         name: docgen-results-${{ matrix.guest.os }}-${{ matrix.guest.ver }}
         path: cijoe/docgen-${{ matrix.guest.os }}-${{ matrix.guest.ver }}/*
         if-no-files-found: error
+
+  #
+  # All of the following "analysis" jobs only trigger on 'workflow_dispatch'
+  #
+
+  #
+  # Code-analysis using scan-build
+  #
+  analyze-scan-build:
+    needs: source-archive
+    runs-on: ubuntu-latest
+    container: ghcr.io/xnvme/xnvme-deps-citools-latest:next
+    if: ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'analyze'))
+
+    steps:
+    - name: Retrieve the xNVMe source archive
+      uses: actions/download-artifact@v3.0.1
+      with:
+        name: xnvme-src-archive
+    - name: Extract, and then remove, the xNVMe source archive
+      run: |
+        tar xzf xnvme-src.tar.gz --strip 1
+        rm xnvme-src.tar.gz
+
+    - name: Run config-debug
+      run: scan-build make config-debug
+
+    - name: Run scan-build
+      run: scan-build --exclude subprojects -o /tmp/scan-build-report make
+
+    - name: Upload scan-build report
+      uses: actions/upload-artifact@v3.1.1
+      if: always()
+      with:
+        name: scan-build-report
+        path: /tmp/scan-build-report/*
+        if-no-files-found: error
+
+  #
+  # Code-analysis using GitHUB CodeQL
+  #
+  analyze-codeql:
+    needs: source-archive
+    runs-on: ubuntu-latest
+    container: debian:bullseye
+    if: ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'analyze'))
+
+    steps:
+    - name: Retrieve the xNVMe source archive
+      uses: actions/download-artifact@v3.0.1
+      with:
+        name: xnvme-src-archive
+    - name: Extract, and then remove, the xNVMe source archive
+      run: |
+        tar xzf xnvme-src.tar.gz --strip 1
+        rm xnvme-src.tar.gz
+
+    - name: Install build-requirements
+      run: source toolbox/pkgs/debian-bullseye.sh
+
+    - name: Configure, the build
+      run: make config
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: 'cpp'
+        config-file: ./.github/codeql/codeql-config.yml
+
+    - name: Build
+      run: make -j $(nproc)
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
+
+  #
+  # Code-analysis using Coverity
+  #
+  analyze-coverity:
+    needs: source-archive
+    runs-on: ubuntu-latest
+    if: ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'analyze'))
+
+    container: debian:buster
+    env:
+      COVERITY_TGZ_PATH: "/tmp/cov-analysis-linux64.tar.gz"
+      COVERITY_ROOT: "/tmp/cov-analysis-linux64"
+      PROJECT_NAME: "xNVMe"
+
+    steps:
+    - name: Retrieve the xNVMe source archive
+      uses: actions/download-artifact@v3.0.1
+      with:
+        name: xnvme-src-archive
+    - name: Extract, and then remove, the xNVMe source archive
+      run: |
+        tar xzf xnvme-src.tar.gz --strip 1
+        rm xnvme-src.tar.gz
+
+    - name: xNVMe, install build-requirements
+      run: |
+        source toolbox/pkgs/debian-buster.sh
+
+    - name: xNVMe, configure the build
+      run: |
+        make config
+
+    - name: xNVMe, dump the compile-commands and machine
+      run: |
+        cat /proc/cpuinfo || true
+        cat build/compile_commands.json || true
+
+    - name: Project, define version env. var.
+      run: |
+        PROJECT_VERSION=$(python3 toolbox/xnvme_ver.py --path meson.build)
+        echo "PROJECT_VERSION=${PROJECT_VERSION}" >> $GITHUB_ENV
+
+    - name: Coverity, install requirements
+      run: |
+        apt-get install -qy wget curl
+
+    - name: Coverity, download
+      run: |
+        wget -q https://scan.coverity.com/download/cxx/linux64 \
+         --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=${PROJECT_NAME}" \
+         -O ${COVERITY_TGZ_PATH}
+
+    - name: Coverity, unpack
+      run: |
+        mkdir -p "${COVERITY_ROOT}"
+        tar xzf "${COVERITY_TGZ_PATH}" --strip 1 -C "${COVERITY_ROOT}"
+
+    - name: Coverity, configure compiler/gcc
+      run: |
+        export PATH="${COVERITY_ROOT}/bin:$PATH"
+        cov-configure --gcc
+
+    - name: Coverity, build xNVMe
+      run: |
+        export PATH="${COVERITY_ROOT}/bin:$PATH"
+        make clean config
+        cov-build --dir cov-int make
+
+    - name: Coverity, submit results for analysis
+      run: |
+        tar czvf "${PROJECT_NAME}_cov.tgz" cov-int
+        curl --form token=${{ secrets.COVERITY_SCAN_TOKEN }} \
+        --form email=${{ secrets.COVERITY_SCAN_EMAIL }} \
+        --form file=@${PROJECT_NAME}_cov.tgz \
+        --form version="v${PROJECT_VERSION}" \
+        --form description="xNVMe libraries and tools for NVMe" \
+        "https://scan.coverity.com/builds?project=${PROJECT_NAME}"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,14 +3,11 @@ name: verify
 
 on:
   push:
-    branches:
-    - '*'
-    tags:
-    - '*'
+    branches: [main, next]
+    tags: ['v*']
   pull_request:
     types: [opened, reopened, synchronize]
-    branches:
-    - '*'
+    branches: [next]
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
@@ -18,17 +15,10 @@ on:
       job:
         description: 'Job'
         required: true
-        default: all
+        default: docgen
         type: choice
         options:
-        - all
         - analyze
-        - analyze-codeql
-        - analyze-coverity
-        - build
-        - build-linux
-        - build-windows
-        - build-macos
         - build-and-test
         - docgen
 
@@ -134,6 +124,7 @@ jobs:
     needs: source-archive
     runs-on: ubuntu-latest
     container: ghcr.io/xnvme/xnvme-deps-citools-latest:next
+    if: ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'analyze'))
 
     steps:
     - name: Retrieve the xNVMe source archive
@@ -165,9 +156,8 @@ jobs:
   analyze-codeql:
     needs: source-archive
     runs-on: ubuntu-latest
-    if: ((github.event_name == 'workflow_dispatch') && ((github.event.inputs.job == 'all') || contains('analyze-codeql', github.event.inputs.job)))
-
     container: debian:bullseye
+    if: ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'analyze'))
 
     steps:
     - name: Retrieve the xNVMe source archive
@@ -203,8 +193,7 @@ jobs:
   analyze-coverity:
     needs: source-archive
     runs-on: ubuntu-latest
-    if: ((github.event_name == 'workflow_dispatch') && ((github.event.inputs.job == 'all') || contains('analyze-coverity',
-      github.event.inputs.job)))
+    if: ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'analyze'))
 
     container: debian:buster
     env:
@@ -282,8 +271,6 @@ jobs:
   build-python:
     needs: source-archive
     runs-on: ubuntu-latest
-    if: ((github.event_name == 'pull_request') || ((github.event_name == 'workflow_dispatch') && ((github.event.inputs.job
-      == 'all') || contains('build-linux', github.event.inputs.job) || contains('docgen', github.event.inputs.job))))
     container: ghcr.io/xnvme/xnvme-deps-debian-bullseye:next
     strategy:
       fail-fast: false
@@ -330,8 +317,7 @@ jobs:
   build-linux:
     needs: [source-archive, source-format-check, build-python]
     runs-on: ubuntu-latest
-    if: ((github.event_name == 'pull_request') || ((github.event_name == 'workflow_dispatch') && ((github.event.inputs.job
-      == 'all') || contains('build-linux', github.event.inputs.job))))
+    if: contains('merge_group push pull_request', github.event_name)
 
     strategy:
       fail-fast: false
@@ -491,8 +477,7 @@ jobs:
   build-macos:
     needs: [source-archive, source-format-check, build-python]
     runs-on: ${{ matrix.runner.os }}-${{ matrix.runner.ver }}
-    if: ((github.event_name == 'pull_request') || ((github.event_name == 'workflow_dispatch') && ((github.event.inputs.job
-      == 'all') || contains('build-macos', github.event.inputs.job))))
+    if: contains('merge_group push pull_request', github.event_name)
 
     strategy:
       fail-fast: false
@@ -583,8 +568,7 @@ jobs:
   build-windows:
     needs: [source-archive, source-format-check]
     runs-on: ${{ matrix.runner.os }}-${{ matrix.runner.ver }}
-    if: ((github.event_name == 'pull_request') || ((github.event_name == 'workflow_dispatch') && ((github.event.inputs.job
-      == 'all') || contains('build-windows', github.event.inputs.job))))
+    if: contains('merge_group push pull_request', github.event_name)
 
     strategy:
       fail-fast: false
@@ -652,8 +636,9 @@ jobs:
   build-and-test:
     needs: [source-archive, source-format-check, build-python]
     runs-on: self-hosted
-    if: (((github.event_name == 'workflow_dispatch') && ((github.event.inputs.job == 'all') || (github.event.inputs.job ==
-      'build-and-test'))) || contains(github.ref_name, 'gh-readonly-queue'))
+
+    if: (contains('merge_group push', github.event_name) || ((github.event_name == 'workflow_dispatch') || ((github.event_name
+      == 'workflow_dispatch') && (github.event.inputs.job == 'build-and-test'))))
 
     strategy:
       fail-fast: false
@@ -768,7 +753,7 @@ jobs:
   docgen:
     needs: [source-archive, source-format-check, build-python]
     runs-on: self-hosted
-    if: ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'docgen'))
+    if: ((github.event_name == 'push') || ((github.event_name == 'workflow_dispatch') && (github.event.inputs.job == 'docgen')))
 
     strategy:
       fail-fast: false

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,11 +8,10 @@ on:
     tags:
     - '*'
   pull_request:
-    types: [labeled, opened, reopened, synchronize]
+    types: [opened, reopened, synchronize]
     branches:
     - '*'
   merge_group:
-    branches: [next]
     types: [checks_requested]
   workflow_dispatch:
     inputs:
@@ -53,7 +52,6 @@ jobs:
   source-archive:
     runs-on: ubuntu-20.04
     container: ghcr.io/xnvme/xnvme-deps-alpine-latest:next
-    if: ((github.event.action != 'labeled') || (github.event.action == 'labeled') && (github.event.label.name == 'pr-ready-for-test'))
 
     steps:
     - name: Grab source
@@ -655,7 +653,7 @@ jobs:
     needs: [source-archive, source-format-check, build-python]
     runs-on: self-hosted
     if: (((github.event_name == 'workflow_dispatch') && ((github.event.inputs.job == 'all') || (github.event.inputs.job ==
-      'build-and-test'))) || (github.event_name == 'merge_group'))
+      'build-and-test'))) || contains(github.ref_name, 'gh-readonly-queue'))
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
With these changes, then it should possible to enable the github merge-queue. This means that:

* When a PR for the ``next`` branch meets all requirements
  * Is rebased / up-to-date
  * Has been reviewed
  * Passes "fast" checks (code-format and build-checks)

Then it can go into the "merge-queue", when entering the merge-queue, additional longer-running checks are performed, specifically: spinning up a virtual machine (qemu) with NVMe device emulation and running the full functional test-suite on it. In case the testing passes, then the PR is "automatically" merged into ``next``. In case it fails, then it is removed from the merge-queue and the submitter can choose to:

* Reproduce the issue locally
* Make changes
* Send to the merge-queue again

The merge-queue is introduced to make it more transparent when multiple PRs are ready to be merged but then they each have to sit and wait until it is their turn. In this flow, one has to constantly rebase as PRs trickle in. This also means re-running the long-running tests again and again. Thus, this integration-test-phase is **hopefully** now something that can be manage by the merge-queue, where PR as put on top of each other, and then tested.