### PR TITLE
fix(nvm): change sdlba to slba for write_zeroes

### DIFF
--- a/include/libxnvme_nvm.h
+++ b/include/libxnvme_nvm.h
@@ -66,14 +66,14 @@ xnvme_nvm_write_uncorrectable(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t
  *
  * @param ctx Pointer to command context (::xnvme_cmd_ctx)
  * @param nsid Namespace Identifier
- * @param sdlba The Starting Destination LBA to start copying to
+ * @param slba The LBA to start the write at
  * @param nlb Number Of Logical Blocks
  *
  * @return On success, 0 is returned. On error, -1 is returned, `errno` set to
  * indicate and param ctx.cpl filled with lower-level status codes
  */
 int
-xnvme_nvm_write_zeroes(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t sdlba, uint16_t nlb);
+xnvme_nvm_write_zeroes(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t slba, uint16_t nlb);
 
 /**
  * Submit, and optionally wait for completion of, a NVMe Write

--- a/lib/xnvme_nvm.c
+++ b/lib/xnvme_nvm.c
@@ -91,11 +91,11 @@ xnvme_nvm_write_uncorrectable(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t
 }
 
 int
-xnvme_nvm_write_zeroes(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t sdlba, uint16_t nlb)
+xnvme_nvm_write_zeroes(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t slba, uint16_t nlb)
 {
 	ctx->cmd.common.opcode = XNVME_SPEC_NVM_OPC_WRITE_ZEROES;
 	ctx->cmd.common.nsid = nsid;
-	ctx->cmd.write_zeroes.slba = sdlba;
+	ctx->cmd.write_zeroes.slba = slba;
 	ctx->cmd.write_zeroes.nlb = nlb;
 
 	return xnvme_cmd_pass(ctx, NULL, 0, NULL, 0);


### PR DESCRIPTION
According to the spec there is no such thing as sdlba for write zeroes, this is only used for copy