### PR TITLE
get/show controller-registers using backends: [linux,spdk]

### DIFF
--- a/include/libxnvme.h
+++ b/include/libxnvme.h
@@ -34,7 +34,6 @@ extern "C" {
 #include "libxnvme_util.h"
 #include "libxnvme_opts.h"
 #include "libxnvme_dev.h"
-#include "libxnvme_topology.h"
 #include "libxnvme_be.h"
 #include "libxnvme_buf.h"
 #include "libxnvme_mem.h"
@@ -53,6 +52,7 @@ extern "C" {
 #include "libxnvme_nvm.h"
 #include "libxnvme_kvs.h"
 #include "libxnvme_znd.h"
+#include "libxnvme_topology.h"
 #include "libxnvme_libconf.h"
 #include "libxnvme_cli.h"
 

--- a/include/libxnvme_spec_pp.h
+++ b/include/libxnvme_spec_pp.h
@@ -205,3 +205,9 @@ xnvme_spec_znd_state_str(enum xnvme_spec_znd_state eval);
  */
 const char *
 xnvme_spec_znd_type_str(enum xnvme_spec_znd_type eval);
+
+int
+xnvme_spec_ctrlr_bar_fpr(FILE *stream, struct xnvme_spec_ctrlr_bar *bar, int opts);
+
+int
+xnvme_spec_ctrlr_bar_pp(struct xnvme_spec_ctrlr_bar *bar, int opts);

--- a/include/libxnvme_topology.h
+++ b/include/libxnvme_topology.h
@@ -29,3 +29,13 @@ xnvme_controller_reset(struct xnvme_dev *dev);
 
 int
 xnvme_namespace_rescan(struct xnvme_dev *dev);
+
+/**
+ * Read NVMe PCIe controller reigsters
+ *
+ * @param dev Device handle obtained with xnvme_dev_open()
+ * @param bar NVMe PCIe BAR0 registers buffer to save read values
+ * @return On success, 0 is return. On error, a non-zero value is returned.
+ */
+int
+xnvme_controller_get_registers(struct xnvme_dev *dev, struct xnvme_spec_ctrlr_bar *bar);

--- a/lib/xnvme_spec_pp.c
+++ b/lib/xnvme_spec_pp.c
@@ -421,3 +421,62 @@ xnvme_spec_znd_type_str(enum xnvme_spec_znd_type eval)
 
 	return "ENOSYS";
 }
+
+int
+xnvme_spec_ctrlr_bar_fpr(FILE *stream, struct xnvme_spec_ctrlr_bar *bar, int opts)
+{
+	int wrtn = 0;
+
+	switch (opts) {
+	case XNVME_PR_TERSE:
+		wrtn += fprintf(stream, "# ENOSYS: opts(%x)", opts);
+		return wrtn;
+
+	case XNVME_PR_DEF:
+	case XNVME_PR_YAML:
+		break;
+	}
+
+	wrtn += fprintf(stream, "xnvme_spec_ctrlr_bar:");
+	if (!bar) {
+		wrtn += fprintf(stream, "~\n");
+		return wrtn;
+	}
+
+	wrtn += fprintf(stream, "\n");
+
+	wrtn += fprintf(stream, "  cap: 0x%016" PRIx64 "\n", bar->cap);
+	wrtn += fprintf(stream, "  vs: %" PRIu32 "\n", bar->vs);
+	wrtn += fprintf(stream, "  intms: %" PRIu32 "\n", bar->intms);
+	wrtn += fprintf(stream, "  intmc: %" PRIu32 "\n", bar->intmc);
+	wrtn += fprintf(stream, "  cc: %" PRIu32 "\n", bar->cc);
+	wrtn += fprintf(stream, "  csts: %" PRIu32 "\n", bar->csts);
+	wrtn += fprintf(stream, "  nssr: %" PRIu32 "\n", bar->nssr);
+	wrtn += fprintf(stream, "  aqa: %" PRIu32 "\n", bar->aqa);
+
+	wrtn += fprintf(stream, "  asq: %" PRIu64 "\n", bar->asq);
+	wrtn += fprintf(stream, "  acq: %" PRIu64 "\n", bar->acq);
+
+	wrtn += fprintf(stream, "  cmbloc: %" PRIu32 "\n", bar->cmbloc);
+	wrtn += fprintf(stream, "  cmbsz: %" PRIu32 "\n", bar->cmbsz);
+	wrtn += fprintf(stream, "  bpinfo: %" PRIu32 "\n", bar->bpinfo);
+	wrtn += fprintf(stream, "  bprsel: %" PRIu32 "\n", bar->bprsel);
+	wrtn += fprintf(stream, "  bpmbl: %" PRIu64 "\n", bar->bpmbl);
+	wrtn += fprintf(stream, "  cmbmsc: %" PRIu64 "\n", bar->cmbmsc);
+	wrtn += fprintf(stream, "  cmbsts: %" PRIu32 "\n", bar->cmbsts);
+	wrtn += fprintf(stream, "  pmrcap: %" PRIu32 "\n", bar->pmrcap);
+	wrtn += fprintf(stream, "  pmrctl: %" PRIu32 "\n", bar->pmrctl);
+	wrtn += fprintf(stream, "  pmrsts: %" PRIu32 "\n", bar->pmrsts);
+	wrtn += fprintf(stream, "  pmrebs: %" PRIu32 "\n", bar->pmrebs);
+	wrtn += fprintf(stream, "  pmrswtp: %" PRIu32 "\n", bar->pmrswtp);
+	wrtn += fprintf(stream, "  pmrmscl: %" PRIu32 "\n", bar->pmrmscl);
+	wrtn += fprintf(stream, "  pmrmscu: %" PRIu32 "\n", bar->pmrmscu);
+
+	return wrtn;
+}
+
+int
+xnvme_spec_ctrlr_bar_pp(struct xnvme_spec_ctrlr_bar *bar, int opts)
+{
+	return xnvme_spec_ctrlr_bar_fpr(stdout, bar, opts);
+}

--- a/lib/xnvme_topology.c
+++ b/lib/xnvme_topology.c
@@ -17,9 +17,12 @@ xnvme_subsystem_reset(struct xnvme_dev *dev)
 
 	err = xnvme_cmd_pass_pseudo(&ctx, NULL, 0x0, NULL, 0x0);
 	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_cmd_pass_pseudo(); err: %d", err);
 		return err;
 	}
 	if (xnvme_cmd_ctx_cpl_status(&ctx)) {
+		XNVME_DEBUG("FAILED: xnvme_cmd_pass_pseudo(); xnvme_cmd_ctx_cpl_status.sc: %d",
+			    ctx.cpl.status.sc);
 		return -ctx.cpl.status.sc;
 	}
 
@@ -36,9 +39,12 @@ xnvme_controller_reset(struct xnvme_dev *dev)
 
 	err = xnvme_cmd_pass_pseudo(&ctx, NULL, 0x0, NULL, 0x0);
 	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_cmd_pass_pseudo(); err: %d", err);
 		return err;
 	}
 	if (xnvme_cmd_ctx_cpl_status(&ctx)) {
+		XNVME_DEBUG("FAILED: xnvme_cmd_pass_pseudo(); xnvme_cmd_ctx_cpl_status.sc: %d",
+			    ctx.cpl.status.sc);
 		return -ctx.cpl.status.sc;
 	}
 
@@ -55,9 +61,12 @@ xnvme_namespace_rescan(struct xnvme_dev *dev)
 
 	err = xnvme_cmd_pass_pseudo(&ctx, NULL, 0x0, NULL, 0x0);
 	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_cmd_pass_pseudo(); err: %d", err);
 		return err;
 	}
 	if (xnvme_cmd_ctx_cpl_status(&ctx)) {
+		XNVME_DEBUG("FAILED: xnvme_cmd_pass_pseudo(); xnvme_cmd_ctx_cpl_status.sc: %d",
+			    ctx.cpl.status.sc);
 		return -ctx.cpl.status.sc;
 	}
 
@@ -76,9 +85,12 @@ xnvme_controller_get_registers(struct xnvme_dev *dev, struct xnvme_spec_ctrlr_ba
 
 	err = xnvme_cmd_pass_pseudo(&ctx, bar, sizeof(*bar), NULL, 0x0);
 	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_cmd_pass_pseudo(); err: %d", err);
 		return err;
 	}
 	if (xnvme_cmd_ctx_cpl_status(&ctx)) {
+		XNVME_DEBUG("FAILED: xnvme_cmd_pass_pseudo(); xnvme_cmd_ctx_cpl_status.sc: %d",
+			    ctx.cpl.status.sc);
 		return -ctx.cpl.status.sc;
 	}
 

--- a/lib/xnvme_topology.c
+++ b/lib/xnvme_topology.c
@@ -65,3 +65,22 @@ xnvme_namespace_rescan(struct xnvme_dev *dev)
 
 	return -ENOSYS;
 }
+
+int
+xnvme_controller_get_registers(struct xnvme_dev *dev, struct xnvme_spec_ctrlr_bar *bar)
+{
+	struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
+	int err;
+
+	ctx.cmd.common.opcode = XNVME_SPEC_PSEUDO_OPC_SHOW_REGS;
+
+	err = xnvme_cmd_pass_pseudo(&ctx, bar, sizeof(*bar), NULL, 0x0);
+	if (err) {
+		return err;
+	}
+	if (xnvme_cmd_ctx_cpl_status(&ctx)) {
+		return -ctx.cpl.status.sc;
+	}
+
+	return 0;
+}

--- a/subprojects/packagefiles/spdk-win/patches/spdk-win-0003-lib-nvme-restore-spdk_nvme_ctrlr_get_registers.patch
+++ b/subprojects/packagefiles/spdk-win/patches/spdk-win-0003-lib-nvme-restore-spdk_nvme_ctrlr_get_registers.patch
@@ -1,0 +1,130 @@
+From d287ca5a625568c5f4b77d07431e45e14016e253 Mon Sep 17 00:00:00 2001
+From: "Szulik, Maciej" <maciej.szulik@intel.com>
+Date: Wed, 29 Mar 2023 12:37:51 +0200
+Subject: [PATCH] lib/nvme: restore spdk_nvme_ctrlr_get_registers
+
+This function was intended to be deleted as unused, however it can be
+useful for debug and test capabilities.
+
+Its declaration was left in header file, so just adding implementation
+for PCIE and VFIO USER transports.
+
+Signed-off-by: Szulik, Maciej <maciej.szulik@intel.com>
+Change-Id: I670acb53c2f88a844525a0ecea27143b055f117b
+Reviewed-on: https://review.spdk.io/gerrit/c/spdk/spdk/+/17400
+Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
+Reviewed-by: Ben Walker <benjamin.walker@intel.com>
+Reviewed-by: Jim Harris <james.r.harris@intel.com>
+Community-CI: Mellanox Build Bot
+Reviewed-by: Aleksey Marchuk <alexeymar@nvidia.com>
+---
+ include/spdk/nvme.h       |  2 ++
+ lib/nvme/nvme_pcie.c      |  9 +++++++++
+ lib/nvme/nvme_transport.c | 12 ++++++++++++
+ lib/nvme/nvme_vfio_user.c |  9 +++++++++
+ lib/nvme/spdk_nvme.map    |  1 +
+ 5 files changed, 33 insertions(+)
+
+diff --git a/include/spdk/nvme.h b/include/spdk/nvme.h
+index 4157292da..110571eb9 100644
+--- a/include/spdk/nvme.h
++++ b/include/spdk/nvme.h
+@@ -3982,6 +3982,8 @@ struct spdk_nvme_transport_ops {
+ 	int (*ctrlr_get_memory_domains)(const struct spdk_nvme_ctrlr *ctrlr,
+ 					struct spdk_memory_domain **domains,
+ 					int array_size);
++
++	volatile struct spdk_nvme_registers *(*ctrlr_get_registers)(struct spdk_nvme_ctrlr *ctrlr);
+ };
+ 
+ /**
+diff --git a/lib/nvme/nvme_pcie.c b/lib/nvme/nvme_pcie.c
+index 14f563532..3330425c2 100644
+--- a/lib/nvme/nvme_pcie.c
++++ b/lib/nvme/nvme_pcie.c
+@@ -178,6 +178,14 @@ nvme_pcie_reg_addr(struct spdk_nvme_ctrlr *ctrlr, uint32_t offset)
+ 	return (volatile void *)((uintptr_t)pctrlr->regs + offset);
+ }
+ 
++static volatile struct spdk_nvme_registers *
++nvme_pcie_ctrlr_get_registers(struct spdk_nvme_ctrlr *ctrlr)
++{
++	struct nvme_pcie_ctrlr *pctrlr = nvme_pcie_ctrlr(ctrlr);
++
++	return pctrlr->regs;
++}
++
+ static int
+ nvme_pcie_ctrlr_set_reg_4(struct spdk_nvme_ctrlr *ctrlr, uint32_t offset, uint32_t value)
+ {
+@@ -1130,6 +1138,7 @@ const struct spdk_nvme_transport_ops pcie_ops = {
+ 	.ctrlr_destruct = nvme_pcie_ctrlr_destruct,
+ 	.ctrlr_enable = nvme_pcie_ctrlr_enable,
+ 
++	.ctrlr_get_registers = nvme_pcie_ctrlr_get_registers,
+ 	.ctrlr_set_reg_4 = nvme_pcie_ctrlr_set_reg_4,
+ 	.ctrlr_set_reg_8 = nvme_pcie_ctrlr_set_reg_8,
+ 	.ctrlr_get_reg_4 = nvme_pcie_ctrlr_get_reg_4,
+diff --git a/lib/nvme/nvme_transport.c b/lib/nvme/nvme_transport.c
+index e8e91acc2..f1325c5f4 100644
+--- a/lib/nvme/nvme_transport.c
++++ b/lib/nvme/nvme_transport.c
+@@ -801,3 +801,15 @@ enum spdk_nvme_transport_type nvme_transport_get_trtype(const struct spdk_nvme_t
+ {
+ 	return transport->ops.type;
+ }
++
++volatile struct spdk_nvme_registers *
++spdk_nvme_ctrlr_get_registers(struct spdk_nvme_ctrlr *ctrlr)
++{
++	const struct spdk_nvme_transport *transport = nvme_get_transport(ctrlr->trid.trstring);
++
++	if (transport->ops.ctrlr_get_registers) {
++		return transport->ops.ctrlr_get_registers(ctrlr);
++	}
++
++	return NULL;
++}
+\ No newline at end of file
+diff --git a/lib/nvme/nvme_vfio_user.c b/lib/nvme/nvme_vfio_user.c
+index c52b8d4ef..e942f8572 100644
+--- a/lib/nvme/nvme_vfio_user.c
++++ b/lib/nvme/nvme_vfio_user.c
+@@ -60,6 +60,14 @@ nvme_vfio_ctrlr(struct spdk_nvme_ctrlr *ctrlr)
+ 	return SPDK_CONTAINEROF(pctrlr, struct nvme_vfio_ctrlr, pctrlr);
+ }
+ 
++static volatile struct spdk_nvme_registers *
++nvme_vfio_ctrlr_get_registers(struct spdk_nvme_ctrlr *ctrlr)
++{
++	struct nvme_vfio_ctrlr *vctrlr = nvme_vfio_ctrlr(ctrlr);
++
++	return vctrlr->pctrlr.regs;
++}
++
+ static int
+ nvme_vfio_ctrlr_set_reg_4(struct spdk_nvme_ctrlr *ctrlr, uint32_t offset, uint32_t value)
+ {
+@@ -346,6 +354,7 @@ const struct spdk_nvme_transport_ops vfio_ops = {
+ 	.ctrlr_destruct = nvme_vfio_ctrlr_destruct,
+ 	.ctrlr_enable = nvme_vfio_ctrlr_enable,
+ 
++	.ctrlr_get_registers = nvme_vfio_ctrlr_get_registers,
+ 	.ctrlr_set_reg_4 = nvme_vfio_ctrlr_set_reg_4,
+ 	.ctrlr_set_reg_8 = nvme_vfio_ctrlr_set_reg_8,
+ 	.ctrlr_get_reg_4 = nvme_vfio_ctrlr_get_reg_4,
+diff --git a/lib/nvme/spdk_nvme.map b/lib/nvme/spdk_nvme.map
+index f4522aa31..f3bbaa898 100644
+--- a/lib/nvme/spdk_nvme.map
++++ b/lib/nvme/spdk_nvme.map
+@@ -114,6 +114,7 @@
+ 	spdk_nvme_ctrlr_set_remove_cb;
+ 	spdk_nvme_ctrlr_get_memory_domains;
+ 	spdk_nvme_ctrlr_get_discovery_log_page;
++	spdk_nvme_ctrlr_get_registers;
+ 
+ 	spdk_nvme_poll_group_create;
+ 	spdk_nvme_poll_group_add;
+-- 
+2.39.1
+

--- a/tools/xnvme.c
+++ b/tools/xnvme.c
@@ -1076,6 +1076,25 @@ exit:
 }
 
 static int
+show_regs(struct xnvme_cli *cli)
+{
+	struct xnvme_dev *dev = cli->args.dev;
+	struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
+	struct xnvme_spec_ctrlr_bar bar = {0};
+	int err;
+
+	err = xnvme_controller_get_registers(dev, &bar);
+	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		xnvme_cli_perr("xnvme_controller_get_registers()", err);
+		return err;
+	}
+
+	xnvme_spec_ctrlr_bar_pp(&bar, XNVME_PR_DEF);
+
+	return 0;
+}
+
+static int
 subsystem_reset(struct xnvme_cli *cli)
 {
 	struct xnvme_dev *dev = cli->args.dev;
@@ -1604,6 +1623,18 @@ static struct xnvme_cli_sub g_subs[] = {
 		"Resets the subsystem",
 		"Resets the subsystem",
 		subsystem_reset,
+		{
+			{XNVME_CLI_OPT_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_URI, XNVME_CLI_POSA},
+
+			XNVME_CLI_ADMIN_OPTS,
+		},
+	},
+	{
+		"show-regs",
+		"Show controller-registers",
+		"Show controller-registers",
+		show_regs,
 		{
 			{XNVME_CLI_OPT_POSA_TITLE, XNVME_CLI_SKIP},
 			{XNVME_CLI_OPT_URI, XNVME_CLI_POSA},


### PR DESCRIPTION
This is a refactoring of PR https://github.com/OpenMPDK/xNVMe/pull/350 after the introduction of the following preparation work:

* https://github.com/OpenMPDK/xNVMe/pull/322
  * This provides a general interface for things like resets/rescans, such that the backend interface does not need to change when new functionality is needed
* https://github.com/OpenMPDK/xNVMe/pull/353
  * This provides initial implementations of the interface in the Linux and SPDK backends
* https://github.com/OpenMPDK/xNVMe/pull/372
  * With this, we get the register-mapping capabilities from SPDK, instead of backporting patches
* https://github.com/OpenMPDK/xNVMe/pull/385
  * Without this, it was not possible to get a handle to e.g. ``/dev/nvme0`` to do the various resets

Last, a commit is added invoking show-regs via ``xnvme show-regs``, that is, a command-line is added to show-registers.

A related note for testing ``show-regs``: https://github.com/OpenMPDK/xNVMe/issues/387
