### PR TITLE
fix(cijoe,python): add 'vfio' to backend-test-matrix

### DIFF
--- a/cijoe/tests/logic/test_xnvme_tests_ioworker.py
+++ b/cijoe/tests/logic/test_xnvme_tests_ioworker.py
@@ -19,6 +19,8 @@ def test_verify_sync(cijoe, device, be_opts, cli_args):
 def test_verify_iovec(cijoe, device, be_opts, cli_args):
     if be_opts["be"] == "spdk":
         pytest.skip(reason="[be=spdk] does not implement iovec")
+    if be_opts["be"] == "vfio":
+        pytest.skip(reason="[be=vfio] does not implement iovec")
     if be_opts["async"] == "posix":
         pytest.skip(reason="[async=posix] does not implement iovec")
     if be_opts["be"] == "linux" and be_opts["sync"] == "psync":
@@ -34,6 +36,8 @@ def test_verify_iovec(cijoe, device, be_opts, cli_args):
 def test_verify_sync_iovec(cijoe, device, be_opts, cli_args):
     if be_opts["be"] == "spdk":
         pytest.skip(reason="[be=spdk] does not implement iovec")
+    if be_opts["be"] == "vfio":
+        pytest.skip(reason="[be=vfio] does not implement iovec")
     if be_opts["be"] == "linux" and be_opts["sync"] == "psync":
         pytest.skip(reason="[be=linux] and [sync=psync] does not implement iovec")
     if be_opts["be"] == "fbsd" and be_opts["sync"] == "nvme":
@@ -59,6 +63,8 @@ def test_verify_sync_direct(cijoe, device, be_opts, cli_args):
 def test_verify_iovec_direct(cijoe, device, be_opts, cli_args):
     if be_opts["be"] == "spdk":
         pytest.skip(reason="[be=spdk] does not implement iovec")
+    if be_opts["be"] == "vfio":
+        pytest.skip(reason="[be=vfio] does not implement iovec")
     if be_opts["async"] == "posix":
         pytest.skip(reason="[async=posix] does not implement iovec")
     if be_opts["be"] == "linux" and be_opts["sync"] == "psync":
@@ -74,6 +80,8 @@ def test_verify_iovec_direct(cijoe, device, be_opts, cli_args):
 def test_verify_sync_iovec_direct(cijoe, device, be_opts, cli_args):
     if be_opts["be"] == "spdk":
         pytest.skip(reason="[be=spdk] does not implement iovec")
+    if be_opts["be"] == "vfio":
+        pytest.skip(reason="[be=vfio] does not implement iovec")
     if be_opts["be"] == "linux" and be_opts["sync"] == "psync":
         pytest.skip(reason="[be=linux] and [sync=psync] does not implement iovec")
     if be_opts["be"] == "fbsd" and be_opts["sync"] == "nvme":

--- a/cijoe/tests/xnvme_be_combinations.py
+++ b/cijoe/tests/xnvme_be_combinations.py
@@ -64,6 +64,14 @@ def get_combinations():
         },
         # User-space NVMe-driver
         {
+            "be": ["vfio"],
+            "mem": ["vfio"],
+            "async": ["vfio"],
+            "sync": ["vfio"],
+            "admin": ["vfio"],
+            "label": ["pcie"],
+        },
+        {
             "be": ["spdk"],
             "mem": ["spdk"],
             "async": ["nvme"],
@@ -80,18 +88,6 @@ def get_combinations():
             "label": ["fabrics"],
         },
     ]
-    if False:
-        # User-space NVMe-driver
-        combos["linux"].append(
-            {
-                "be": ["libvfn"],
-                "mem": ["libvfn"],
-                "async": ["libvfn"],
-                "sync": ["libvfn"],
-                "admin": ["libvfn"],
-                "label": ["pcie"],
-            }
-        )
 
     combos["freebsd"].append(
         {

--- a/cijoe/workflows/test-debian-bullseye.yaml
+++ b/cijoe/workflows/test-debian-bullseye.yaml
@@ -12,7 +12,7 @@ steps:
 - name: test_python
   uses: core.testrunner
   with:
-    args: '{{ config.xnvme.source.path }}/python/tests -k "not fabrics"'
+    args: '{{ config.xnvme.source.path }}/python/tests -k "not fabrics and not vfio"'
     run_local: false
 
 - name: test_ramdisk

--- a/lib/xnvme_be_vfio_async.c
+++ b/lib/xnvme_be_vfio_async.c
@@ -122,7 +122,7 @@ xnvme_be_vfio_async_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nb
 	rq->opaque = ctx;
 
 	if (dbuf) {
-		if (!vfio_map_vaddr(state->ctrl->pci.dev.vfio, dbuf, dbuf_nbytes, &iova)) {
+		if (vfio_map_vaddr(state->ctrl->pci.dev.vfio, dbuf, dbuf_nbytes, &iova)) {
 			XNVME_DEBUG("FAILED: vfio_iommu_vaddr_to_iova()");
 			goto err;
 		}
@@ -131,7 +131,7 @@ xnvme_be_vfio_async_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nb
 	}
 
 	if (mbuf) {
-		if (!vfio_map_vaddr(state->ctrl->pci.dev.vfio, mbuf, mbuf_nbytes, &iova)) {
+		if (vfio_map_vaddr(state->ctrl->pci.dev.vfio, mbuf, mbuf_nbytes, &iova)) {
 			XNVME_DEBUG("FAILED: vfio_iommu_vaddr_to_iova()");
 			goto err;
 		}

--- a/lib/xnvme_be_vfio_mem.c
+++ b/lib/xnvme_be_vfio_mem.c
@@ -54,6 +54,7 @@ xnvme_be_vfio_buf_free(const struct xnvme_dev *dev, void *buf)
 
 	if (vfio_unmap_vaddr(vfio, buf, &len)) {
 		XNVME_DEBUG("FAILED: vfio_pci_unmap_vaddr(-, %p): %s\n", buf, strerror(errno));
+		return;
 	}
 
 	if (munmap(buf, len)) {

--- a/lib/xnvme_be_vfio_sync.c
+++ b/lib/xnvme_be_vfio_sync.c
@@ -44,7 +44,7 @@ xnvme_be_vfio_sync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nby
 	}
 
 	if (dbuf) {
-		if (!vfio_map_vaddr(ctrl->pci.dev.vfio, dbuf, dbuf_nbytes, &iova)) {
+		if (vfio_map_vaddr(ctrl->pci.dev.vfio, dbuf, dbuf_nbytes, &iova)) {
 			XNVME_DEBUG("FAILED: vfio_iommu_vaddr_to_iova()");
 			ret = -EINVAL;
 			goto out;
@@ -54,7 +54,7 @@ xnvme_be_vfio_sync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t dbuf_nby
 	}
 
 	if (mbuf) {
-		if (!vfio_map_vaddr(state->ctrl->pci.dev.vfio, mbuf, mbuf_nbytes, &iova)) {
+		if (vfio_map_vaddr(state->ctrl->pci.dev.vfio, mbuf, mbuf_nbytes, &iova)) {
 			XNVME_DEBUG("FAILED: vfio_iommu_vaddr_to_iova()");
 			ret = -EINVAL;
 			goto out;

--- a/python/tests/xnvme_be_combinations.py
+++ b/python/tests/xnvme_be_combinations.py
@@ -64,6 +64,14 @@ def get_combinations():
         },
         # User-space NVMe-driver
         {
+            "be": ["vfio"],
+            "mem": ["vfio"],
+            "async": ["vfio"],
+            "sync": ["vfio"],
+            "admin": ["vfio"],
+            "label": ["pcie"],
+        },
+        {
             "be": ["spdk"],
             "mem": ["spdk"],
             "async": ["nvme"],
@@ -80,18 +88,6 @@ def get_combinations():
             "label": ["fabrics"],
         },
     ]
-    if False:
-        # User-space NVMe-driver
-        combos["linux"].append(
-            {
-                "be": ["libvfn"],
-                "mem": ["libvfn"],
-                "async": ["libvfn"],
-                "sync": ["libvfn"],
-                "admin": ["libvfn"],
-                "label": ["pcie"],
-            }
-        )
 
     combos["freebsd"].append(
         {


### PR DESCRIPTION
This turned out to uncover a handful of issues:

- [x] Bump libvfn to v3 rc2
- [x] Fix usage of libvfn (incorrect usage of return-value)
- [x] Fix error handling in libvfn backend
- [ ] Feat: add support for iovec in libvfn backend
- [ ] Fix: enable use of libvfn backend with Python bindings
The two latter items are captured in issues.