### PR TITLE
fix(cijoe): change the script that starts qemu

### DIFF
--- a/cijoe/workflows/docgen.yaml
+++ b/cijoe/workflows/docgen.yaml
@@ -14,7 +14,7 @@ steps:
   uses: qemu.guest_init_using_bootimage
 
 - name: start
-  uses: qemu.guest_start_nvme
+  uses: xnvme_guest_start_nvme
 
 - name: sysinfo
   uses: linux.sysinfo


### PR DESCRIPTION
Previously, then 'cijoe-pkg-qemu' provided a script to start qemu with a
complicated NVMe-device configuration. This, has later been removed from
'cijoe-pkg-qemu' as it goes well beyond the scope of the package.

Instead, 'xnvme_guest_start_nvme' extends the 'cijoe-pkg-qemu'
capabilities, and does the advanced config. By doing so, then the script
comes closer to where it is used. That is, it is usually the xNVMe
project that changes this file, thus it makes sense that it lives inside
the xNVMe repository.

Note, 'cijoe-pkg-qemu', still has scripts for startin/stopping qemu with
different configurations, it is just a matter of moving the config
specific to xNVMe into the xNVMe repository.