### PR TITLE
fix(rust): add loop-breakout when header is found

### DIFF
--- a/rust/xnvme-sys/build.rs
+++ b/rust/xnvme-sys/build.rs
@@ -13,6 +13,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         header_path.clear();
         header_path.clone_from(include_path);
         header_path.push("libxnvme.h");
+
+        if header_path.exists() {
+            break;
+        }
     }
 
     if !header_path.exists() {


### PR DESCRIPTION
The search in include-headers did not break when the header was found, thus, it would only setup header_path correctly when it was located in the last iterated include_path.