### PR TITLE
docs(release-checklist): add description on Python + Rust publication

### DIFF
--- a/docs/contributing/release-checklist.rst
+++ b/docs/contributing/release-checklist.rst
@@ -62,4 +62,12 @@ release are integrated on ``next`` and all tests are passing. Then:
 
 * Publish the Python package
 
+  - We wish to publish the Python package that have been utilized for testing
+    and provided as artifact for the release. Thus, download and rename it,
+    then upload it.
+  - Rename: ``xnvme-py-sdist.tar.gz xnvme-X.Y.Z.tar.gz``
+  - Upload: ``twine upload xnvme-X.Y.Z.tar.gz``
+
 * Publish the Rust crate
+
+  - Upload: ``cd rust/xnvme-sys && cargo publish``


### PR DESCRIPTION
This briefly describes how to publish the Python xNVMe bindings package to the Python package index and how to published the Rust crate to crates.io.