### PR TITLE
feat(queue): add a default NOOP callback

### DIFF
--- a/lib/xnvme_queue.c
+++ b/lib/xnvme_queue.c
@@ -30,6 +30,12 @@ xnvme_queue_term(struct xnvme_queue *queue)
 	return err;
 }
 
+static void
+callback_noop(struct xnvme_cmd_ctx *XNVME_UNUSED(ctx), void *XNVME_UNUSED(cb_arg))
+{
+	return;
+}
+
 int
 xnvme_queue_init(struct xnvme_dev *dev, uint16_t capacity, int opts, struct xnvme_queue **queue)
 {
@@ -60,7 +66,7 @@ xnvme_queue_init(struct xnvme_dev *dev, uint16_t capacity, int opts, struct xnvm
 	for (uint32_t i = 0; i <= (*queue)->base.capacity; ++i) {
 		(*queue)->pool_storage[i].dev = dev;
 		(*queue)->pool_storage[i].async.queue = *queue;
-		(*queue)->pool_storage[i].async.cb = NULL;
+		(*queue)->pool_storage[i].async.cb = callback_noop;
 		(*queue)->pool_storage[i].async.cb_arg = NULL;
 		(*queue)->pool_storage[i].opts = XNVME_CMD_ASYNC;
 


### PR DESCRIPTION
The callback on the command-context initilization is set to NULL. When set to NULL, then it is the backend responsibility to check whether a valid function pointer is set upon "callback-time".

To avoid having to check this, then this change assigns a default NOOP callback.