### PR TITLE
Support nvme with char-device

### DIFF
--- a/lib/xnvme_be_linux_dev.c
+++ b/lib/xnvme_be_linux_dev.c
@@ -144,8 +144,11 @@ xnvme_be_linux_dev_open(struct xnvme_dev *dev)
 
 		err = xnvme_be_linux_nvme_dev_nsid(dev);
 		if (err < 1) {
-			XNVME_DEBUG("INFO: open() : retrieving nsid, got: %x", err);
-			break;
+			if (strncmp(basename(dev->ident.uri), "nvme", 4)) {
+				XNVME_DEBUG("INFO: open() : retrieving nsid, got: %x", err);
+				break;
+			}
+			err = 0;
 		}
 
 		XNVME_DEBUG("INFO: open() : char-device-file: NVMe ioctl() with async. emulation");


### PR DESCRIPTION
/dev/nvme0 is nvme char device.
But nsid of /dev/nvme0 is returned as 0xffffffff.
So check the uri to support nvme char device.