### PR TITLE
fix(cijoe/configs): correct the linux.repository.remote

### DIFF
--- a/cijoe/configs/debian-bookworm-arm.toml
+++ b/cijoe/configs/debian-bookworm-arm.toml
@@ -234,6 +234,6 @@ path = "/opt/aux/spdk_bdev"
 type = "external_preload"
 
 [linux.repository]
-remote = "https://github.com/linux/linux.git"
+remote = "https://github.com/torvalds/linux.git"
 path = "{{ local.env.HOME }}/git/linux"
-tag = "v5.19"
+tag = "v6.7"

--- a/cijoe/configs/debian-bullseye.toml
+++ b/cijoe/configs/debian-bullseye.toml
@@ -231,6 +231,6 @@ path = "/opt/aux/spdk_bdev"
 type = "external_preload"
 
 [linux.repository]
-remote = "https://github.com/linux/linux.git"
+remote = "https://github.com/torvalds/linux.git"
 path = "{{ local.env.HOME }}/git/linux"
-tag = "v5.19"
+tag = "v6.7"


### PR DESCRIPTION
The remote was pointing to a non-existant repository. This fixes it by pointing it to https://github.com/torvalds/linux.git