### PR TITLE
feat(mk): add helper producing documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,15 @@ docker:
 	@docker run -it -w /tmp/xnvme --mount type=bind,source="$(shell pwd)",target=/tmp/xnvme ghcr.io/xnvme/xnvme-deps-debian-bookworm:next bash
 	@echo "## xNVME: docker [DONE]"
 
+define docs-help
+# Build docs (without command-execution) and open them
+endef
+.PHONY: docs
+docs:
+	@echo "## xNVMe: make docs"
+	cd docs/autogen && make
+	@echo "## xNVMe: make docs [DONE]"
+
 define docker-privileged-help
 # Drop into a privileged docker instance with the repository bind-mounted at /tmp/xnvme
 endef


### PR DESCRIPTION
For producing documentation, with output from command-examples included,
then different resources are needed such as a virtual machine with the
proper device configuration, and wall-clock time to execute all the
commands. A helper 'cijoe-do-docgen' takes care of this.

However, when reducing the scope to rendering the prose of the
documentation, then the build requirements is reduced to the setup of
a Python venv. and executing doxygen, breathe, a couple of scripts,
and sphinx-doc.

Such rendering is done by executing 'make' inside of 'docs/autogen', for
convenience, then this is lifted up into the Makefile in the root of the
repository. Such that 'make docs' will to a quick rendering, providing a
significantly simpler means to maintain and expand documentation.