### PR TITLE
fix(build/fedora): add zlib-devel dependency

### DIFF
--- a/toolbox/pkgs/fedora-36.sh
+++ b/toolbox/pkgs/fedora-36.sh
@@ -31,7 +31,8 @@ dnf install -y \
  procps \
  python3-devel \
  python3-pip \
- python3-pyelftools
+ python3-pyelftools \
+ zlib-devel
 
 #
 # Clone, build and install libvfn

--- a/toolbox/pkgs/fedora-37.sh
+++ b/toolbox/pkgs/fedora-37.sh
@@ -33,7 +33,8 @@ dnf install -y \
  procps \
  python3-devel \
  python3-pip \
- python3-pyelftools
+ python3-pyelftools \
+ zlib-devel
 
 #
 # Clone, build and install libvfn

--- a/toolbox/pkgs/fedora-38.sh
+++ b/toolbox/pkgs/fedora-38.sh
@@ -33,7 +33,8 @@ dnf install -y \
  procps \
  python3-devel \
  python3-pip \
- python3-pyelftools
+ python3-pyelftools \
+ zlib-devel
 
 #
 # Clone, build and install libvfn


### PR DESCRIPTION
The `test_linkandload` fails on fedora since zlib-devel is missing. 
With this addition, that is no longer the case.