### PR TITLE
feat(build/spdk): bump to v23.01

### DIFF
--- a/subprojects/packagefiles/spdk/meson.build
+++ b/subprojects/packagefiles/spdk/meson.build
@@ -1,7 +1,7 @@
 project(
   'spdk',
   'c',
-  version: '22.09',
+  version: '23.01',
 )
 fs = import('fs')
 
@@ -53,6 +53,11 @@ elf_dep = cc.find_library(
   'elf',
   has_headers: ['sys/elf_common.h'],
   required: is_freebsd,
+)
+
+archive_dep = cc.find_library(
+  'archive',
+  has_headers: ['archive.h'],
 )
 
 if get_option('build_subprojects') and not fs.exists('build')
@@ -128,7 +133,7 @@ isal_libnames = get_option('build_subprojects') ? [
   'isal',
 ] : []
 
-spdk_deps = [dlfcn_dep, math_dep, numa_dep, uuid_dep, ssl_dep, ssl_dep, execinfo_dep, elf_dep,]
+spdk_deps = [dlfcn_dep, math_dep, numa_dep, uuid_dep, ssl_dep, ssl_dep, execinfo_dep, elf_dep, archive_dep,]
 
 spdk_paths = []
 foreach libname : spdk_libnames + dpdk_libnames + isal_libnames

--- a/subprojects/packagefiles/spdk/patches/spdk-0001-nvmf-add-passthru-handlers-for-IOCS-specific-identif.patch
+++ b/subprojects/packagefiles/spdk/patches/spdk-0001-nvmf-add-passthru-handlers-for-IOCS-specific-identif.patch
@@ -1,4 +1,4 @@
-From 8a27b3c9dbe99903effc5443816840501aa032d1 Mon Sep 17 00:00:00 2001
+From 9c6e096982edf761fe9f9d1321b50925193258a0 Mon Sep 17 00:00:00 2001
 From: "Ivan L. Picoli" <i.picoli@samsung.com>
 Date: Tue, 16 Jun 2020 20:58:31 +0200
 Subject: [PATCH 1/2] nvmf: add passthru handlers for IOCS specific identify
@@ -7,14 +7,14 @@ Subject: [PATCH 1/2] nvmf: add passthru handlers for IOCS specific identify
 Signed-off-by: Ivan L. Picoli <i.picoli@samsung.com>
 Change-Id: I5db2c902e6513acec05498849c6c4add0da3ac1d
 ---
- lib/nvmf/ctrlr.c | 23 +++++++++++++++++++++++
- 1 file changed, 23 insertions(+)
+ lib/nvmf/ctrlr.c | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
 
 diff --git a/lib/nvmf/ctrlr.c b/lib/nvmf/ctrlr.c
-index 19d018346..69a628a32 100644
+index 504a8af1b..c7a8610f2 100644
 --- a/lib/nvmf/ctrlr.c
 +++ b/lib/nvmf/ctrlr.c
-@@ -452,6 +452,8 @@ nvmf_ctrlr_create(struct spdk_nvmf_subsystem *subsystem,
+@@ -531,6 +531,8 @@ nvmf_ctrlr_create(struct spdk_nvmf_subsystem *subsystem,
  	req->qpair->ctrlr = ctrlr;
  	spdk_thread_send_msg(subsystem->thread, _nvmf_subsystem_add_ctrlr, req);
  
@@ -23,18 +23,7 @@ index 19d018346..69a628a32 100644
  	return ctrlr;
  err_listener:
  	spdk_bit_array_free(&ctrlr->qpair_mask);
-@@ -2904,8 +2906,10 @@ nvmf_ctrlr_identify(struct spdk_nvmf_request *req)
- 	}
- 
- 	switch (cns) {
-+	case SPDK_NVME_IDENTIFY_NS_IOCS:
- 	case SPDK_NVME_IDENTIFY_NS:
- 		return spdk_nvmf_ctrlr_identify_ns(ctrlr, cmd, rsp, req->data);
-+	case SPDK_NVME_IDENTIFY_CTRLR_IOCS:
- 	case SPDK_NVME_IDENTIFY_CTRLR:
- 		return spdk_nvmf_ctrlr_identify_ctrlr(ctrlr, req->data);
- 	case SPDK_NVME_IDENTIFY_ACTIVE_NS_LIST:
-@@ -3383,6 +3387,23 @@ nvmf_ctrlr_process_admin_cmd(struct spdk_nvmf_request *req)
+@@ -3577,6 +3579,23 @@ nvmf_ctrlr_process_admin_cmd(struct spdk_nvmf_request *req)
  
  	/* Call a custom adm cmd handler if set. Aborts are handled in a different path (see nvmf_passthru_admin_cmd) */
  	if (g_nvmf_custom_admin_cmd_hdlrs[cmd->opc].hdlr && cmd->opc != SPDK_NVME_OPC_ABORT) {
@@ -58,7 +47,7 @@ index 19d018346..69a628a32 100644
  		rc = g_nvmf_custom_admin_cmd_hdlrs[cmd->opc].hdlr(req);
  		if (rc >= SPDK_NVMF_REQUEST_EXEC_STATUS_COMPLETE) {
  			/* The handler took care of this command */
-@@ -3390,6 +3411,8 @@ nvmf_ctrlr_process_admin_cmd(struct spdk_nvmf_request *req)
+@@ -3584,6 +3603,8 @@ nvmf_ctrlr_process_admin_cmd(struct spdk_nvmf_request *req)
  		}
  	}
  
@@ -68,5 +57,5 @@ index 19d018346..69a628a32 100644
  	case SPDK_NVME_OPC_GET_LOG_PAGE:
  		return nvmf_ctrlr_get_log_page(req);
 -- 
-2.37.3
+2.42.0
 

--- a/subprojects/packagefiles/spdk/patches/spdk-0002-nvmf-Added-passthru-support-for-log-zone-changes.patch
+++ b/subprojects/packagefiles/spdk/patches/spdk-0002-nvmf-Added-passthru-support-for-log-zone-changes.patch
@@ -1,4 +1,4 @@
-From dab4fb2ea1a40b27c80a885d34b63a5ec350bcb4 Mon Sep 17 00:00:00 2001
+From 80a6a56b2665a592b2815e27fb6a14d88ed8af3d Mon Sep 17 00:00:00 2001
 From: "Ivan L. Picoli" <i.picoli@samsung.com>
 Date: Tue, 18 Aug 2020 17:31:37 +0200
 Subject: [PATCH 2/2] nvmf: Added passthru support for log zone changes
@@ -10,10 +10,10 @@ Signed-off-by: Ivan L. Picoli <i.picoli@samsung.com>
  2 files changed, 13 insertions(+)
 
 diff --git a/include/spdk/nvme_spec.h b/include/spdk/nvme_spec.h
-index 68bd9615d..1f2d09112 100644
+index 1b77243ef..877a5a6d1 100644
 --- a/include/spdk/nvme_spec.h
 +++ b/include/spdk/nvme_spec.h
-@@ -2990,6 +2990,9 @@ enum spdk_nvme_log_page {
+@@ -3043,6 +3043,9 @@ enum spdk_nvme_log_page {
  
  	/* 0x81-0xBF - I/O command set specific */
  
@@ -24,10 +24,10 @@ index 68bd9615d..1f2d09112 100644
  	SPDK_NVME_LOG_VENDOR_SPECIFIC_START	= 0xc0,
  	SPDK_NVME_LOG_VENDOR_SPECIFIC_END	= 0xff,
 diff --git a/lib/nvmf/ctrlr.c b/lib/nvmf/ctrlr.c
-index 665862ae1..b0d131052 100644
+index c7a8610f2..aecf19bcd 100644
 --- a/lib/nvmf/ctrlr.c
 +++ b/lib/nvmf/ctrlr.c
-@@ -453,6 +453,7 @@ nvmf_ctrlr_create(struct spdk_nvmf_subsystem *subsystem,
+@@ -532,6 +532,7 @@ nvmf_ctrlr_create(struct spdk_nvmf_subsystem *subsystem,
  	spdk_thread_send_msg(subsystem->thread, _nvmf_subsystem_add_ctrlr, req);
  
  	spdk_nvmf_set_passthru_admin_cmd(SPDK_NVME_OPC_IDENTIFY, 1);
@@ -35,7 +35,7 @@ index 665862ae1..b0d131052 100644
  
  	return ctrlr;
  err_listener:
-@@ -3407,6 +3408,15 @@ nvmf_ctrlr_process_admin_cmd(struct spdk_nvmf_request *req)
+@@ -3596,6 +3597,15 @@ nvmf_ctrlr_process_admin_cmd(struct spdk_nvmf_request *req)
  			}
  		}
  
@@ -52,5 +52,5 @@ index 665862ae1..b0d131052 100644
  		if (rc >= SPDK_NVMF_REQUEST_EXEC_STATUS_COMPLETE) {
  			/* The handler took care of this command */
 -- 
-2.37.3
+2.42.0
 

--- a/subprojects/packagefiles/spdk/spdk_configure.sh
+++ b/subprojects/packagefiles/spdk/spdk_configure.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env sh
 ./configure \
+  --disable-tests \
+  --disable-unit-tests \
+  --disable-examples \
   --disable-apps \
   --without-crypto \
   --without-fuse \
@@ -7,12 +10,11 @@
   --without-iscsi-initiator \
   --without-nvme-cuse \
   --without-ocf \
-  --without-pmdk \
   --without-rbd \
-  --without-reduce \
   --without-shared \
   --without-uring \
   --without-usdt \
   --without-vhost \
   --without-vtune \
-  --without-virtio
+  --without-virtio \
+  --without-xnvme

--- a/subprojects/packagefiles/spdk/spdk_configure_debug.sh
+++ b/subprojects/packagefiles/spdk/spdk_configure_debug.sh
@@ -1,19 +1,21 @@
 #!/usr/bin/env sh
 ./configure \
-  --disable-apps \
-  --without-crypto \
-  --without-fuse \
-  --without-idxd \
-  --without-iscsi-initiator \
-  --without-nvme-cuse \
-  --without-ocf \
-  --without-pmdk \
-  --without-rbd \
-  --without-reduce \
-  --without-shared \
-  --without-uring \
-  --without-usdt \
-  --without-vhost \
-  --without-vtune \
-  --without-virtio \
-  --enable-debug
+    --disable-tests \
+    --disable-unit-tests \
+    --disable-examples \
+    --disable-apps \
+    --without-crypto \
+    --without-fuse \
+    --without-idxd \
+    --without-iscsi-initiator \
+    --without-nvme-cuse \
+    --without-ocf \
+    --without-rbd \
+    --without-shared \
+    --without-uring \
+    --without-usdt \
+    --without-vhost \
+    --without-vtune \
+    --without-virtio \
+    --without-xnvme \
+    --enable-debug

--- a/subprojects/spdk.wrap
+++ b/subprojects/spdk.wrap
@@ -4,7 +4,7 @@
 
 [wrap-git]
 url = https://github.com/spdk/spdk.git
-revision = v22.09
+revision = v23.01
 patch_directory = spdk
 clone-recursive = true
 

--- a/toolbox/pkgs/alpine-latest.sh
+++ b/toolbox/pkgs/alpine-latest.sh
@@ -17,6 +17,7 @@ apk add \
  gawk \
  git \
  libaio-dev \
+ libarchive-dev \
  liburing-dev \
  libuuid \
  linux-headers \

--- a/toolbox/pkgs/archlinux-latest.sh
+++ b/toolbox/pkgs/archlinux-latest.sh
@@ -15,6 +15,7 @@ pacman -S --noconfirm \
  findutils \
  git \
  libaio \
+ libarchive \
  liburing \
  libutil-linux \
  make \

--- a/toolbox/pkgs/centos-stream9.sh
+++ b/toolbox/pkgs/centos-stream9.sh
@@ -20,6 +20,7 @@ dnf install -y \
  gcc-c++ \
  git \
  libaio-devel \
+ libarchive-devel \
  libtool \
  libuuid-devel \
  make \

--- a/toolbox/pkgs/debian-bookworm.sh
+++ b/toolbox/pkgs/debian-bookworm.sh
@@ -22,6 +22,7 @@ apt-get -qy install \
  findutils \
  git \
  libaio-dev \
+ libarchive-dev \
  libcunit1-dev \
  libncurses5-dev \
  libnuma-dev \

--- a/toolbox/pkgs/debian-bullseye.sh
+++ b/toolbox/pkgs/debian-bullseye.sh
@@ -22,6 +22,7 @@ apt-get -qy install \
  findutils \
  git \
  libaio-dev \
+ libarchive-dev \
  libcunit1-dev \
  libncurses5-dev \
  libnuma-dev \

--- a/toolbox/pkgs/debian-trixie.sh
+++ b/toolbox/pkgs/debian-trixie.sh
@@ -22,6 +22,7 @@ apt-get -qy install \
  findutils \
  git \
  libaio-dev \
+ libarchive-dev \
  libcunit1-dev \
  libncurses5-dev \
  libnuma-dev \

--- a/toolbox/pkgs/emitter/deps.yaml
+++ b/toolbox/pkgs/emitter/deps.yaml
@@ -97,6 +97,20 @@ deps:
       pkg: [py39-pipx]
       zypper: [python3-pipx]
 
+  archive:
+    notes: Required by DPDK 23.03 and thereby for SPDK 23.05
+    ver: 0.0
+    when: [building, running]
+    purpose: {be: [spdk]}
+    names:
+      default: [libarchive-dev]
+      pacman: [libarchive]
+      emerge: [app-arch/libarchive]
+      dnf: [libarchive-devel]
+      yum: [libarchive-devel]
+      zypper: [libarchive-devel]
+      pkg: [archivers/libarchive]
+
   cunit:
     notes: Required by SPDK
     ver: 0.0
@@ -259,8 +273,8 @@ defaults:
 
   linux:
     deps:
-    - [sys, [bash, cunit, clang-format, elftools, find, git, libaio, liburing, libuuid, make, meson, nasm, ncurses, numactl,
-        openssl, patch, pipx, pkg-config, python3]]
+    - [sys, [archive, bash, cunit, clang-format, elftools, find, git, libaio, liburing, libuuid, make, meson, nasm, ncurses,
+        numactl, openssl, patch, pipx, pkg-config, python3]]
     - [src, [libvfn]]
     apps:
     - [src, [fio]]

--- a/toolbox/pkgs/fedora-36.sh
+++ b/toolbox/pkgs/fedora-36.sh
@@ -17,6 +17,7 @@ dnf install -y \
  gcc \
  git \
  libaio-devel \
+ libarchive-devel \
  libtool \
  libuuid-devel \
  make \

--- a/toolbox/pkgs/fedora-37.sh
+++ b/toolbox/pkgs/fedora-37.sh
@@ -17,6 +17,7 @@ dnf install -y \
  gcc \
  git \
  libaio-devel \
+ libarchive-devel \
  libtool \
  liburing \
  liburing-devel \

--- a/toolbox/pkgs/fedora-38.sh
+++ b/toolbox/pkgs/fedora-38.sh
@@ -17,6 +17,7 @@ dnf install -y \
  gcc \
  git \
  libaio-devel \
+ libarchive-devel \
  libtool \
  liburing \
  liburing-devel \

--- a/toolbox/pkgs/gentoo-latest.sh
+++ b/toolbox/pkgs/gentoo-latest.sh
@@ -11,6 +11,7 @@ echo "export LDFLAGS=\"-ltinfo -lncurses\""
 
 emerge-webrsync
 emerge \
+ app-arch/libarchive \
  bash \
  dev-lang/nasm \
  dev-libs/libaio \

--- a/toolbox/pkgs/opensuse-tumbleweed-latest.sh
+++ b/toolbox/pkgs/opensuse-tumbleweed-latest.sh
@@ -20,6 +20,7 @@ zypper --non-interactive install -y --allow-downgrade \
  git \
  gzip \
  libaio-devel \
+ libarchive-devel \
  libnuma-devel \
  libopenssl-devel \
  libtool \

--- a/toolbox/pkgs/oraclelinux-9.sh
+++ b/toolbox/pkgs/oraclelinux-9.sh
@@ -21,6 +21,7 @@ dnf install -y \
  gcc-c++ \
  git \
  libaio-devel \
+ libarchive-devel \
  libtool \
  libuuid-devel \
  make \

--- a/toolbox/pkgs/rockylinux-9.2.sh
+++ b/toolbox/pkgs/rockylinux-9.2.sh
@@ -21,6 +21,7 @@ dnf install -y \
  gcc-c++ \
  git \
  libaio-devel \
+ libarchive-devel \
  libtool \
  libuuid-devel \
  make \

--- a/toolbox/pkgs/ubuntu-focal.sh
+++ b/toolbox/pkgs/ubuntu-focal.sh
@@ -22,6 +22,7 @@ apt-get -qy install \
  findutils \
  git \
  libaio-dev \
+ libarchive-dev \
  libcunit1-dev \
  libncurses5-dev \
  libnuma-dev \

--- a/toolbox/pkgs/ubuntu-jammy.sh
+++ b/toolbox/pkgs/ubuntu-jammy.sh
@@ -22,6 +22,7 @@ apt-get -qy install \
  findutils \
  git \
  libaio-dev \
+ libarchive-dev \
  libcunit1-dev \
  libncurses5-dev \
  libnuma-dev \

--- a/toolbox/pkgs/ubuntu-lunar.sh
+++ b/toolbox/pkgs/ubuntu-lunar.sh
@@ -22,6 +22,7 @@ apt-get -qy install \
  findutils \
  git \
  libaio-dev \
+ libarchive-dev \
  libcunit1-dev \
  libncurses5-dev \
  libnuma-dev \


### PR DESCRIPTION
Bump SPDK since #350 uses a patch that is available in SPDK v23.01.

This requires a new dependency 'libarchive' for the version of DPDK which comes
with SPDK v23.01.

Besides this, the `spdk_configure.sh` script has been updated to disable
more things we don't need.

