### PR TITLE
Refactor identification

### DIFF
--- a/include/libxnvme_spec.h
+++ b/include/libxnvme_spec.h
@@ -774,39 +774,6 @@ struct xnvme_spec_elbaf {
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_elbaf) == 4, "Incorrect size")
 
-/**
- * Representation of NVMe completion result for NVM command set I/O command set
- * specific Identify Namespace
- *
- * That is, for opcode XNVME_SPEC_OPC_IDFY(0x06) with XNVME_SPEC_IDFY_NS_IOCS(0x05)
- *
- * @struct xnvme_spec_nvm_idfy_ns_iocs
- */
-struct xnvme_spec_nvm_idfy_ns_iocs {
-	uint64_t lbstm; ///< Logical block storage tag mask
-
-	/** Protection information capabilities */
-	union {
-		struct {
-			/** 16b guard protection information storage tag mask */
-			uint8_t gpistm    : 1;
-
-			/** 16b guard protection information storage tag support */
-			uint8_t gpists    : 1;
-
-			uint8_t reserved1 : 6;
-		};
-		uint8_t val;
-	} pic;
-
-	uint8_t reserved9[3];
-
-	struct xnvme_spec_elbaf elbaf[64];
-
-	uint8_t reserved268[3828];
-};
-XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_nvm_idfy_ns_iocs) == 4096, "Incorrect size")
-
 #define XNVME_SPEC_CTRLR_SN_LEN 20
 #define XNVME_SPEC_CTRLR_MN_LEN 40
 #define XNVME_SPEC_CTRLR_FR_LEN 8
@@ -2325,16 +2292,38 @@ struct xnvme_spec_nvm_idfy_ctrlr {
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_nvm_idfy_ctrlr) == 4096, "Incorrect size")
 
 /**
- * @todo Document this
+ * Representation of NVMe completion result for NVM command set I/O command set
+ * specific Identify Namespace
+ *
+ * That is, for opcode XNVME_SPEC_OPC_IDFY(0x06) with XNVME_SPEC_IDFY_NS_IOCS(0x05)
+ *
+ * @struct xnvme_spec_nvm_idfy_ns
  */
 struct xnvme_spec_nvm_idfy_ns {
-	uint8_t byte0_73[74];
+	uint64_t lbstm; ///< Logical block storage tag mask
 
-	uint16_t mssrl; ///< Maximum Single Source Range Length
-	uint32_t mcl;   ///< Maximum Copy Length
-	uint8_t msrc;   ///< Maximum Source Range Count
+	/** Protection information capabilities */
+	union {
+		struct {
+			/** 16b guard protection information storage tag support */
+			uint8_t gpists    : 1;
 
-	uint8_t byte81_4095[4014];
+			/** 16b guard protection information storage tag mask */
+			uint8_t gpistm    : 1;
+
+			/** storage tag check read support */
+			uint8_t stcrs     : 1;
+
+			uint8_t reserved3 : 5;
+		};
+		uint8_t val;
+	} pic;
+
+	uint8_t reserved9[3];
+
+	struct xnvme_spec_elbaf elbaf[64];
+
+	uint8_t reserved268[3828];
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_nvm_idfy_ns) == 4096, "Incorrect size")
 

--- a/include/libxnvme_spec.h
+++ b/include/libxnvme_spec.h
@@ -2304,37 +2304,23 @@ struct xnvme_spec_nvm_cmd {
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_nvm_cmd) == 64, "Incorrect size")
 
+/**
+ * Representation of NVMe completion result for NVM command set I/O command set
+ * specific Identify Controller
+ *
+ * That is, for opcode XNVME_SPEC_OPC_IDFY(0x06) with XNVME_SPEC_IDFY_CTLR_IOCS(0x6)
+ *
+ * @struct xnvme_spec_nvm_idfy_ctrlr
+ */
 struct xnvme_spec_nvm_idfy_ctrlr {
-	uint8_t byte0_519[520];
+	uint8_t vsl;    ///< Verify Size Limit
+	uint8_t wzsl;   ///< Write Zeroes Size Limit
+	uint8_t wusl;   ///< Write Uncorrectable Size Limit
+	uint8_t dmrl;   ///< Dataset Management Ranges Limit
+	uint32_t dmrsl; ///< Dataset Management Range Size Limit
+	uint64_t dmsl;  ///< Dataset Management Size Limit
 
-	/** optional nvm command support */
-	union {
-		struct {
-			uint16_t compare           : 1;
-			uint16_t write_unc         : 1;
-			uint16_t dsm               : 1;
-			uint16_t write_zeroes      : 1;
-			uint16_t set_features_save : 1;
-			uint16_t reservations      : 1;
-			uint16_t timestamp         : 1;
-			uint16_t verify            : 1;
-			uint16_t copy              : 1;
-			uint16_t reserved          : 7;
-		};
-		uint16_t val;
-	} oncs;
-
-	uint8_t byte522_533[12];
-
-	union {
-		struct {
-			uint16_t copy_fmt0 : 1;
-			uint16_t rsvd      : 15;
-		};
-		uint16_t val;
-	} ocfs; ///< Optional Copy Format Supported
-
-	uint8_t byte536_4095[3559];
+	uint8_t reserved16[4080];
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_spec_nvm_idfy_ctrlr) == 4096, "Incorrect size")
 
@@ -3115,7 +3101,7 @@ xnvme_spec_idfy_ns_pr(const struct xnvme_spec_idfy_ns *idfy, int opts);
  * @return On success, the number of characters printed is returned.
  */
 int
-xnvme_spec_idfy_ctrl_fpr(FILE *stream, const struct xnvme_spec_idfy_ctrlr *idfy, int opts);
+xnvme_spec_idfy_ctrlr_fpr(FILE *stream, const struct xnvme_spec_idfy_ctrlr *idfy, int opts);
 
 /**
  * Prints the given :;xnvme_spec_idfy_ctrlr to stdout
@@ -3125,7 +3111,7 @@ xnvme_spec_idfy_ctrl_fpr(FILE *stream, const struct xnvme_spec_idfy_ctrlr *idfy,
  * @return On success, the number of characters printed is returned.
  */
 int
-xnvme_spec_idfy_ctrl_pr(const struct xnvme_spec_idfy_ctrlr *idfy, int opts);
+xnvme_spec_idfy_ctrlr_pr(const struct xnvme_spec_idfy_ctrlr *idfy, int opts);
 
 int
 xnvme_spec_idfy_cs_fpr(FILE *stream, const struct xnvme_spec_idfy_cs *idfy, int opts);
@@ -3275,8 +3261,6 @@ xnvme_spec_nvm_scopy_source_range_pr(const struct xnvme_spec_nvm_scopy_source_ra
 /**
  * Prints the given ::xnvme_spec_nvm_idfy_ctrlr to the given output stream
  *
- * Only fields specific to Logical Block Namespaces are printed by this function
- *
  * @param stream output stream used for printing
  * @param idfy pointer to the structure to print
  * @param opts printer options, see ::xnvme_pr
@@ -3284,7 +3268,7 @@ xnvme_spec_nvm_scopy_source_range_pr(const struct xnvme_spec_nvm_scopy_source_ra
  * @return On success, the number of characters printed is returned
  */
 int
-xnvme_spec_idfy_ctrlr_fpr(FILE *stream, struct xnvme_spec_nvm_idfy_ctrlr *idfy, int opts);
+xnvme_spec_nvm_idfy_ctrlr_fpr(FILE *stream, struct xnvme_spec_nvm_idfy_ctrlr *idfy, int opts);
 
 /**
  * Prints the given ::xnvme_spec_nvm_idfy_ctrlr to stdout

--- a/lib/xnvme_be_ramdisk_admin.c
+++ b/lib/xnvme_be_ramdisk_admin.c
@@ -57,12 +57,11 @@ static int
 _idfy_ctrlr(struct xnvme_dev *XNVME_UNUSED(dev), void *dbuf)
 {
 	struct xnvme_spec_idfy_ctrlr *ctrlr = dbuf;
-	struct xnvme_spec_nvm_idfy_ctrlr *nvm_ctrlr = dbuf;
 	ctrlr->mdts = 0;
 	ctrlr->oncs.copy = 1;
 	ctrlr->oncs.write_zeroes = 1;
 
-	nvm_ctrlr->ocfs.copy_fmt0 = 1;
+	ctrlr->cdfs.format0 = 1;
 	return 0;
 }
 

--- a/lib/xnvme_dev.c
+++ b/lib/xnvme_dev.c
@@ -49,7 +49,7 @@ _conventional_geometry(struct xnvme_dev *dev)
 	const struct xnvme_spec_idfy_ctrlr *ctrlr = (void *)xnvme_dev_get_ctrlr(dev);
 	const struct xnvme_spec_idfy_ns *nvm = (void *)xnvme_dev_get_ns(dev);
 	const struct xnvme_spec_lbaf *lbaf = &nvm->lbaf[nvm->flbas.format];
-	struct xnvme_spec_nvm_idfy_ns_iocs *nns = (void *)xnvme_dev_get_ns_css(dev);
+	struct xnvme_spec_nvm_idfy_ns *nns = (void *)xnvme_dev_get_ns_css(dev);
 	struct xnvme_spec_elbaf *elbaf = &nns->elbaf[nvm->flbas.format];
 	struct xnvme_geo *geo = &dev->geo;
 

--- a/lib/xnvme_spec.c
+++ b/lib/xnvme_spec.c
@@ -424,7 +424,7 @@ xnvme_spec_ruhs_pr(const struct xnvme_spec_ruhs *ruhs, int limit, int opts)
 }
 
 int
-xnvme_spec_idfy_ctrl_fpr(FILE *stream, const struct xnvme_spec_idfy_ctrlr *idfy, int opts)
+xnvme_spec_idfy_ctrlr_fpr(FILE *stream, const struct xnvme_spec_idfy_ctrlr *idfy, int opts)
 {
 	int wrtn = 0;
 
@@ -537,7 +537,17 @@ xnvme_spec_idfy_ctrl_fpr(FILE *stream, const struct xnvme_spec_idfy_ctrlr *idfy,
 	wrtn += fprintf(stream, "  cqes: %#" PRIx8 "\n", idfy->cqes.val);
 	wrtn += fprintf(stream, "  maxcmd: %" PRIu16 "\n", idfy->maxcmd);
 	wrtn += fprintf(stream, "  nn: %" PRIu32 "\n", idfy->nn);
-	wrtn += fprintf(stream, "  oncs: %#" PRIx16 "\n", idfy->oncs.val);
+	wrtn += fprintf(stream, "  oncs:\n");
+	wrtn += fprintf(stream, "    compare: %" PRIu16 "\n", idfy->oncs.compare);
+	wrtn += fprintf(stream, "    write_unc: %" PRIu16 "\n", idfy->oncs.write_unc);
+	wrtn += fprintf(stream, "    dsm: %" PRIu16 "\n", idfy->oncs.dsm);
+	wrtn += fprintf(stream, "    write_zeroes: %" PRIu16 "\n", idfy->oncs.write_zeroes);
+	wrtn += fprintf(stream, "    set_features_save: %" PRIu16 "\n",
+			idfy->oncs.set_features_save);
+	wrtn += fprintf(stream, "    reservations: %" PRIu16 "\n", idfy->oncs.reservations);
+	wrtn += fprintf(stream, "    timestamp: %" PRIu16 "\n", idfy->oncs.timestamp);
+	wrtn += fprintf(stream, "    verify: %" PRIu16 "\n", idfy->oncs.verify);
+	wrtn += fprintf(stream, "    copy: %" PRIu16 "\n", idfy->oncs.copy);
 	wrtn += fprintf(stream, "  fuses: %#" PRIx16 "\n", idfy->fuses);
 	wrtn += fprintf(stream, "  fna: %#" PRIx8 "\n", idfy->fna.val);
 	wrtn += fprintf(stream, "  vwc: %#" PRIx8 "\n", idfy->vwc.val);
@@ -546,6 +556,9 @@ xnvme_spec_idfy_ctrl_fpr(FILE *stream, const struct xnvme_spec_idfy_ctrlr *idfy,
 	wrtn += fprintf(stream, "  nvscc: %" PRIu8 "\n", idfy->nvscc);
 	wrtn += fprintf(stream, "  acwu: %d" PRIu16 "\n", idfy->acwu);
 	wrtn += fprintf(stream, "  cdfs: %#" PRIx16 "\n", idfy->cdfs.val);
+	wrtn += fprintf(stream, "  cdfs:\n");
+	wrtn += fprintf(stream, "    format0: %" PRIu16 "\n", idfy->cdfs.format0);
+	wrtn += fprintf(stream, "    format1: %" PRIu16 "\n", idfy->cdfs.format1);
 	wrtn += fprintf(stream, "  sgls: %#" PRIx32 "\n", idfy->sgls.val);
 	wrtn += fprintf(stream, "  mnan: %" PRIu32 "\n", idfy->mnan);
 	// TODO: present these better
@@ -559,9 +572,9 @@ xnvme_spec_idfy_ctrl_fpr(FILE *stream, const struct xnvme_spec_idfy_ctrlr *idfy,
 }
 
 int
-xnvme_spec_idfy_ctrl_pr(const struct xnvme_spec_idfy_ctrlr *idfy, int opts)
+xnvme_spec_idfy_ctrlr_pr(const struct xnvme_spec_idfy_ctrlr *idfy, int opts)
 {
-	return xnvme_spec_idfy_ctrl_fpr(stdout, idfy, opts);
+	return xnvme_spec_idfy_ctrlr_fpr(stdout, idfy, opts);
 }
 
 int
@@ -996,7 +1009,7 @@ xnvme_spec_nvm_scopy_source_range_pr(const struct xnvme_spec_nvm_scopy_source_ra
 
 // TODO: add yaml file and call it
 int
-xnvme_spec_idfy_ctrlr_fpr(FILE *stream, struct xnvme_spec_nvm_idfy_ctrlr *idfy, int opts)
+xnvme_spec_nvm_idfy_ctrlr_fpr(FILE *stream, struct xnvme_spec_nvm_idfy_ctrlr *idfy, int opts)
 {
 	int wrtn = 0;
 
@@ -1017,20 +1030,12 @@ xnvme_spec_idfy_ctrlr_fpr(FILE *stream, struct xnvme_spec_nvm_idfy_ctrlr *idfy, 
 	}
 
 	wrtn += fprintf(stream, "\n");
-	wrtn += fprintf(stream, "  oncs:\n");
-	wrtn += fprintf(stream, "    compare: %" PRIu16 "\n", idfy->oncs.compare);
-	wrtn += fprintf(stream, "    write_unc: %" PRIu16 "\n", idfy->oncs.write_unc);
-	wrtn += fprintf(stream, "    dsm: %" PRIu16 "\n", idfy->oncs.dsm);
-	wrtn += fprintf(stream, "    write_zeroes: %" PRIu16 "\n", idfy->oncs.write_zeroes);
-	wrtn += fprintf(stream, "    set_features_save: %" PRIu16 "\n",
-			idfy->oncs.set_features_save);
-	wrtn += fprintf(stream, "    reservations: %" PRIu16 "\n", idfy->oncs.reservations);
-	wrtn += fprintf(stream, "    timestamp: %" PRIu16 "\n", idfy->oncs.timestamp);
-	wrtn += fprintf(stream, "    verify: %" PRIu16 "\n", idfy->oncs.verify);
-	wrtn += fprintf(stream, "    copy: %" PRIu16 "\n", idfy->oncs.copy);
-
-	wrtn += fprintf(stream, "  ocfs:\n");
-	wrtn += fprintf(stream, "    copy_fmt0: %" PRIu16 "\n", idfy->ocfs.copy_fmt0);
+	wrtn += fprintf(stream, "  vsl: %" PRIu8 "\n", idfy->vsl);
+	wrtn += fprintf(stream, "  wzsl: %" PRIu8 "\n", idfy->wzsl);
+	wrtn += fprintf(stream, "  wusl: %" PRIu8 "\n", idfy->wusl);
+	wrtn += fprintf(stream, "  dmrl: %" PRIu8 "\n", idfy->dmrl);
+	wrtn += fprintf(stream, "  dmrsl: %" PRIu32 "\n", idfy->dmrsl);
+	wrtn += fprintf(stream, "  dmsl: %" PRIu64 "\n", idfy->dmsl);
 
 	return wrtn;
 }
@@ -1038,7 +1043,7 @@ xnvme_spec_idfy_ctrlr_fpr(FILE *stream, struct xnvme_spec_nvm_idfy_ctrlr *idfy, 
 int
 xnvme_spec_nvm_idfy_ctrlr_pr(struct xnvme_spec_nvm_idfy_ctrlr *idfy, int opts)
 {
-	return xnvme_spec_idfy_ctrlr_fpr(stdout, idfy, opts);
+	return xnvme_spec_nvm_idfy_ctrlr_fpr(stdout, idfy, opts);
 }
 
 int

--- a/lib/xnvme_spec.c
+++ b/lib/xnvme_spec.c
@@ -1068,10 +1068,17 @@ xnvme_spec_nvm_idfy_ns_fpr(FILE *stream, struct xnvme_spec_nvm_idfy_ns *idfy, in
 	}
 
 	wrtn += fprintf(stream, "\n");
-	wrtn += fprintf(stream, "  mcl: %" PRIu32 "\n", idfy->mcl);
-	wrtn += fprintf(stream, "  mssrl: %" PRIu16 "\n", idfy->mssrl);
-	wrtn += fprintf(stream, "  msrc: %" PRIu8 "\n", idfy->msrc);
+	wrtn += fprintf(stream, "  lbstm: %" PRIu64 "\n", idfy->lbstm);
+	wrtn += fprintf(stream, "  oncs:\n");
+	wrtn += fprintf(stream, "    gpistm: %" PRIu8 "\n", idfy->pic.gpistm);
+	wrtn += fprintf(stream, "    gpists: %" PRIu8 "\n", idfy->pic.gpists);
+	wrtn += fprintf(stream, "    stcrs: %" PRIu8 "\n", idfy->pic.stcrs);
 
+	wrtn += fprintf(stream, "  elbaf:\n");
+	for (int i = 0; i < 64; ++i) {
+		wrtn += fprintf(stream, "    - {sts: %" PRIu32 ", pif: %" PRIu32 "}\n",
+				idfy->elbaf[i].sts, idfy->elbaf[i].pif);
+	}
 	return wrtn;
 }
 

--- a/python/tests/test_lblk.py
+++ b/python/tests/test_lblk.py
@@ -204,12 +204,12 @@ class TestLBLK:
             rng_elba,
         ) = boilerplate
 
-        # Force void* casting to xnvme_spec_nvm_idfy_ns*
-        # xnvme_spec_nvm_idfy_ns *nvm = (void *)xnvme_dev_get_ns(dev)
+        # Force void* casting to xnvme_spec_idfy_ns*
+        # xnvme_spec_idfy_ns *nvm = (void *)xnvme_dev_get_ns(dev)
         _nvm = xnvme.xnvme_dev_get_ns(dev)
         _void_p = xnvme.xnvme_void_p(_nvm.void_pointer)
-        nvm = xnvme.xnvme_spec_nvm_idfy_ns(__void_p=_void_p)
-        xnvme.xnvme_spec_nvm_idfy_ns_pr(nvm, xnvme.XNVME_PR_DEF)
+        nvm = xnvme.xnvme_spec_idfy_ns(__void_p=_void_p)
+        xnvme.xnvme_spec_idfy_ns_pr(nvm, xnvme.XNVME_PR_DEF)
 
         if nvm.msrc:
             xfer_naddr = min(min(nvm.msrc + 1, xfer_naddr), nvm.mcl)
@@ -230,8 +230,8 @@ class TestLBLK:
             ),
             xnvme.XNVME_PR_DEF,
         )
-        xnvme.xnvme_spec_nvm_idfy_ns_pr(
-            xnvme.xnvme_spec_nvm_idfy_ns(
+        xnvme.xnvme_spec_idfy_ns_pr(
+            xnvme.xnvme_spec_idfy_ns(
                 __void_p=xnvme.xnvme_void_p(xnvme.xnvme_dev_get_ns(dev).void_pointer)
             ),
             xnvme.XNVME_PR_DEF,

--- a/python/tests/test_lblk.py
+++ b/python/tests/test_lblk.py
@@ -224,8 +224,8 @@ class TestLBLK:
         # NVMe-struct copy format
         copy_fmt = xnvme.XNVME_NVM_SCOPY_FMT_ZERO
 
-        xnvme.xnvme_spec_nvm_idfy_ctrlr_pr(
-            xnvme.xnvme_spec_nvm_idfy_ctrlr(
+        xnvme.xnvme_spec_idfy_ctrlr_pr(
+            xnvme.xnvme_spec_idfy_ctrlr(
                 __void_p=xnvme.xnvme_void_p(xnvme.xnvme_dev_get_ctrlr(dev).void_pointer)
             ),
             xnvme.XNVME_PR_DEF,

--- a/tests/scc.c
+++ b/tests/scc.c
@@ -21,7 +21,7 @@ static int
 sub_support(struct xnvme_cli *cli)
 {
 	struct xnvme_dev *dev = cli->args.dev;
-	struct xnvme_spec_nvm_idfy_ctrlr *ctrlr;
+	struct xnvme_spec_idfy_ctrlr *ctrlr;
 	struct xnvme_spec_nvm_idfy_ns *ns;
 	int err = 0;
 
@@ -37,14 +37,14 @@ sub_support(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_dev_get_ns()", -err);
 		return err;
 	}
-	xnvme_spec_nvm_idfy_ctrlr_pr(ctrlr, XNVME_PR_DEF);
+	xnvme_spec_idfy_ctrlr_pr(ctrlr, XNVME_PR_DEF);
 	xnvme_spec_nvm_idfy_ns_pr(ns, XNVME_PR_DEF);
 
 	if (!ctrlr->oncs.copy) {
 		err = -ENOSYS;
 		xnvme_cli_perr("!ctrlr->oncs.copy", -err);
 	}
-	if (!ctrlr->ocfs.copy_fmt0) {
+	if (!ctrlr->cdfs.format0) {
 		err = -ENOSYS;
 		xnvme_cli_perr("!ctrlr->ocfs.copy_fmt0", -err);
 	}
@@ -67,7 +67,7 @@ static int
 sub_idfy(struct xnvme_cli *cli)
 {
 	struct xnvme_dev *dev = cli->args.dev;
-	struct xnvme_spec_nvm_idfy_ctrlr *ctrlr;
+	struct xnvme_spec_idfy_ctrlr *ctrlr;
 	struct xnvme_spec_nvm_idfy_ns *ns;
 	int err;
 
@@ -84,7 +84,7 @@ sub_idfy(struct xnvme_cli *cli)
 		return err;
 	}
 
-	xnvme_spec_nvm_idfy_ctrlr_pr(ctrlr, XNVME_PR_DEF);
+	xnvme_spec_idfy_ctrlr_pr(ctrlr, XNVME_PR_DEF);
 	xnvme_spec_nvm_idfy_ns_pr(ns, XNVME_PR_DEF);
 
 	xnvme_cli_pinf("LGTM");

--- a/tests/scc.c
+++ b/tests/scc.c
@@ -22,7 +22,7 @@ sub_support(struct xnvme_cli *cli)
 {
 	struct xnvme_dev *dev = cli->args.dev;
 	struct xnvme_spec_idfy_ctrlr *ctrlr;
-	struct xnvme_spec_nvm_idfy_ns *ns;
+	struct xnvme_spec_idfy_ns *ns;
 	int err = 0;
 
 	ctrlr = (void *)xnvme_dev_get_ctrlr(dev);
@@ -38,7 +38,7 @@ sub_support(struct xnvme_cli *cli)
 		return err;
 	}
 	xnvme_spec_idfy_ctrlr_pr(ctrlr, XNVME_PR_DEF);
-	xnvme_spec_nvm_idfy_ns_pr(ns, XNVME_PR_DEF);
+	xnvme_spec_idfy_ns_pr(ns, XNVME_PR_DEF);
 
 	if (!ctrlr->oncs.copy) {
 		err = -ENOSYS;
@@ -68,7 +68,7 @@ sub_idfy(struct xnvme_cli *cli)
 {
 	struct xnvme_dev *dev = cli->args.dev;
 	struct xnvme_spec_idfy_ctrlr *ctrlr;
-	struct xnvme_spec_nvm_idfy_ns *ns;
+	struct xnvme_spec_idfy_ns *ns;
 	int err;
 
 	ctrlr = (void *)xnvme_dev_get_ctrlr(dev);
@@ -85,7 +85,7 @@ sub_idfy(struct xnvme_cli *cli)
 	}
 
 	xnvme_spec_idfy_ctrlr_pr(ctrlr, XNVME_PR_DEF);
-	xnvme_spec_nvm_idfy_ns_pr(ns, XNVME_PR_DEF);
+	xnvme_spec_idfy_ns_pr(ns, XNVME_PR_DEF);
 
 	xnvme_cli_pinf("LGTM");
 
@@ -116,7 +116,7 @@ _scopy_helper(struct xnvme_cli *cli, uint64_t tlbas)
 	struct xnvme_dev *dev = cli->args.dev;
 	const struct xnvme_geo *geo = xnvme_dev_get_geo(dev);
 	uint32_t nsid = cli->args.nsid;
-	struct xnvme_spec_nvm_idfy_ns *ns;
+	struct xnvme_spec_idfy_ns *ns;
 	enum xnvme_nvm_scopy_fmt copy_fmt;
 	char *dbuf = NULL, *vbuf = NULL;
 	size_t buf_nbytes;
@@ -321,7 +321,7 @@ sub_scopy(struct xnvme_cli *cli)
 static int
 sub_scopy_msrc(struct xnvme_cli *cli)
 {
-	struct xnvme_spec_nvm_idfy_ns *ns;
+	struct xnvme_spec_idfy_ns *ns;
 
 	ns = (void *)xnvme_dev_get_ns(cli->args.dev);
 	if (!ns) {

--- a/tools/xnvme.c
+++ b/tools/xnvme.c
@@ -159,7 +159,7 @@ _sub_idfy(struct xnvme_cli *cli, uint8_t cns, uint16_t cntid, uint8_t nsid, uint
 		break;
 
 	case XNVME_SPEC_IDFY_CTRLR:
-		xnvme_spec_idfy_ctrl_pr(&dbuf->ctrlr, XNVME_PR_DEF);
+		xnvme_spec_idfy_ctrlr_pr(&dbuf->ctrlr, XNVME_PR_DEF);
 		break;
 
 	case XNVME_SPEC_IDFY_IOCS:


### PR DESCRIPTION
I have cleaned up the identification part of the documentation, such that it is more clear which idfy structs are command set specific and which aren't.

There were multiple duplicated structs these have been cleaned up.