### PR TITLE
fix(pkgs/gentoo): rename dev-util/meson to dev-build/meson

### DIFF
--- a/toolbox/pkgs/emitter/deps.yaml
+++ b/toolbox/pkgs/emitter/deps.yaml
@@ -49,7 +49,7 @@ deps:
     when: [building]
     names:
       default: [meson] # apt, apk, pacman, dnf, zypper
-      emerge: [dev-util/meson]
+      emerge: [dev-build/meson]
       pip: [meson, ninja]
       pipx: [meson, ninja]
 

--- a/toolbox/pkgs/gentoo-latest.sh
+++ b/toolbox/pkgs/gentoo-latest.sh
@@ -13,6 +13,7 @@ emerge-webrsync
 emerge \
  app-arch/libarchive \
  bash \
+ dev-build/meson \
  dev-lang/nasm \
  dev-libs/isa-l \
  dev-libs/libaio \
@@ -20,7 +21,6 @@ emerge \
  dev-python/pip \
  dev-python/pyelftools \
  dev-util/cunit \
- dev-util/meson \
  dev-util/pkgconf \
  dev-vcs/git \
  findutils \


### PR DESCRIPTION
Seems the emerge package has been renamed.
The new one is here:
https://packages.gentoo.org/packages/dev-build/meson
