### PR TITLE
fix reclaim unit handle status output format

### DIFF
--- a/lib/xnvme_spec.c
+++ b/lib/xnvme_spec.c
@@ -403,6 +403,8 @@ xnvme_spec_ruhs_fpr(FILE *stream, const struct xnvme_spec_ruhs *ruhs, int limit,
 		return wrtn;
 	}
 
+	limit = limit > ruhs->nruhsd ? ruhs->nruhsd : limit;
+
 	wrtn += fprintf(stream, "  nruhsd: %" PRIu16 "\n", ruhs->nruhsd);
 
 	for (int i = 0; i < limit; ++i) {


### PR DESCRIPTION
Output reclaim unit handle status descriptors to either the requested limit or the device supported value, whichever is smaller.