### PR TITLE
be:macos: add missing include of mach_error.h

### DIFF
--- a/lib/xnvme_be_macos_admin.c
+++ b/lib/xnvme_be_macos_admin.c
@@ -6,6 +6,7 @@
 #include <xnvme_be.h>
 #include <xnvme_be_nosys.h>
 #ifdef XNVME_BE_MACOS_ENABLED
+#include <mach/mach_error.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/storage/nvme/NVMeSMARTLibExternal.h>
 

--- a/lib/xnvme_be_macos_dev.c
+++ b/lib/xnvme_be_macos_dev.c
@@ -6,6 +6,7 @@
 #include <xnvme_be.h>
 #include <xnvme_be_nosys.h>
 #ifdef XNVME_BE_MACOS_ENABLED
+#include <mach/mach_error.h>
 #include <IOKit/IOTypes.h>
 #include <IOKit/storage/nvme/NVMeSMARTLibExternal.h>
 #include <CoreFoundation/CoreFoundation.h>


### PR DESCRIPTION
Compilation fails without this include