### PR TITLE
vfio: fix completion result for sync io

### DIFF
--- a/include/xnvme_be_vfio.h
+++ b/include/xnvme_be_vfio.h
@@ -15,13 +15,11 @@
 struct xnvme_be_vfio_state {
 	struct nvme_ctrl *ctrl;
 	unsigned long long qidmap; // Queue identifier bit map
-	uint queue_id;             // Next queue id to be created on ctrl
 
-	struct nvme_sq *sq_sync;   // Submission queue for synchronous IOs
-	struct nvme_cq *cq_sync;   // Completion queue for synchronous IOs
-	struct nvme_cqe *cqe_sync; // Completion queue entry for synchronous IOs
+	struct nvme_sq *sq_sync; // Submission queue for synchronous IOs
+	struct nvme_cq *cq_sync; // Completion queue for synchronous IOs
 
-	uint8_t _rsvd[78];
+	uint8_t _rsvd[94];
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_be_vfio_state) == XNVME_BE_STATE_NBYTES, "Incorrect size")
 

--- a/lib/xnvme_be_vfio_sync.c
+++ b/lib/xnvme_be_vfio_sync.c
@@ -65,7 +65,7 @@ xnvme_be_vfio_sync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nby
 
 	nvme_rq_exec(rq, (union nvme_cmd *)&ctx->cmd);
 
-	if (nvme_rq_poll(rq, &state->cqe_sync)) {
+	if (nvme_rq_poll(rq, &ctx->cpl)) {
 		ret = -errno;
 	}
 


### PR DESCRIPTION
The VFIO/libvfn interface used a deprecated member 'cqe_sync' on the state struct. This is changed to the correct command context, so the completion result is returned.

Unused members 'queue_id' and 'cqe_sync' removed from VFIO state.