### PR TITLE
fix(tests/copy): send correct amount of Source Range entries

### DIFF
--- a/cijoe/tests/logic/test_xnvme_tests_copy.py
+++ b/cijoe/tests/logic/test_xnvme_tests_copy.py
@@ -7,6 +7,10 @@ from ..conftest import xnvme_parametrize
 def test_copy(cijoe, device, be_opts, cli_args):
     if be_opts["be"] == "linux" and be_opts["sync"] in ["block", "psync"]:
         pytest.skip(reason=f"Not supported: simple-copy via { be_opts['sync'] }")
+    if be_opts["be"] == "linux" and be_opts["admin"] in ["block"]:
+        pytest.skip(
+            reason=f"Admin { be_opts['admin'] } doesn't report MSSRL on the namespace"
+        )
 
     err, _ = cijoe.run(f"xnvme_tests_copy copy {cli_args}")
     assert not err

--- a/cijoe/tests/logic/test_xnvme_tests_copy.py
+++ b/cijoe/tests/logic/test_xnvme_tests_copy.py
@@ -14,3 +14,29 @@ def test_copy(cijoe, device, be_opts, cli_args):
 
     err, _ = cijoe.run(f"xnvme_tests_copy copy {cli_args}")
     assert not err
+
+
+@xnvme_parametrize(labels=["scc"], opts=["be", "admin", "sync"])
+def test_copy_src_before_dest(cijoe, device, be_opts, cli_args):
+    if be_opts["be"] == "linux" and be_opts["sync"] in ["block", "psync"]:
+        pytest.skip(reason=f"Not supported: simple-copy via { be_opts['sync'] }")
+    if be_opts["be"] == "linux" and be_opts["admin"] in ["block"]:
+        pytest.skip(
+            reason=f"Admin { be_opts['admin'] } doesn't report MSSRL on the namespace"
+        )
+
+    err, _ = cijoe.run(f"xnvme_tests_copy copy {cli_args} --slba 0 --nlb 7 --sdlba 8")
+    assert not err
+
+
+@xnvme_parametrize(labels=["scc"], opts=["be", "admin", "sync"])
+def test_copy_src_after_dest(cijoe, device, be_opts, cli_args):
+    if be_opts["be"] == "linux" and be_opts["sync"] in ["block", "psync"]:
+        pytest.skip(reason=f"Not supported: simple-copy via { be_opts['sync'] }")
+    if be_opts["be"] == "linux" and be_opts["admin"] in ["block"]:
+        pytest.skip(
+            reason=f"Admin { be_opts['admin'] } doesn't report MSSRL on the namespace"
+        )
+
+    err, _ = cijoe.run(f"xnvme_tests_copy copy {cli_args} --slba 8 --nlb 7 --sdlba 0")
+    assert not err

--- a/include/libxnvme_cli.h
+++ b/include/libxnvme_cli.h
@@ -42,7 +42,6 @@ struct xnvme_cli_args {
 
 	const char *cmd_input;
 	const char *cmd_output;
-
 	size_t data_nbytes;
 	const char *data_input;
 	const char *data_output;
@@ -165,6 +164,8 @@ struct xnvme_cli_args {
 	uint8_t prchk;
 	uint32_t apptag;
 	uint32_t apptag_mask;
+
+	uint64_t sdlba;
 };
 
 void
@@ -331,8 +332,9 @@ enum xnvme_cli_opt {
 	XNVME_CLI_OPT_PRCHK       = 121, ///< XNVME_CLI_OPT_PRCHK
 	XNVME_CLI_OPT_APPTAG      = 122, ///< XNVME_CLI_OPT_APPTAG
 	XNVME_CLI_OPT_APPTAG_MASK = 123, ///< XNVME_CLI_OPT_APPTAG_MASK
-					 //
-	XNVME_CLI_OPT_END = 124,         ///< XNVME_CLI_OPT_END
+
+	XNVME_CLI_OPT_SDLBA = 124,
+	XNVME_CLI_OPT_END   = 125, ///< XNVME_CLI_OPT_END
 };
 
 /**

--- a/lib/xnvme_cli.c
+++ b/lib/xnvme_cli.c
@@ -854,7 +854,12 @@ static struct xnvme_cli_opt_attr xnvme_cli_opts[] = {
 		.name = "apptag_mask",
 		.descr = "Application Tag Mask",
 	},
-
+	{
+		.opt = XNVME_CLI_OPT_SDLBA,
+		.vtype = XNVME_CLI_OPT_VTYPE_HEX,
+		.name = "sdlba",
+		.descr = "Starting Destination Logical Block Address",
+	},
 	{
 		.opt = XNVME_CLI_OPT_END,
 		.vtype = XNVME_CLI_OPT_VTYPE_NUM,
@@ -1511,6 +1516,9 @@ xnvme_cli_assign_arg(struct xnvme_cli *cli, struct xnvme_cli_opt_attr *opt_attr,
 		break;
 	case XNVME_CLI_OPT_APPTAG_MASK:
 		args->apptag_mask = num;
+		break;
+	case XNVME_CLI_OPT_SDLBA:
+		args->sdlba = num;
 		break;
 	case XNVME_CLI_OPT_POSA_TITLE:
 	case XNVME_CLI_OPT_NON_POSA_TITLE:


### PR DESCRIPTION
Previously, we sent 128 Source Ranges even though we only filled out the
first. This PR fixes this.

Furthermore, the MSSRL is now used to limit the number of bytes per
Source Range.