### PR TITLE
fix(gha): bump checkout to v4.0.0

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - name: Grab source
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v4.0.0
     - name: Add repos to git-config safe.directory
       run: |
         git config --global --add safe.directory $(pwd)
@@ -77,7 +77,7 @@ jobs:
 
     steps:
     - name: Grab source
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v4.0.0
     - name: Add repos to git-config safe.directory
       run: |
         git config --global --add safe.directory $(pwd)
@@ -686,7 +686,7 @@ jobs:
         --output "docgen-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
 
     - name: Checkout site
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v4.0.0
       with:
         repository: "xnvme/xnvme.github.io"
         token: ${{ secrets.DOCS_PAT }}


### PR DESCRIPTION
While attemptning to fix the docgen build-issue, then github had an outage / breakage of the checkout action. On:

https://github.com/actions/checkout/issues/1448

Then it is reported that the current fix is to bump to v4.0.0, thus, trying it out here.