### PR TITLE
Pseudo commands support

### DIFF
--- a/cijoe/configs/debian-bullseye.toml
+++ b/cijoe/configs/debian-bullseye.toml
@@ -70,7 +70,7 @@ driver_attachment = "kernel"
 [[devices]]
 uri = "0000:03:00.0"
 nsid = 1
-labels = [ "dev", "pcie", "nvm", "scc", "write_zeroes" ]
+labels = [ "dev", "pcie", "nvm", "scc", "write_zeroes", "ctrlr" ]
 driver_attachment = "userspace"
 
 [[devices]]
@@ -144,6 +144,12 @@ uri = "0000:06:00.0"
 nsid = 1
 labels = [ "dev", "pcie", "nvm", "scc", "fdp" ]
 driver_attachment = "userspace"
+
+[[devices]]
+uri = "/dev/nvme0"
+nsid = 0
+labels = [ "ctrlr", "cdev"]
+driver_attachment = "kernel"
 
 [[devices]]
 uri = "127.0.0.1:4420"

--- a/cijoe/tests/tools/test_xnvme.py
+++ b/cijoe/tests/tools/test_xnvme.py
@@ -236,3 +236,42 @@ def test_dsm(cijoe, device, be_opts, cli_args):
         f"xnvme dsm {cli_args} --nsid {device['nsid']} --ad --idw --idr --slba 0 --llb 1"
     )
     assert not err
+
+
+# For these three tests we request a device with labels 'ctrlr'
+@xnvme_parametrize(labels=["ctrlr"], opts=["be", "admin"])
+def test_subsystem_reset(cijoe, device, be_opts, cli_args):
+    if be_opts["be"] == "vfio":
+        pytest.skip(reason="[be=vfio] does not support pseudo commands")
+
+    err, _ = cijoe.run(
+        f"xnvme subsystem-reset {device['uri']} --be {be_opts['be']} --admin {be_opts['admin']}"
+    )
+
+    assert not err
+
+
+@xnvme_parametrize(labels=["ctrlr"], opts=["be", "admin"])
+def test_ctrlr_reset(cijoe, device, be_opts, cli_args):
+    if be_opts["be"] == "vfio":
+        pytest.skip(reason="[be=vfio] does not support pseudo commands")
+
+    err, _ = cijoe.run(
+        f"xnvme ctrlr-reset {device['uri']} --be {be_opts['be']} --admin {be_opts['admin']}"
+    )
+
+    assert not err
+
+
+@xnvme_parametrize(labels=["ctrlr"], opts=["be", "admin"])
+def test_namespace_rescan(cijoe, device, be_opts, cli_args):
+    if be_opts["be"] == "vfio":
+        pytest.skip(reason="[be=vfio] does not support pseudo commands")
+    if be_opts["be"] == "spdk":
+        pytest.skip(reason="[be=spdk] does not support namespace rescan")
+
+    err, _ = cijoe.run(
+        f"xnvme ns-rescan {device['uri']} --be {be_opts['be']} --admin {be_opts['admin']}"
+    )
+
+    assert not err

--- a/lib/xnvme_be_spdk_admin.c
+++ b/lib/xnvme_be_spdk_admin.c
@@ -9,6 +9,7 @@
 #include <spdk/env.h>
 #include <xnvme_dev.h>
 #include <xnvme_queue.h>
+#include <xnvme_spec.h>
 #include <xnvme_be_spdk.h>
 
 static void
@@ -71,13 +72,38 @@ xnvme_be_spdk_sync_cmd_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_
 
 	return 0;
 }
+
+int
+xnvme_be_spdk_sync_cmd_pseudo(struct xnvme_cmd_ctx *ctx, void *XNVME_UNUSED(dbuf),
+			      size_t XNVME_UNUSED(dbuf_nbytes), void *XNVME_UNUSED(mbuf),
+			      size_t XNVME_UNUSED(mbuf_nbytes))
+{
+	struct xnvme_be_spdk_state *state = (void *)ctx->dev->be.state;
+	int err;
+
+	switch (ctx->cmd.common.opcode) {
+	case XNVME_SPEC_PSEUDO_OPC_SUBSYSTEM_RESET:
+		err = spdk_nvme_ctrlr_reset_subsystem(state->ctrlr);
+		break;
+
+	case XNVME_SPEC_PSEUDO_OPC_CONTROLLER_RESET:
+		err = spdk_nvme_ctrlr_reset(state->ctrlr);
+		break;
+
+	default:
+		XNVME_DEBUG("FAILED: unsupported opcode: %d", ctx->cmd.common.opcode);
+		return -ENOSYS;
+	}
+
+	return err;
+}
 #endif
 
 struct xnvme_be_admin g_xnvme_be_spdk_admin = {
 	.id = "nvme",
 #ifdef XNVME_BE_SPDK_ENABLED
 	.cmd_admin = xnvme_be_spdk_sync_cmd_admin,
-	.cmd_pseudo = xnvme_be_nosys_sync_cmd_pseudo,
+	.cmd_pseudo = xnvme_be_spdk_sync_cmd_pseudo,
 #else
 	.cmd_admin = xnvme_be_nosys_sync_cmd_admin,
 	.cmd_pseudo = xnvme_be_nosys_sync_cmd_pseudo,

--- a/tools/xnvme.c
+++ b/tools/xnvme.c
@@ -1075,6 +1075,54 @@ exit:
 	return err;
 }
 
+static int
+subsystem_reset(struct xnvme_cli *cli)
+{
+	struct xnvme_dev *dev = cli->args.dev;
+	struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
+	int err;
+
+	err = xnvme_subsystem_reset(dev);
+	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		xnvme_cli_perr("xnvme_subsystem_reset()", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static int
+ctrlr_reset(struct xnvme_cli *cli)
+{
+	struct xnvme_dev *dev = cli->args.dev;
+	struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
+	int err;
+
+	err = xnvme_controller_reset(dev);
+	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		xnvme_cli_perr("xnvme_controller_reset()", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static int
+ns_rescan(struct xnvme_cli *cli)
+{
+	struct xnvme_dev *dev = cli->args.dev;
+	struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
+	int err;
+
+	err = xnvme_namespace_rescan(dev);
+	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		xnvme_cli_perr("xnvme_namespace_rescan()", err);
+		return err;
+	}
+
+	return 0;
+}
+
 //
 // Command-Line Interface (CLI) definition
 //
@@ -1547,6 +1595,42 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_IDR, XNVME_CLI_LFLG},
 			{XNVME_CLI_OPT_SLBA, XNVME_CLI_LREQ},
 			{XNVME_CLI_OPT_LLB, XNVME_CLI_LREQ},
+
+			XNVME_CLI_ADMIN_OPTS,
+		},
+	},
+	{
+		"subsystem-reset",
+		"Resets the subsystem",
+		"Resets the subsystem",
+		subsystem_reset,
+		{
+			{XNVME_CLI_OPT_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_URI, XNVME_CLI_POSA},
+
+			XNVME_CLI_ADMIN_OPTS,
+		},
+	},
+	{
+		"ctrlr-reset",
+		"Resets the controller",
+		"Resets the controller",
+		ctrlr_reset,
+		{
+			{XNVME_CLI_OPT_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_URI, XNVME_CLI_POSA},
+
+			XNVME_CLI_ADMIN_OPTS,
+		},
+	},
+	{
+		"ns-rescan",
+		"Rescans the nvme namespaces",
+		"Rescans the nvme namespaces",
+		ns_rescan,
+		{
+			{XNVME_CLI_OPT_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_URI, XNVME_CLI_POSA},
 
 			XNVME_CLI_ADMIN_OPTS,
 		},


### PR DESCRIPTION
Pseudo commands (ctrl reset, ns rescan and subsystem reset) support in xNVMe.

1. Adding ctrl reset, ns rescan and subsystem reset.
2. Add pseudo commands testing tool.