### PR TITLE
Packaging

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1058,3 +1058,46 @@ jobs:
         --form version="v${PROJECT_VERSION}" \
         --form description="xNVMe libraries and tools for NVMe" \
         "https://scan.coverity.com/builds?project=${PROJECT_NAME}"
+
+  packaging-debian:
+    needs: source-archive
+    runs-on: ubuntu-latest
+    container: ghcr.io/xnvme/xnvme-deps-debian-packaging:main
+    if: github.event_name == 'pull_request'
+
+    steps:
+    - name: Info
+      run: |
+        echo "Current branch is ${{ github.base_ref }}"
+        echo "Current tag is ${{ github.ref }}"
+
+    - name: Retrieve the xNVMe source archive
+      uses: actions/download-artifact@v3.0.1
+      with:
+        name: xnvme-src-archive
+
+    - name: Retrieve the xNVMe Debian package repository by branch
+      run: |
+        git clone https://salsa.debian.org/safl/xnvme.git debpkg
+        git -C debpkg checkout ${{ github.base_ref }}
+
+    - name: Prep
+      run: |
+        mv xnvme-src.tar.gz debpkg/input/xnvme-0.7.3.tar.gz
+
+    - name: Build
+      run: |
+        cd debpkg && make
+
+    - name: Upload debian packages
+      uses: actions/upload-artifact@v3.1.1
+      with:
+        name: packages-debian
+        path: |
+          debpkg/builddir/libxnvme*.deb
+          debpkg/builddir/xnvme-cli*.deb
+          debpkg/builddir/xnvme-full*.deb
+          debpkg/builddir/*.dsc
+          debpkg/builddir/*.buildinfo
+          debpkg/builddir/*.changes
+        if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ builddir
 docs/build
 docs/autogen/enumerate_example
 docs/tutorial/dynamic_loading/enumerate_example
+compile_commands.json
 cscope.out
 tags
 cmake-build-debug/

--- a/Makefile
+++ b/Makefile
@@ -384,11 +384,12 @@ gen-man-pages:
 	@echo "## xNVMe: make gen-man-pages [DONE]"
 
 define tags-help
-# Helper-target to produce tags
+# Helper-target to produce tags and compile-commands
 endef
 .PHONY: tags
 tags:
 	@echo "## xNVMe: make tags"
+	@if [ -d "$(BUILD_DIR)" ]; then cp $(BUILD_DIR)/compile_commands.json .; fi;
 	@$(CTAGS) * --languages=C -h=".c.h" -R --exclude=$(BUILD_DIR) \
 		include \
 		lib \

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -20,6 +20,7 @@ feedback on your `pull-request`_ or ask questions.
    contributing-toolbox.rst
    contributing-conventions.rst
    contributing-branches.rst
+   packaging/index.rst
    release-checklist.rst
 
 .. _Discord: https://discord.com/invite/XCbBX9DmKf

--- a/docs/contributing/packaging/aur/index.rst
+++ b/docs/contributing/packaging/aur/index.rst
@@ -1,0 +1,19 @@
+.. _sec-contributing-packaging-aur:
+
+Arch Linux (AUR - ``pacman``)
+-----------------------------
+
+To update the pkg::
+
+  # Clone the repository
+  git clone https://aur.archlinux.org/xnvme.git
+  cd xnvme
+
+Edit ``PKGBUILD`` -- update ``pkgver``, ``md5sums``, then::
+
+  updpkgsums
+  makepkg --printsrcinfo > .SRCINFO
+  git add PKGBUILD
+  git add .SRCINFO
+  git commit -s -m "bump to <major.minor.patch>"
+  git push origin

--- a/docs/contributing/packaging/brew/index.rst
+++ b/docs/contributing/packaging/brew/index.rst
@@ -1,0 +1,64 @@
+.. _sec-contributing-packaging-brew:
+
+macOS (``brew``)
+----------------
+
+Notes are provided on updating the package / brew-formula for **xNVMe**. At the
+bottom you will find notes on the initial creation of the formula. Do this:
+
+.. code-block:: bash
+
+    # Fork the **homebrew-core** repository
+
+    git clone https://github.com/Homebrew/homebrew-core/
+
+    # Add your fork to your local install
+    brew tap homebrew/core
+    cd $(brew --repository homebrew/core)
+    git remote add <your_fork> <uri_of_your_clone>
+    git fetch <your_fork>
+    git checkout -b xnvme_update master
+
+    # Edit the xNVMe formula
+    brew edit xnvme
+
+    # Test it
+    brew uninstall --force xnvme
+    HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source xnvme
+    # this was needed...
+    brew link --overwrite
+    brew test xnvme
+    brew audit --strict xnvme
+    brew style xnvme
+
+Commit and push the changes:
+
+.. code-block:: bash
+
+  # Commit changes
+  git add .
+  git commit -s -m "xnvme major.minor.patch"
+
+  # Push them
+  git push your_fork xnvme_update
+
+* Setup PR and address any issues
+
+Initial creation of the package
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A couple of useful commands:
+
+.. code-block:: bash
+
+  # On macOS use this to calculate the checksum of the src-archive
+  shasum -a 256
+
+  # Test the formula
+  HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source xnvme.rb
+  brew test xnvme.rb
+  brew audit --strict xnvme
+
+  # Only needed on creation?
+  brew audit --new xnvme
+  brew audit --new-formula xnvme

--- a/docs/contributing/packaging/index.rst
+++ b/docs/contributing/packaging/index.rst
@@ -1,0 +1,52 @@
+.. _sec-contributing-packaging:
+
+Packaging
+=========
+
+A couple of notes/pointers on the packaging of **xNVMe** for Linux
+distributions, FreeBSD, Windows, Python, and Rust. For the most recent changes,
+see the `GitHUB Issue Tracker`_.
+
+* Alpine Linux (``apk``)
+
+  - See: https://pkgs.alpinelinux.org/packages?name=xnvme
+
+* :ref:`sec-contributing-packaging-aur`
+
+  - See: https://aur.archlinux.org/packages/xnvme
+
+* :ref:`sec-contributing-packaging-brew`
+
+  - See: https://formulae.brew.sh/formula/xnvme
+
+* Debian Linux (``.deb`` / ``apt``)
+
+  - See: https://mentors.debian.net/package/xnvme/
+
+  - See: https://github.com/safl/xnvme-debpkg
+
+  - This is a work-in-progress
+
+* Fedora / OpenSUSE, CentOS / Rocky / RHEL (``rpm``)
+
+  - See: https://copr.fedorainfracloud.org/coprs/karlowich/xNVMe/
+
+* FreeBSD (``ports``)
+
+  - See: https://ports.freebsd.org/cgi/ports.cgi?query=xnvme 
+
+* Windows (``choco``)
+
+  - Currently under exploration
+  
+.. toctree::
+   :hidden:
+
+   aur/index.rst
+   brew/index.rst
+   debian/index.rst
+   windows/index.rst
+
+
+.. _salsa: https://github.com/Homebrew/homebrew-core
+.. _GitHUB Issue Tracker: https://github.com/OpenMPDK/xNVMe/issues/389

--- a/docs/contributing/packaging/windows/index.rst
+++ b/docs/contributing/packaging/windows/index.rst
@@ -1,0 +1,6 @@
+.. _sec-contributing-packaging-windows:
+
+Windows (``choco``)
+-------------------
+
+...

--- a/toolbox/pkgs/emitter/templates/pkgman-brew.sh.jinja
+++ b/toolbox/pkgs/emitter/templates/pkgman-brew.sh.jinja
@@ -1,5 +1,6 @@
 # This is done to avoid appleframework deprecation warnings
 export MACOSX_DEPLOYMENT_TARGET=11.0
+export HOMEBREW_NO_AUTO_UPDATE=1
 
 # Install packages via brew, assuming that brew is: installed, updated, and upgraded
 {%- for dep in deps %}
@@ -8,6 +9,6 @@ if make --version | grep i386-apple; then
   brew install make
 fi
 {% else %}
-{{ dep }} --version && echo "Installed" || brew install {{ dep }} 
+{{ dep }} --version && echo "Installed" || brew install {{ dep }} --overwrite || echo "Failed installing"
 {%- endif %}
 {%- endfor %}

--- a/toolbox/pkgs/macos-11.sh
+++ b/toolbox/pkgs/macos-11.sh
@@ -7,17 +7,18 @@ ldd --version || true
 
 # This is done to avoid appleframework deprecation warnings
 export MACOSX_DEPLOYMENT_TARGET=11.0
+export HOMEBREW_NO_AUTO_UPDATE=1
 
 # Install packages via brew, assuming that brew is: installed, updated, and upgraded
-clang-format --version && echo "Installed" || brew install clang-format
-git --version && echo "Installed" || brew install git
+clang-format --version && echo "Installed" || brew install clang-format --overwrite || echo "Failed installing"
+git --version && echo "Installed" || brew install git --overwrite || echo "Failed installing"
 if make --version | grep i386-apple; then
   brew install make
 fi
 
-meson --version && echo "Installed" || brew install meson
-pkg-config --version && echo "Installed" || brew install pkg-config
-python3 --version && echo "Installed" || brew install python3
+meson --version && echo "Installed" || brew install meson --overwrite || echo "Failed installing"
+pkg-config --version && echo "Installed" || brew install pkg-config --overwrite || echo "Failed installing"
+python3 --version && echo "Installed" || brew install python3 --overwrite || echo "Failed installing"
 
 # Install packages via the Python package-manager (pip)
 python3 -m pip install --upgrade pip

--- a/toolbox/pkgs/macos-12.sh
+++ b/toolbox/pkgs/macos-12.sh
@@ -7,17 +7,18 @@ ldd --version || true
 
 # This is done to avoid appleframework deprecation warnings
 export MACOSX_DEPLOYMENT_TARGET=11.0
+export HOMEBREW_NO_AUTO_UPDATE=1
 
 # Install packages via brew, assuming that brew is: installed, updated, and upgraded
-clang-format --version && echo "Installed" || brew install clang-format
-git --version && echo "Installed" || brew install git
+clang-format --version && echo "Installed" || brew install clang-format --overwrite || echo "Failed installing"
+git --version && echo "Installed" || brew install git --overwrite || echo "Failed installing"
 if make --version | grep i386-apple; then
   brew install make
 fi
 
-meson --version && echo "Installed" || brew install meson
-pkg-config --version && echo "Installed" || brew install pkg-config
-python3 --version && echo "Installed" || brew install python3
+meson --version && echo "Installed" || brew install meson --overwrite || echo "Failed installing"
+pkg-config --version && echo "Installed" || brew install pkg-config --overwrite || echo "Failed installing"
+python3 --version && echo "Installed" || brew install python3 --overwrite || echo "Failed installing"
 
 # Install packages via the Python package-manager (pip)
 python3 -m pip install --upgrade pip

--- a/toolbox/pkgs/macos-13.sh
+++ b/toolbox/pkgs/macos-13.sh
@@ -7,17 +7,18 @@ ldd --version || true
 
 # This is done to avoid appleframework deprecation warnings
 export MACOSX_DEPLOYMENT_TARGET=11.0
+export HOMEBREW_NO_AUTO_UPDATE=1
 
 # Install packages via brew, assuming that brew is: installed, updated, and upgraded
-clang-format --version && echo "Installed" || brew install clang-format
-git --version && echo "Installed" || brew install git
+clang-format --version && echo "Installed" || brew install clang-format --overwrite || echo "Failed installing"
+git --version && echo "Installed" || brew install git --overwrite || echo "Failed installing"
 if make --version | grep i386-apple; then
   brew install make
 fi
 
-meson --version && echo "Installed" || brew install meson
-pkg-config --version && echo "Installed" || brew install pkg-config
-python3 --version && echo "Installed" || brew install python3
+meson --version && echo "Installed" || brew install meson --overwrite || echo "Failed installing"
+pkg-config --version && echo "Installed" || brew install pkg-config --overwrite || echo "Failed installing"
+python3 --version && echo "Installed" || brew install python3 --overwrite || echo "Failed installing"
 
 # Install packages via the Python package-manager (pip)
 python3 -m pip install --upgrade pip


### PR DESCRIPTION
This is a quick stab at getting the packaging on the road, so to speak.
See https://github.com/OpenMPDK/xNVMe/issues/389 for a status on the packaging effort.

The files introduced here is a collection of the xNVMe packaging-effort, documenting the maintenance tasks, and the status of availability. The primary preparation work on this PR is the Debian packaging, in addition to the continous work on it, then the following tasks are intended:

- [x] Add package-verification via CI
  - Where applicable, e.g. running the package-creation process with verification-tools such as ``lintian``, that is, such that as much as possible is caught before packages are created for a release
- [x] This needs to be addressed: https://github.com/OpenMPDK/xNVMe/issues/401
  - An approach of encoding the version like: ``libnvme.so, libxnvme.so.0, libxnvme.so.0.7.3`` is now being pursued, which I assume comply with Debian and Redhat policy

All changes needed for packaging is done "upstream", that is, no patches inside e.g. the ``debian`` folder. This is done since the changes to comply with e.g. Debian policy so far only benefit the project/code-based and I am not expecting it to introduce in-compatible changes. If so, then we can explicitly address those.

Most of this has now gone in as preparation on ``next``, the remainder is the Debian packaging for which I await account-creation on https://salsa.debian.org/ as I have now learning that the proper process is to **not** keep the ``debian`` folder within the repository. When this is removed, then what remains:

- [x] Move the Debian packaging to [Salsa](https://salsa.debian.org/)
  - Currently moved here https://github.com/safl/xnvme-debpkg thus when the account on Salsa becomes available then things from the xNVMe repos side and CI is ready and just needs to change where it is retrieving the packaging from
- [x] CI scripts, testing the packaging scripts for Debian (clone salsa repos, pass it src-archive, build and lint)
- [x] Documentation, the ``README.rst``will be converted into a **packaging** section of the contributors documentation