### PR TITLE
Fix breakage of the automated doc. generator

### DIFF
--- a/docs/autogen/Makefile
+++ b/docs/autogen/Makefile
@@ -34,7 +34,7 @@ apis:
 .PHONY: commands
 commands:
 	@echo "# commands"
-	${VENV} kmdo $(DOCS_DIR)/getting_started
+	${VENV} kmdo $(DOCS_DIR)/getting_started --exclude "win"
 	${VENV} kmdo $(DOCS_DIR)/capis
 	${VENV} kmdo $(DOCS_DIR)/examples
 	${VENV} kmdo $(DOCS_DIR)/tools

--- a/docs/autogen/requirements.txt
+++ b/docs/autogen/requirements.txt
@@ -1,7 +1,7 @@
 breathe
 docutils==0.17
 Jinja2==3.0.3
-kmdo
+kmdo==1.0.6
 sphinx==3.0.0
 sphinx_rtd_theme
 sphinxcontrib-bibtex

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -447,16 +447,15 @@ Yielding the output:
 
 .. literalinclude:: xnvme_win_io_async_read_iocp.out
    :language: bash
-   :lines: 1-12
 
 
-Async I/O via ``iocp-th``
+Async I/O via ``iocp_th``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Similar to ``iocp`` interface, only difference is separate poller is used
-to fetch the completed IOs.
+Similar to ``iocp`` interface, only difference is separate poller is used to
+fetch the completed IOs.
 
-One can explicitly tell **xNVMe** to utilize ``iocp-th`` for async I/O by
+One can explicitly tell **xNVMe** to utilize ``iocp_th`` for async I/O by
 encoding it in the device identifier, like so:
 
 .. literalinclude:: xnvme_win_io_async_read_iocp_th.cmd
@@ -466,18 +465,17 @@ Yielding the output:
 
 .. literalinclude:: xnvme_win_io_async_read_iocp_th.out
    :language: bash
-   :lines: 1-12
 
 Async I/O via ``io_ring``
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **xNVMe** utilizes the Windows **io_ring** interface, its support for
 feature-probing the **io_ring** interface and the **io_ring** opcodes:
 
-When available, then **xNVMe** can send the **ioring** specific request using
-**IORING_HANDLE_REF** and **IORING_BUFFER_REF** structure for **read** via
-the Windows **io_ring** interface. Doing so improves command-throughput at
-all io-depths when compared to sending the command via NVMe Driver IOCTLs.
+When available, then **xNVMe** can send the **io_ring** specific request using
+**IORING_HANDLE_REF** and **IORING_BUFFER_REF** structure for **read** via the
+Windows **io_ring** interface. Doing so improves command-throughput at all
+io-depths when compared to sending the command via NVMe Driver IOCTLs.
 
 One can explicitly tell **xNVMe** to utilize ``io_ring`` for async I/O by
 encoding it in the device identifier, like so:

--- a/include/libxnvme_kvs.h
+++ b/include/libxnvme_kvs.h
@@ -25,6 +25,7 @@ enum xnvme_store_opts {
  * @param key_len KV Key size in bytes
  * @param vbuf pointer to Host Buffer
  * @param vbuf_nbytes Host Buffer size in bytes
+ * @param opt Retrieve options, see ::xnvme_retrieve_opts
  *
  * @return On success, 0 is returned. On error, negative `errno` is returned.
  */
@@ -41,6 +42,7 @@ xnvme_kvs_retrieve(struct xnvme_cmd_ctx *ctx, uint32_t nsid, const void *key, ui
  * @param key_len KV Key size in bytes
  * @param vbuf pointer to data payload
  * @param vbuf_nbytes data payload size in bytes
+ * @param opt Store-options, see ::xnvme_store_opts
  *
  * @return On success, 0 is returned. On error, negative `errno` is returned.
  */

--- a/include/libxnvme_mem.h
+++ b/include/libxnvme_mem.h
@@ -20,7 +20,6 @@
  * @param dev Device handle obtained with xnvme_dev_open()
  * @param vaddr Pointer to start of virtual memory to use as mapped memory
  * @param nbytes The number of bytes to map, starting at vaddr
- * @param phys Pointer to physical address e.g. pointer to an iova
  *
  * @return On success, 0 is returned. On error, negative `errno` is returned
  */

--- a/include/libxnvme_spec.h
+++ b/include/libxnvme_spec.h
@@ -2986,11 +2986,9 @@ xnvme_spec_ruhs_pr(const struct xnvme_spec_ruhs *ruhs, int limit, int opts);
  * Prints the given :;xnvme_spec_idfy_ns to the given output stream
  *
  * @param stream output stream used for printing
- * Prints the given :;xnvme_spec_idfy_ns to the given output stream
- *
- * @param stream output stream used for printing
  * @param idfy pointer to structure to print
  * @param opts printer options, see ::xnvme_pr
+ *
  * @return On success, the number of characters printed is returned.
  */
 int


### PR DESCRIPTION
This fixes the current breakage of the documentation generation. It fails as there are now ``.cmd`` files for Windows, however, it is not running in a Windows environment, thus need to be generated seperately and thus skipped for now in the automated doc. generator.