### PR TITLE
feat(build/spdk): bump to v23.05

### DIFF
--- a/subprojects/packagefiles/spdk/meson.build
+++ b/subprojects/packagefiles/spdk/meson.build
@@ -1,7 +1,7 @@
 project(
   'spdk',
   'c',
-  version: '22.09',
+  version: '23.05',
 )
 fs = import('fs')
 
@@ -53,6 +53,11 @@ elf_dep = cc.find_library(
   'elf',
   has_headers: ['sys/elf_common.h'],
   required: is_freebsd,
+)
+
+archive_dep = cc.find_library(
+  'archive',
+  has_headers: ['archive.h'],
 )
 
 if get_option('build_subprojects') and not fs.exists('build')
@@ -124,7 +129,7 @@ isal_libnames = get_option('build_subprojects') ? [
   'isal',
 ] : []
 
-spdk_deps = [dlfcn_dep, math_dep, numa_dep, uuid_dep, ssl_dep, ssl_dep, execinfo_dep, elf_dep,]
+spdk_deps = [dlfcn_dep, math_dep, numa_dep, uuid_dep, ssl_dep, ssl_dep, execinfo_dep, elf_dep, archive_dep,]
 
 spdk_paths = []
 foreach libname : spdk_libnames + dpdk_libnames + isal_libnames

--- a/subprojects/packagefiles/spdk/spdk_configure.sh
+++ b/subprojects/packagefiles/spdk/spdk_configure.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env sh
 ./configure \
+  --disable-tests \
+  --disable-unit-tests \
+  --disable-examples \
   --disable-apps \
   --without-crypto \
   --without-fuse \
@@ -7,12 +10,11 @@
   --without-iscsi-initiator \
   --without-nvme-cuse \
   --without-ocf \
-  --without-pmdk \
   --without-rbd \
-  --without-reduce \
-  --without-shared \
   --without-uring \
   --without-usdt \
   --without-vhost \
   --without-vtune \
-  --without-virtio
+  --without-virtio \
+  --without-xnvme \
+  --without-shared \

--- a/subprojects/spdk.wrap
+++ b/subprojects/spdk.wrap
@@ -4,7 +4,7 @@
 
 [wrap-git]
 url = https://github.com/spdk/spdk.git
-revision = v22.09
+revision = v23.05
 patch_directory = spdk
 clone-recursive = true
 

--- a/toolbox/pkgs/alpine-latest.sh
+++ b/toolbox/pkgs/alpine-latest.sh
@@ -17,6 +17,7 @@ apk add \
  gawk \
  git \
  libaio-dev \
+ libarchive-dev \
  liburing-dev \
  libuuid \
  linux-headers \

--- a/toolbox/pkgs/archlinux-latest.sh
+++ b/toolbox/pkgs/archlinux-latest.sh
@@ -15,6 +15,7 @@ pacman -S --noconfirm \
  findutils \
  git \
  libaio \
+ libarchive \
  liburing \
  libutil-linux \
  make \

--- a/toolbox/pkgs/centos-stream9.sh
+++ b/toolbox/pkgs/centos-stream9.sh
@@ -20,6 +20,7 @@ dnf install -y \
  gcc-c++ \
  git \
  libaio-devel \
+ libarchive-devel \
  libtool \
  libuuid-devel \
  make \

--- a/toolbox/pkgs/debian-bookworm.sh
+++ b/toolbox/pkgs/debian-bookworm.sh
@@ -22,6 +22,7 @@ apt-get -qy install \
  findutils \
  git \
  libaio-dev \
+ libarchive-dev \
  libcunit1-dev \
  libncurses5-dev \
  libnuma-dev \

--- a/toolbox/pkgs/debian-bullseye.sh
+++ b/toolbox/pkgs/debian-bullseye.sh
@@ -22,6 +22,7 @@ apt-get -qy install \
  findutils \
  git \
  libaio-dev \
+ libarchive-dev \
  libcunit1-dev \
  libncurses5-dev \
  libnuma-dev \

--- a/toolbox/pkgs/debian-trixie.sh
+++ b/toolbox/pkgs/debian-trixie.sh
@@ -22,6 +22,7 @@ apt-get -qy install \
  findutils \
  git \
  libaio-dev \
+ libarchive-dev \
  libcunit1-dev \
  libncurses5-dev \
  libnuma-dev \

--- a/toolbox/pkgs/emitter/deps.yaml
+++ b/toolbox/pkgs/emitter/deps.yaml
@@ -97,6 +97,20 @@ deps:
       pkg: [py39-pipx]
       zypper: [python3-pipx]
 
+  archive:
+    notes: Required by DPDK 23.03 and thereby for SPDK 23.05
+    ver: 0.0
+    when: [building, running]
+    purpose: {be: [spdk]}
+    names:
+      default: [libarchive-dev]
+      pacman: [libarchive]
+      emerge: [app-arch/libarchive]
+      dnf: [libarchive-devel]
+      yum: [libarchive-devel]
+      zypper: [libarchive-devel]
+      pkg: [archivers/libarchive]
+
   cunit:
     notes: Required by SPDK
     ver: 0.0
@@ -259,8 +273,8 @@ defaults:
 
   linux:
     deps:
-    - [sys, [bash, cunit, clang-format, elftools, find, git, libaio, liburing, libuuid, make, meson, nasm, ncurses, numactl,
-        openssl, patch, pipx, pkg-config, python3]]
+    - [sys, [archive, bash, cunit, clang-format, elftools, find, git, libaio, liburing, libuuid, make, meson, nasm, ncurses,
+        numactl, openssl, patch, pipx, pkg-config, python3]]
     - [src, [libvfn]]
     apps:
     - [src, [fio]]

--- a/toolbox/pkgs/fedora-36.sh
+++ b/toolbox/pkgs/fedora-36.sh
@@ -17,6 +17,7 @@ dnf install -y \
  gcc \
  git \
  libaio-devel \
+ libarchive-devel \
  libtool \
  libuuid-devel \
  make \

--- a/toolbox/pkgs/fedora-37.sh
+++ b/toolbox/pkgs/fedora-37.sh
@@ -17,6 +17,7 @@ dnf install -y \
  gcc \
  git \
  libaio-devel \
+ libarchive-devel \
  libtool \
  liburing \
  liburing-devel \

--- a/toolbox/pkgs/fedora-38.sh
+++ b/toolbox/pkgs/fedora-38.sh
@@ -17,6 +17,7 @@ dnf install -y \
  gcc \
  git \
  libaio-devel \
+ libarchive-devel \
  libtool \
  liburing \
  liburing-devel \

--- a/toolbox/pkgs/gentoo-latest.sh
+++ b/toolbox/pkgs/gentoo-latest.sh
@@ -11,6 +11,7 @@ echo "export LDFLAGS=\"-ltinfo -lncurses\""
 
 emerge-webrsync
 emerge \
+ app-arch/libarchive \
  bash \
  dev-lang/nasm \
  dev-libs/libaio \

--- a/toolbox/pkgs/opensuse-tumbleweed-latest.sh
+++ b/toolbox/pkgs/opensuse-tumbleweed-latest.sh
@@ -20,6 +20,7 @@ zypper --non-interactive install -y --allow-downgrade \
  git \
  gzip \
  libaio-devel \
+ libarchive-devel \
  libnuma-devel \
  libopenssl-devel \
  libtool \

--- a/toolbox/pkgs/oraclelinux-9.sh
+++ b/toolbox/pkgs/oraclelinux-9.sh
@@ -21,6 +21,7 @@ dnf install -y \
  gcc-c++ \
  git \
  libaio-devel \
+ libarchive-devel \
  libtool \
  libuuid-devel \
  make \

--- a/toolbox/pkgs/rockylinux-9.2.sh
+++ b/toolbox/pkgs/rockylinux-9.2.sh
@@ -21,6 +21,7 @@ dnf install -y \
  gcc-c++ \
  git \
  libaio-devel \
+ libarchive-devel \
  libtool \
  libuuid-devel \
  make \

--- a/toolbox/pkgs/ubuntu-focal.sh
+++ b/toolbox/pkgs/ubuntu-focal.sh
@@ -22,6 +22,7 @@ apt-get -qy install \
  findutils \
  git \
  libaio-dev \
+ libarchive-dev \
  libcunit1-dev \
  libncurses5-dev \
  libnuma-dev \

--- a/toolbox/pkgs/ubuntu-jammy.sh
+++ b/toolbox/pkgs/ubuntu-jammy.sh
@@ -22,6 +22,7 @@ apt-get -qy install \
  findutils \
  git \
  libaio-dev \
+ libarchive-dev \
  libcunit1-dev \
  libncurses5-dev \
  libnuma-dev \

--- a/toolbox/pkgs/ubuntu-lunar.sh
+++ b/toolbox/pkgs/ubuntu-lunar.sh
@@ -22,6 +22,7 @@ apt-get -qy install \
  findutils \
  git \
  libaio-dev \
+ libarchive-dev \
  libcunit1-dev \
  libncurses5-dev \
  libnuma-dev \


### PR DESCRIPTION
This requires a new dependency 'libarchive' for DPDK v23.03 which comes with SPDK v23.05.

Besides this, the `spdk_configure.sh` script has been updated to disable more things we don't need.