### PR TITLE
feat(cijoe/tests): test ioworker on fabrics

### DIFF
--- a/cijoe/workflows/test-debian-bullseye.yaml
+++ b/cijoe/workflows/test-debian-bullseye.yaml
@@ -33,4 +33,4 @@ steps:
 - name: test_fabrics
   uses: core.testrunner
   with:
-    args: '-k "fabrics and not ioworker" tests'
+    args: '-k "fabrics" tests'


### PR DESCRIPTION
Previously, this was disabled because the performance of nvme/tcp was very slow - this has now been fixed, thus enabling the tests.