### PR TITLE
fix assertion failure with xnvme enum

### DIFF
--- a/lib/xnvme_be_spdk_dev.c
+++ b/lib/xnvme_be_spdk_dev.c
@@ -288,6 +288,11 @@ _xnvme_be_spdk_ident_to_trid(const struct xnvme_ident *ident, struct xnvme_opts 
 
 	memset(trid, 0, sizeof(*trid));
 
+	// For TCP, RDMA, FC and CUSTOM transport types, prevent assertion 0,
+	// failure in spdk_nvme_trid_populate_transport().
+	// TODO: See if there is a better way to fix this.
+	trid->trtype = trtype;
+
 	switch (trtype) {
 	case SPDK_NVME_TRANSPORT_PCIE:
 		sprintf(trid_str, "trtype:%s traddr:%s", spdk_nvme_transport_id_trtype_str(trtype),


### PR DESCRIPTION
During xnvme enumeration for spdk backend trtype is not set for TCP, RDMA, FC and CUSTOM transport. If assertions are enabled in spdk, this leads to `spdk_nvme_trid_populate_transport()` throw below specified error.

`DBG:xnvme_be_spdk_dev.c:xnvme_be_spdk_enumerate-687: INFO: trtype: TCP, # 2 of 4 DBG:xnvme_be_spdk_dev.c:_xnvme_be_spdk_ident_to_trid-300: FAILED: uri: , trtype: TCP DBG:xnvme_be_spdk_dev.c:xnvme_be_spdk_enumerate-693: SKIP: !_xnvme_be_spdk_ident_to_trid() nvme.c:1035:spdk_nvme_trid_populate_transport: *ERROR*: no available transports xnvme: nvme.c:1036: spdk_nvme_trid_populate_transport: Assertion `0' failed. Aborted (core dumped)`

Set trtype to avoid assertion 0 failed error.