### PR TITLE
feat(be/liburing): turn on batching by default

### DIFF
--- a/lib/xnvme_be_linux_async_liburing.c
+++ b/lib/xnvme_be_linux_async_liburing.c
@@ -122,8 +122,9 @@ xnvme_be_linux_liburing_init(struct xnvme_queue *q, int opts)
 		return -err;
 	}
 
-	if (getenv("XNVME_QUEUE_BATCHING")) {
-		queue->batching = 1;
+	queue->batching = 1;
+	if (getenv("XNVME_QUEUE_BATCHING_OFF")) {
+		queue->batching = 0;
 	}
 
 	//


### PR DESCRIPTION
Instead of requiring `XNVME_QUEUE_BATCHING = 1` to enable batching, now we require `XNVME_QUEUE_BATCHING_OFF = 1` to disable batching