### PR TITLE
fix(core): correcting css struct size

### DIFF
--- a/include/libxnvme_opts.h
+++ b/include/libxnvme_opts.h
@@ -7,8 +7,8 @@
  */
 
 struct xnvme_opts_css {
-	uint32_t value;
-	uint32_t given;
+	uint32_t value : 31;
+	uint32_t given : 1;
 };
 
 /**


### PR DESCRIPTION
Commit 59c6fe0b1ac2bd933464ba81389b080762bb8850 moved the css struct but replaced it with a struct of the wrong size. This reinstates the correct size.