### PR TITLE
feat(spdk): add keep_alive_timeout to opts

### DIFF
--- a/include/libxnvme_opts.h
+++ b/include/libxnvme_opts.h
@@ -48,6 +48,7 @@ struct xnvme_opts {
 	uint32_t admin_timeout;    ///< SPDK fabrics: enable admin command timeout
 	uint32_t command_timeout;  ///< SPDK fabrics: enable io command timeout
 	uint32_t spdk_fabrics;     ///< Is assigned a value by backend if SPDK uses fabrics
+	uint32_t keep_alive_timeout_ms; ///< SPDK fabrics: set keep alive timeout
 };
 
 /**

--- a/lib/xnvme_be_spdk_dev.c
+++ b/lib/xnvme_be_spdk_dev.c
@@ -379,7 +379,7 @@ _spdk_setup_controller_opts(struct xnvme_opts *opts, const struct spdk_nvme_tran
 	case SPDK_NVME_TRANSPORT_RDMA:
 		ctrlr_opts->header_digest = 1;
 		ctrlr_opts->data_digest = 1;
-		ctrlr_opts->keep_alive_timeout_ms = 0;
+		ctrlr_opts->keep_alive_timeout_ms = opts->keep_alive_timeout_ms;
 		if (opts->hostnqn) {
 			strncpy(ctrlr_opts->hostnqn, opts->hostnqn, SPDK_NVMF_NQN_MAX_LEN);
 		}


### PR DESCRIPTION
Relates to #462
This only adds the option to specify keep alive timeout, if this option is used, the user must send the KEEP_ALIVE command on their own.