### PR TITLE
fix(meson): change license to 'BSD-3-Clause'

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project(
   'xnvme',
   'c',
   version: '0.7.0',
-  license: 'APACHE',
+  license: 'BSD-3-Clause',
   default_options: [
     'c_std=gnu11',
     'warning_level=2',


### PR DESCRIPTION
The license of xNVMe was previously changed from APACHE to BSD-3-Clause, however, the meson.build was missing this change. Thus changing it here.