### PR TITLE
NVMe Controller handles (``/dev/nvme0``) in Linux backend

### DIFF
--- a/lib/xnvme_be.c
+++ b/lib/xnvme_be.c
@@ -457,6 +457,14 @@ xnvme_be_dev_idfy(struct xnvme_dev *dev)
 		XNVME_DEBUG("FAILED: xnvme_adm_idfy_ctrlr(), err: %d", err);
 		goto exit;
 	}
+	// Store idfy-ctrlr in device instance
+	memcpy(&dev->id.ctrlr, idfy_ctrlr, sizeof(*idfy_ctrlr));
+	// Store subnqn in device-identifier
+	memcpy(dev->ident.subnqn, idfy_ctrlr->ctrlr.subnqn, sizeof(dev->ident.subnqn));
+
+	if (dev->ident.dtype == XNVME_DEV_TYPE_NVME_CONTROLLER) {
+		goto exit;
+	}
 
 	// Retrieve idfy-ns
 	memset(idfy_ns, 0, sizeof(*idfy_ns));
@@ -467,12 +475,7 @@ xnvme_be_dev_idfy(struct xnvme_dev *dev)
 		XNVME_DEBUG("FAILED: xnvme_adm_idfy_ns(), err: %d", err);
 		goto exit;
 	}
-
-	// Store subnqn in device-identifier
-	memcpy(dev->ident.subnqn, idfy_ctrlr->ctrlr.subnqn, sizeof(dev->ident.subnqn));
-
-	// Store idfy-ctrlr and idfy-ns in device instance
-	memcpy(&dev->id.ctrlr, idfy_ctrlr, sizeof(*idfy_ctrlr));
+	// Store idfy-ns in device instance
 	memcpy(&dev->id.ns, idfy_ns, sizeof(*idfy_ns));
 
 	//

--- a/lib/xnvme_be.c
+++ b/lib/xnvme_be.c
@@ -330,7 +330,19 @@ _kvs_geometry(struct xnvme_dev *dev)
 	return 0;
 }
 
-// TODO: add proper handling of NVMe controllers
+static inline int
+_controller_geometry(struct xnvme_dev *dev)
+{
+	struct xnvme_geo *geo = &dev->geo;
+
+	memset(geo, 0, sizeof(*geo));
+	geo->type = XNVME_GEO_UNKNOWN;
+
+	///< note: mdts is setup in derive-geometry, so this function does nothing
+
+	return 0;
+}
+
 int
 xnvme_be_dev_derive_geometry(struct xnvme_dev *dev)
 {
@@ -338,8 +350,7 @@ xnvme_be_dev_derive_geometry(struct xnvme_dev *dev)
 
 	switch (dev->ident.dtype) {
 	case XNVME_DEV_TYPE_NVME_CONTROLLER:
-		XNVME_DEBUG("FAILED: not supported");
-		return -ENOSYS;
+		return _controller_geometry(dev);
 
 	case XNVME_DEV_TYPE_FS_FILE:
 		return _fs_geometry(dev);


### PR DESCRIPTION
A long-standing thing to address is: https://github.com/OpenMPDK/xNVMe/issues/230
This is an initial improvement in this area, motivated by PR https://github.com/OpenMPDK/xNVMe/pull/365
However, instead of going with PR #365 then a bit more work is done here to enable the correct internal representation of the device-type.