### PR TITLE
fix(toolbox/pkgs): build libvfn as release

### DIFF
--- a/toolbox/pkgs/alpine-latest.sh
+++ b/toolbox/pkgs/alpine-latest.sh
@@ -48,7 +48,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd

--- a/toolbox/pkgs/archlinux-latest.sh
+++ b/toolbox/pkgs/archlinux-latest.sh
@@ -45,7 +45,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd

--- a/toolbox/pkgs/centos-stream9.sh
+++ b/toolbox/pkgs/centos-stream9.sh
@@ -73,7 +73,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd

--- a/toolbox/pkgs/debian-bookworm.sh
+++ b/toolbox/pkgs/debian-bookworm.sh
@@ -54,7 +54,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd

--- a/toolbox/pkgs/debian-bullseye.sh
+++ b/toolbox/pkgs/debian-bullseye.sh
@@ -74,7 +74,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd

--- a/toolbox/pkgs/debian-trixie.sh
+++ b/toolbox/pkgs/debian-trixie.sh
@@ -54,7 +54,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd

--- a/toolbox/pkgs/emitter/templates/src-libvfn.sh.jinja
+++ b/toolbox/pkgs/emitter/templates/src-libvfn.sh.jinja
@@ -10,7 +10,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd

--- a/toolbox/pkgs/fedora-36.sh
+++ b/toolbox/pkgs/fedora-36.sh
@@ -47,7 +47,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd

--- a/toolbox/pkgs/fedora-37.sh
+++ b/toolbox/pkgs/fedora-37.sh
@@ -49,7 +49,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd

--- a/toolbox/pkgs/fedora-38.sh
+++ b/toolbox/pkgs/fedora-38.sh
@@ -49,7 +49,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd

--- a/toolbox/pkgs/gentoo-latest.sh
+++ b/toolbox/pkgs/gentoo-latest.sh
@@ -41,7 +41,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd

--- a/toolbox/pkgs/opensuse-tumbleweed-latest.sh
+++ b/toolbox/pkgs/opensuse-tumbleweed-latest.sh
@@ -51,7 +51,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd

--- a/toolbox/pkgs/oraclelinux-9.sh
+++ b/toolbox/pkgs/oraclelinux-9.sh
@@ -73,7 +73,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd

--- a/toolbox/pkgs/rockylinux-9.2.sh
+++ b/toolbox/pkgs/rockylinux-9.2.sh
@@ -73,7 +73,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd

--- a/toolbox/pkgs/ubuntu-focal.sh
+++ b/toolbox/pkgs/ubuntu-focal.sh
@@ -74,7 +74,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd

--- a/toolbox/pkgs/ubuntu-jammy.sh
+++ b/toolbox/pkgs/ubuntu-jammy.sh
@@ -74,7 +74,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd

--- a/toolbox/pkgs/ubuntu-lunar.sh
+++ b/toolbox/pkgs/ubuntu-lunar.sh
@@ -54,7 +54,7 @@ git clone https://github.com/OpenMPDK/libvfn.git toolbox/third-party/libvfn/repo
 
 pushd toolbox/third-party/libvfn/repository
 git checkout v3.0.0-rc1
-meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --prefix=/usr
+meson setup builddir -Dlibnvme="disabled" -Ddocs="disabled" --buildtype=release --prefix=/usr
 meson compile -C builddir
 meson install -C builddir
 popd


### PR DESCRIPTION
Currently we are building libvfn with debug enabled, this leads to unwanted debug messages getting printed in our CI. Silence these by building as release.

This closes #324 