### PR TITLE
feat(build/spdk): use debug for SPDK if enabled for xNVMe

### DIFF
--- a/subprojects/packagefiles/spdk/meson.build
+++ b/subprojects/packagefiles/spdk/meson.build
@@ -59,7 +59,11 @@ if get_option('build_subprojects') and not fs.exists('build')
   message('Patching ..')
   run_command('spdk_patches.sh', capture: true, check: true)
   message('Configuring ..')
-  run_command('spdk_configure.sh', capture: true, check: true)
+  if get_option('buildtype') == 'debug'
+     run_command('spdk_configure_debug.sh', capture: true, check: true)
+  else
+    run_command('spdk_configure.sh', capture: true, check: true)
+  endif
 endif
 if get_option('build_subprojects') and not fs.exists('build' / 'lib' / 'src' / 'spdk_nvme.a')
   cpu_count = run_command([

--- a/subprojects/packagefiles/spdk/spdk_configure_debug.sh
+++ b/subprojects/packagefiles/spdk/spdk_configure_debug.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+./configure \
+  --disable-apps \
+  --without-crypto \
+  --without-fuse \
+  --without-idxd \
+  --without-iscsi-initiator \
+  --without-nvme-cuse \
+  --without-ocf \
+  --without-pmdk \
+  --without-rbd \
+  --without-reduce \
+  --without-shared \
+  --without-uring \
+  --without-usdt \
+  --without-vhost \
+  --without-vtune \
+  --without-virtio \
+  --enable-debug


### PR DESCRIPTION
If xNVMe is built with buildtype=debug, configure SPDK to use debug too.

I believe this is useful for debugging