### PR TITLE
fix(rust): use header found via system_deps()

### DIFF
--- a/rust/xnvme-sys/build.rs
+++ b/rust/xnvme-sys/build.rs
@@ -1,6 +1,26 @@
-fn main() {
+use std::error::Error;
+use std::io;
+use std::io::ErrorKind;
+use std::path;
+
+fn main() -> Result<(), Box<dyn Error>> {
     // Emit link options for linking system dependencies
-    let deps = system_deps::Config::new().probe().unwrap();
+    let deps = system_deps::Config::new().probe()?;
+    let mut header_path = path::PathBuf::new();
+
+    // Find library header
+    for include_path in deps.all_include_paths().iter() {
+        header_path.clear();
+        header_path.clone_from(include_path);
+        header_path.push("libxnvme.h");
+    }
+
+    if !header_path.exists() {
+        return Err(Box::new(io::Error::new(
+            ErrorKind::Other,
+            "Cannot find header_file('libxnvme.h'); is xNVMe installed?".to_string(),
+        )));
+    }
 
     // Generate include arguments for clang
     let flags: Vec<String> = deps
@@ -11,7 +31,7 @@ fn main() {
 
     // Generate bindings for xnvme
     let bindings = bindgen::Builder::default()
-        .header("../../include/libxnvme.h")
+        .header(header_path.to_str().map(|s| s.to_string()).unwrap())
         .allowlist_function("xnvme_.*")
         .allowlist_type("xnvme_.*")
         .clang_args(flags)
@@ -22,8 +42,11 @@ fn main() {
         .expect("Failed to generate bindings");
 
     // Write bindings to file
-    let out_path = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let out_path = std::path::PathBuf::from(std::env::var("OUT_DIR")?);
+
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Failed to write bindings to file");
+
+    Ok(())
 }


### PR DESCRIPTION
The path to the xNVMe library header was hardcoded. By doing so, 'cargo
build' would generate bindings. However, the build would fail when
invoked via 'cargo publish' as the hardcoded path would be incorrect.

Thus, instead of generating the bindings based on the relative path, the
bindings are generated based on the header found via
system_deps/include_paths. That is, against the library header, the
Rust-crate "system_deps" has verified that it is available in the
correct version.