### PR TITLE
fix(docs): add fdp-tutorial to index

### DIFF
--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -11,6 +11,7 @@ In the future, more tutorials will be added with the purpose of introducing the 
 .. toctree::
    :hidden:
 
+   fdp/index.rst
    devs/index.rst
    dynamic_loading/index.rst
    fabrics/index.rst


### PR DESCRIPTION
Without this, then the fdp-tutorial is not available.