### PR TITLE
feat(be/spdk): enable KV over nvmf

### DIFF
--- a/cijoe/configs/debian-bullseye.toml
+++ b/cijoe/configs/debian-bullseye.toml
@@ -164,6 +164,12 @@ labels = [ "dev", "fabrics", "zns" ]
 driver_attachment = "userspace"
 
 [[devices]]
+uri = "127.0.0.1:4420"
+nsid = 3
+labels = [ "dev", "fabrics", "kvs" ]
+driver_attachment = "userspace"
+
+[[devices]]
 uri = "/tmp/xnvme-testfile.bin"
 nsid = 1
 labels = [ "file" ]

--- a/subprojects/packagefiles/spdk/patches/spdk-0005-lib-bdev-Add-spdk_bdev_is_kv-to-bdev-interface.patch
+++ b/subprojects/packagefiles/spdk/patches/spdk-0005-lib-bdev-Add-spdk_bdev_is_kv-to-bdev-interface.patch
@@ -1,0 +1,88 @@
+From ea0cfa580e9d3fc6adb073cec717a451a2409532 Mon Sep 17 00:00:00 2001
+From: Karl Bonde Torp <k.torp@samsung.com>
+Date: Tue, 19 Sep 2023 10:08:29 +0200
+Subject: [PATCH 4/7] lib/bdev: Add spdk_bdev_is_kv() to bdev interface
+
+This patch is needed to enable KV passthru on fabrics, specifically to
+set the correct csi when the namespace is added to nvmf/subsystem.
+
+spdk_bdev_is_kv() will allow user to check if a
+bdev is a kv bdev.
+
+Signed-off-by: Karl Bonde Torp <k.torp@samsung.com>
+---
+ include/spdk/bdev.h        | 8 ++++++++
+ include/spdk/bdev_module.h | 5 +++++
+ lib/bdev/bdev.c            | 6 ++++++
+ lib/nvmf/ctrlr.c           | 3 +++
+ 4 files changed, 22 insertions(+)
+
+diff --git a/include/spdk/bdev.h b/include/spdk/bdev.h
+index 07a9a42b9..1e6bf6f15 100644
+--- a/include/spdk/bdev.h
++++ b/include/spdk/bdev.h
+@@ -638,6 +638,14 @@ bool spdk_bdev_is_md_interleaved(const struct spdk_bdev *bdev);
+  */
+ bool spdk_bdev_is_md_separate(const struct spdk_bdev *bdev);
+ 
++/**
++ * Checks if bdev supports KV namespace semantics.
++ *
++ * \param bdev Block device to query.
++ * \return true if device supports KV namespace semantics.
++ */
++bool spdk_bdev_is_kv(const struct spdk_bdev *bdev);
++
+ /**
+  * Checks if bdev supports zoned namespace semantics.
+  *
+diff --git a/include/spdk/bdev_module.h b/include/spdk/bdev_module.h
+index f480b50cc..ad89f642d 100644
+--- a/include/spdk/bdev_module.h
++++ b/include/spdk/bdev_module.h
+@@ -552,6 +552,11 @@ struct spdk_bdev {
+ 	 */
+ 	uint32_t dif_check_flags;
+ 
++	/**
++	 * Specify whether bdev is kv device.
++	 */
++	bool kv;
++
+ 	/**
+ 	 * Specify whether bdev is zoned device.
+ 	 */
+diff --git a/lib/bdev/bdev.c b/lib/bdev/bdev.c
+index 3218c7aa6..cf5514628 100644
+--- a/lib/bdev/bdev.c
++++ b/lib/bdev/bdev.c
+@@ -4637,6 +4637,12 @@ spdk_bdev_is_md_separate(const struct spdk_bdev *bdev)
+ 	return (bdev->md_len != 0) && !bdev->md_interleave;
+ }
+ 
++bool
++spdk_bdev_is_kv(const struct spdk_bdev *bdev)
++{
++	return bdev->kv;
++}
++
+ bool
+ spdk_bdev_is_zoned(const struct spdk_bdev *bdev)
+ {
+diff --git a/lib/nvmf/ctrlr.c b/lib/nvmf/ctrlr.c
+index 24898ca4e..de836cbe9 100644
+--- a/lib/nvmf/ctrlr.c
++++ b/lib/nvmf/ctrlr.c
+@@ -3085,6 +3085,9 @@ nvmf_ctrlr_identify_iocs(struct spdk_nvmf_ctrlr *ctrlr,
+ 		if (spdk_bdev_is_zoned(ns->bdev)) {
+ 			vector->zns = 1;
+ 		}
++		if (spdk_bdev_is_kv(ns->bdev)){
++			vector->kv = 1;
++		}
+ 	}
+ 
+ 	rsp->status.sct = SPDK_NVME_SCT_GENERIC;
+-- 
+2.42.0
+

--- a/subprojects/packagefiles/spdk/patches/spdk-0006-nvmf-Support-adding-KV-NS-to-nvmf_tgt.patch
+++ b/subprojects/packagefiles/spdk/patches/spdk-0006-nvmf-Support-adding-KV-NS-to-nvmf_tgt.patch
@@ -1,0 +1,48 @@
+From d36c82874a101bcd6ae86a52bed888cea69a41c2 Mon Sep 17 00:00:00 2001
+From: Karl Bonde Torp <k.torp@samsung.com>
+Date: Tue, 12 Sep 2023 08:16:44 +0200
+Subject: [PATCH 5/7] nvmf: Support adding KV NS to nvmf_tgt
+
+Currently `nvme_ns_has_supported_iocs_specific_data()` and
+`nvme_disk_create` stand in the way
+of adding KV namespaces to a subsystem via the `nvmf_tgt` app.
+
+With this patch, that is no longer the case
+
+Signed-off-by: Karl Bonde Torp <k.torp@samsung.com>
+---
+ lib/nvme/nvme_ns.c           | 2 ++
+ module/bdev/nvme/bdev_nvme.c | 4 ++++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/lib/nvme/nvme_ns.c b/lib/nvme/nvme_ns.c
+index 03f7a0253..81b02a780 100644
+--- a/lib/nvme/nvme_ns.c
++++ b/lib/nvme/nvme_ns.c
+@@ -492,6 +492,8 @@ nvme_ns_has_supported_iocs_specific_data(struct spdk_nvme_ns *ns)
+ 		return false;
+ 	case SPDK_NVME_CSI_ZNS:
+ 		return true;
++	case SPDK_NVME_CSI_KV:
++		return false;
+ 	default:
+ 		SPDK_WARNLOG("Unsupported CSI: %u for NSID: %u\n", ns->csi, ns->id);
+ 		return false;
+diff --git a/module/bdev/nvme/bdev_nvme.c b/module/bdev/nvme/bdev_nvme.c
+index 510bdd89c..6a7eab974 100644
+--- a/module/bdev/nvme/bdev_nvme.c
++++ b/module/bdev/nvme/bdev_nvme.c
+@@ -3905,6 +3905,10 @@ nvme_disk_create(struct spdk_bdev *disk, const char *base_name,
+ 		disk->max_open_zones = spdk_nvme_zns_ns_get_max_open_zones(ns);
+ 		disk->max_active_zones = spdk_nvme_zns_ns_get_max_active_zones(ns);
+ 		break;
++	case SPDK_NVME_CSI_KV:
++		disk->product_name = "NVMe KV disk";
++		disk->kv = true;
++		break;
+ 	default:
+ 		SPDK_ERRLOG("unsupported CSI: %u\n", csi);
+ 		return -ENOTSUP;
+-- 
+2.42.0
+

--- a/subprojects/packagefiles/spdk/patches/spdk-0007-lib-nvmf-Add-I-O-cmd-passthru-for-KV.patch
+++ b/subprojects/packagefiles/spdk/patches/spdk-0007-lib-nvmf-Add-I-O-cmd-passthru-for-KV.patch
@@ -1,0 +1,55 @@
+From dfaf4d79b4f581b549db79aef05919ccbf53a92f Mon Sep 17 00:00:00 2001
+From: Karl Bonde Torp <k.torp@samsung.com>
+Date: Fri, 15 Sep 2023 10:10:25 +0200
+Subject: [PATCH 6/7] lib/nvmf: Add I/O cmd passthru for KV
+
+This enables support for I/O cmds for KV namespaces over fabrics, by
+forcing the use of nvmf_bdev_ctrlr_nvme_passthru_io() if the CSI is KV.
+
+Signed-off-by: Karl Bonde Torp <k.torp@samsung.com>
+---
+ lib/nvmf/ctrlr.c     | 4 +++-
+ lib/nvmf/subsystem.c | 5 +++++
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/lib/nvmf/ctrlr.c b/lib/nvmf/ctrlr.c
+index de836cbe9..4ce430b74 100644
+--- a/lib/nvmf/ctrlr.c
++++ b/lib/nvmf/ctrlr.c
+@@ -345,7 +345,7 @@ nvmf_subsys_has_multi_iocs(struct spdk_nvmf_subsystem *subsystem)
+ 
+ 	for (i = 0; i < subsystem->max_nsid; i++) {
+ 		ns = subsystem->ns[i];
+-		if (ns && ns->bdev && spdk_bdev_is_zoned(ns->bdev)) {
++		if (ns && ns->bdev && (spdk_bdev_is_zoned(ns->bdev) || spdk_bdev_is_kv(ns->bdev))) {
+ 			return true;
+ 		}
+ 	}
+@@ -4303,6 +4303,8 @@ nvmf_ctrlr_process_io_cmd(struct spdk_nvmf_request *req)
+ 	if (spdk_nvmf_request_using_zcopy(req)) {
+ 		assert(req->zcopy_phase == NVMF_ZCOPY_PHASE_INIT);
+ 		return nvmf_bdev_ctrlr_zcopy_start(bdev, desc, ch, req);
++	} else if (ns->csi == SPDK_NVME_CSI_KV) {
++		return nvmf_bdev_ctrlr_nvme_passthru_io(bdev, desc, ch, req);
+ 	} else {
+ 		switch (cmd->opc) {
+ 		case SPDK_NVME_OPC_READ:
+diff --git a/lib/nvmf/subsystem.c b/lib/nvmf/subsystem.c
+index c4165b383..5b448bc94 100644
+--- a/lib/nvmf/subsystem.c
++++ b/lib/nvmf/subsystem.c
+@@ -1724,6 +1724,11 @@ spdk_nvmf_subsystem_add_ns_ext(struct spdk_nvmf_subsystem *subsystem, const char
+ 		subsystem->max_zone_append_size_kib = max_zone_append_size_kib;
+ 	}
+ 
++	if (spdk_bdev_is_kv(ns->bdev)) {
++		SPDK_DEBUGLOG(nvmf, "The added namespace is backed by a KV block device.\n");
++		ns->csi = SPDK_NVME_CSI_KV;
++	}
++
+ 	ns->opts = opts;
+ 	ns->subsystem = subsystem;
+ 	subsystem->ns[opts.nsid - 1] = ns;
+-- 
+2.42.0
+

--- a/subprojects/packagefiles/spdk/patches/spdk-0008-lib-nvmf-Add-identify_-_iocs-passthru-for-KV.patch
+++ b/subprojects/packagefiles/spdk/patches/spdk-0008-lib-nvmf-Add-identify_-_iocs-passthru-for-KV.patch
@@ -1,0 +1,46 @@
+From 2bb724162596d09002a62d1af0f304767732867f Mon Sep 17 00:00:00 2001
+From: Karl Bonde Torp <k.torp@samsung.com>
+Date: Mon, 25 Sep 2023 15:59:24 +0200
+Subject: [PATCH 7/7] lib/nvmf: Add identify_*_iocs passthru for KV
+
+Signed-off-by: Karl Bonde Torp <k.torp@samsung.com>
+---
+ lib/nvmf/ctrlr.c | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/lib/nvmf/ctrlr.c b/lib/nvmf/ctrlr.c
+index 4ce430b74..3fad552ba 100644
+--- a/lib/nvmf/ctrlr.c
++++ b/lib/nvmf/ctrlr.c
+@@ -55,6 +55,7 @@ static struct spdk_nvmf_custom_admin_cmd g_nvmf_custom_admin_cmd_hdlrs[SPDK_NVME
+ 
+ static void _nvmf_request_complete(void *ctx);
+ int nvmf_passthru_admin_cmd_for_ctrlr(struct spdk_nvmf_request *req, struct spdk_nvmf_ctrlr *ctrlr);
++static int nvmf_passthru_admin_cmd(struct spdk_nvmf_request *req);
+ 
+ static inline void
+ nvmf_invalid_connect_response(struct spdk_nvmf_fabric_connect_rsp *rsp,
+@@ -3145,10 +3146,18 @@ nvmf_ctrlr_identify(struct spdk_nvmf_request *req)
+ 				tmpbuf, req->length);
+ 		break;
+ 	case SPDK_NVME_IDENTIFY_NS_IOCS:
+-		ret = spdk_nvmf_ns_identify_iocs_specific(ctrlr, cmd, rsp, (void *)&tmpbuf, req->length);
++		if (cmd->cdw11_bits.identify.csi == SPDK_NVME_CSI_KV) {
++			ret = nvmf_passthru_admin_cmd(req);
++		} else {
++			ret = spdk_nvmf_ns_identify_iocs_specific(ctrlr, cmd, rsp, (void *)&tmpbuf, req->length);
++		}
+ 		break;
+ 	case SPDK_NVME_IDENTIFY_CTRLR_IOCS:
+-		ret = spdk_nvmf_ctrlr_identify_iocs_specific(ctrlr, cmd, rsp, (void *)&tmpbuf, req->length);
++		if (cmd->cdw11_bits.identify.csi == SPDK_NVME_CSI_KV) {
++			ret = nvmf_passthru_admin_cmd_for_ctrlr(req, ctrlr);
++		} else {
++			ret = spdk_nvmf_ctrlr_identify_iocs_specific(ctrlr, cmd, rsp, (void *)&tmpbuf, req->length);
++		}
+ 		break;
+ 	case SPDK_NVME_IDENTIFY_IOCS:
+ 		ret = nvmf_ctrlr_identify_iocs(ctrlr, cmd, rsp, (void *)&tmpbuf, req->length);
+-- 
+2.42.0
+


### PR DESCRIPTION
These additions allow for the creation of KV namespaces in the `nvmf_tgt` app, and the submission of KV cmds over nvmf.

To be clear, all of these patches only affect the SPDK `nvmf_tgt` app, and not the xNVMe SPDK backend.