### PR TITLE
refactor(cijoe/bench): move shared functionality to imported script

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -402,6 +402,7 @@ jobs:
         --config "configs/ramdisk.toml" \
         --workflow "workflows/provision-using-tgz.yaml" \
         --output "prep-fio-${{ matrix.container.os }}-${{ matrix.container.ver }}" \
+        --monitor \
         fio_prep
 
     - name: CIJOE, upload prep-fio
@@ -418,6 +419,7 @@ jobs:
         cd cijoe && cijoe \
         --config "configs/ramdisk.toml" \
         --workflow "workflows/test-ramdisk.yaml" \
+        --monitor \
         --output "test-${{ matrix.container.os }}-${{ matrix.container.ver }}"
 
     - name: CIJOE, upload test-ramdisk-report
@@ -542,6 +544,7 @@ jobs:
         cd cijoe && cijoe \
         --config "configs/ramdisk-macos.toml" \
         --workflow "workflows/test-ramdisk-macos.yaml" \
+        --monitor \
         --output "test-${{ matrix.runner.os }}-${{ matrix.runner.ver }}"
 
     - name: CIJOE, upload test-ramdisk-report
@@ -720,6 +723,7 @@ jobs:
         cd cijoe && cijoe \
         --config "configs/${{ matrix.guest.os }}-${{ matrix.guest.ver }}.toml" \
         --workflow "workflows/provision-using-tgz.yaml" \
+        --monitor \
         --output "provision-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
 
     - name: CIJOE, run test.yaml
@@ -727,6 +731,7 @@ jobs:
         cd cijoe && cijoe \
         --config "configs/${{ matrix.guest.os }}-${{ matrix.guest.ver }}.toml" \
         --workflow "workflows/test-${{ matrix.guest.os }}-${{ matrix.guest.ver }}.yaml" \
+        --monitor \
         --output "test-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
 
     - name: CIJOE, result-log-dump on error
@@ -822,7 +827,8 @@ jobs:
         cd cijoe && cijoe \
         --config "configs/bench-intel.toml" \
         --workflow "workflows/benchmark-provisioning-linux.yaml" \
-        --output "benchmark-provisioning"
+        --output "benchmark-provisioning" \
+        --monitor
 
     - name: CIJOE, run bench
       run: |
@@ -830,6 +836,7 @@ jobs:
         cd cijoe && cijoe \
         --config "configs/bench-intel.toml" \
         --workflow "workflows/bench.yaml" \
+        --monitor \
         --output "bench-results"
 
     - name: CIJOE, compress xnvme-provisioning
@@ -944,6 +951,7 @@ jobs:
         cd cijoe && cijoe \
         --config "configs/perf-lat-${{ matrix.guest.os }}.toml" \
         --workflow "workflows/benchmark-provisioning-${{ matrix.guest.os }}.yaml" \
+        --monitor \
         --output "latency-${{ matrix.guest.os }}-provisioning"
 
     - name: CIJOE, run benchmark latency
@@ -952,6 +960,7 @@ jobs:
         cd cijoe && cijoe \
         --config "configs/perf-lat-${{ matrix.guest.os }}.toml" \
         --workflow "workflows/benchmark-latency.yaml" \
+        --monitor \
         --output "latency-${{ matrix.guest.os }}-results"
 
     - name: CIJOE, compress xnvme-${{ matrix.guest.os }}-provisioning
@@ -1096,6 +1105,7 @@ jobs:
         cd cijoe && cijoe \
         --config "configs/${{ matrix.guest.os }}-${{ matrix.guest.ver }}.toml" \
         --workflow "workflows/provision-using-tgz.yaml" \
+        --monitor \
         --output "provision-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
 
     - name: CIJOE, generate documentation
@@ -1103,6 +1113,7 @@ jobs:
         cd cijoe && cijoe \
         --config "configs/${{ matrix.guest.os }}-${{ matrix.guest.ver }}.toml" \
         --workflow "workflows/docgen.yaml" \
+        --monitor \
         --output "docgen-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
 
     - name: Checkout site

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ endef
 .PHONY: cijoe
 cijoe:
 	@echo "## xNVMe: cijoe"
-	@pipx install cijoe==v0.9.34 --include-deps --force
+	@pipx install cijoe==v0.9.41 --include-deps --force
 	@pipx inject cijoe matplotlib
 	@pipx inject cijoe numpy
 	@pipx install rst2pdf

--- a/cijoe/scripts/bench_plotter.py
+++ b/cijoe/scripts/bench_plotter.py
@@ -22,193 +22,20 @@ bdevperf has:
     This uses matplotlib and numpy for plotting
 """
 import errno
-import hashlib
 import json
 import logging as log
 import os
-import pprint
-import re
 import traceback
 from pathlib import Path
 
 import matplotlib.pyplot as plt
-import numpy as np
-from cijoe.core.resources import dict_from_yamlfile
-
-OUTPUT_NORMALIZED_FILENAME = "benchmark-output-normalized.json"
-
-PLOT_SCALE = 1.5
-
-
-def data_as_a_function_of(data, x="iodepth", y="iops", filter=lambda _: True):
-    """Organize and label data with 'y' points as a function of 'x' points"""
-
-    samples = {}
-
-    for ident, metrics in data:
-        context = metrics["ctx"]
-
-        if not filter(metrics):
-            continue
-
-        if ident not in samples:
-            samples[ident] = {
-                "xys": [],
-                "ident": ident,
-                "label": context["label"],
-                "name": context["name"],
-                "group": context["group"],
-            }
-
-        samples[ident]["xys"].append((context[x], metrics[y]))
-
-    for ident in samples:
-        samples[ident]["xys"].sort()
-
-    return samples
-
-
-def plot_attributes_from_step(step):
-    """Load plot-attributes using paths in step"""
-
-    limits_path = Path(step.get("with", {}).get("limits", "plot-limits.yaml"))
-    legends_path = Path(step.get("with", {}).get("legends", "plot-legends.yaml"))
-    styles_path = Path(step.get("with", {}).get("styles", "plot-styles.yaml"))
-
-    return {
-        "limits": dict_from_yamlfile(limits_path),
-        "legends": dict_from_yamlfile(legends_path),
-        "styles": dict_from_yamlfile(styles_path),
-    }
-
-
-def draw_bar_plot(data, plot_attributes, xlabel=None, ylabel=None, y_limit=None):
-    colors = plot_attributes["styles"].get("colors", ["#000000"])
-    hatches = plot_attributes["styles"].get("hatches", ["."])
-    width = 0.20
-
-    groups = list(set(map(lambda item: item["group"], data.values())))
-    is_grouped = len(groups) > 1
-
-    if is_grouped:
-        x_ticks = dict()
-
-        # fiddly stuff to get groups of uneven sizes to have even space between them
-        group_sizes = [
-            (len(list(filter(lambda item: item["group"] == group, data.values()))) + 1)
-            * width
-            for group in groups
-        ]
-        x_tick_info = dict(
-            [(group, [sum(group_sizes[:i]), 0]) for i, group in enumerate(groups)]
-        )
-    else:
-        num_bars = len(data.items()) - 1
-        unique_x_values = map(lambda xy: xy[0], list(data.values())[0]["xys"])
-        x_ticks = dict(
-            [
-                (x, (i + (num_bars * width) / 2, x))
-                for i, x in enumerate(unique_x_values)
-            ]
-        )
-
-    if y_limit is None:
-        # map each dataset to its maximum y-value, and find the maximum of these
-        # y-values to ensure that all data is within the limits.
-        max_y_value = max(
-            map(lambda item: max(map(lambda xy: xy[1], item["xys"])), data.values())
-        )
-        y_limit = max_y_value * PLOT_SCALE
-
-    plt.clf()
-    fig, ax = plt.subplots()
-
-    multiplier = 0
-
-    for i, samples in enumerate(data.values()):
-        label = samples["label"]
-        attrs = plot_attributes["legends"].get(label, None)
-        if attrs is None:
-            log.error(f"Missing plot-attributes for label({label})")
-            continue
-
-        xs, ys = list(zip(*samples["xys"]))
-
-        if is_grouped:
-            tick_info = x_tick_info[samples["group"]]
-            pos = tick_info[0] + tick_info[1] * width
-            x_tick_info[samples["group"]][1] += 1
-            x_ticks[label] = pos, samples["name"]
-            plotted_x = [pos]
-        else:
-            offset = width * multiplier
-            plotted_x = [x + offset for x in range(len(xs))]
-
-        bar = ax.bar(
-            plotted_x,
-            ys,
-            width,
-            label=attrs["legend"],
-            color=colors[i % len(colors)],
-            hatch=hatches[i % len(hatches)],
-        )
-
-        def fmt(i):
-            if i > 999:
-                return f"{i:,.0f}"
-            else:
-                return f"{i:,.2f}"
-
-        ax.bar_label(bar, fmt=fmt, padding=3, rotation=90)
-        multiplier += 1
-
-    if is_grouped:
-        fig.subplots_adjust(bottom=0.25)
-
-        # add group names at the top of the plot
-        group_ticks = list(
-            map(
-                lambda group: group[0] + (group[1] - 1) / 2 * width,
-                x_tick_info.values(),
-            )
-        )
-        group_labels = x_tick_info.keys()
-        group_axis = ax.secondary_xaxis(location=1)
-        group_axis.set_xticks(group_ticks, labels=group_labels)
-        group_axis.tick_params("x", length=0)
-
-        # add separators between the groups
-        group_separators = [
-            sum(group_sizes[:i]) - width for i in range(1, len(group_sizes))
-        ]
-        for tick in group_separators:
-            plt.vlines(x=tick, ymin=0, ymax=y_limit, ls=":", lw=1, colors="k")
-        group_axis = ax.secondary_xaxis(location=1)
-        group_axis.set_xticks(group_separators, labels=[])
-        group_axis.tick_params("x", length=15, grid_ls=":")
-
-    else:
-        plt.legend(
-            bbox_to_anchor=(0, 0.95, 1, 0.2),
-            loc="upper center",
-            ncol=1,
-            facecolor="white",
-            framealpha=1,
-        )
-
-    if xlabel:
-        ax.set_xlabel(xlabel)
-    if ylabel:
-        ax.set_ylabel(ylabel)
-
-    ax.set_xticks(
-        list(map(lambda val: val[0], x_ticks.values())),
-        list(map(lambda val: val[1], x_ticks.values())),
-        rotation=40 if is_grouped else 0,
-        ha="right" if is_grouped else "center",
-    )
-
-    ax.set_ylim([0, y_limit])
+from plotter import (
+    OUTPUT_NORMALIZED_FILENAME,
+    PLOT_SCALE,
+    data_as_a_function_of,
+    draw_bar_plot,
+    plot_attributes_from_step,
+)
 
 
 def create_plots(args, cijoe, step):
@@ -216,6 +43,7 @@ def create_plots(args, cijoe, step):
     if not search:
         return errno.EINVAL
     artifacts = args.output / "artifacts"
+    os.makedirs(artifacts, exist_ok=True)
 
     tool = step.get("with", {}).get("tool", "fio")
     search_for = OUTPUT_NORMALIZED_FILENAME
@@ -228,7 +56,7 @@ def create_plots(args, cijoe, step):
 
     x = "iodepth"
 
-    max_y_iops = max(map(lambda item: item[1]["iops"], data))
+    max_y = max(map(lambda item: item[1]["iops"], data))
     all_groups = set(map(lambda item: item[1]["ctx"]["group"], data))
 
     # Create a plot for each group, showing the scalability of the xNVMe overhead
@@ -243,9 +71,8 @@ def create_plots(args, cijoe, step):
             plot_attributes,
             xlabel=x,
             ylabel="iops",
-            y_limit=max_y_iops * PLOT_SCALE,
+            y_limit=max_y * PLOT_SCALE,
         )
-        os.makedirs(artifacts, exist_ok=True)
         plt.savefig(artifacts / f"{tool}_iops_barplot_{group}.png")
 
         # Create plot with iodepth on the x-axis and cpu utilization on the y-axis
@@ -259,7 +86,6 @@ def create_plots(args, cijoe, step):
             ylabel="percent",
             y_limit=200,
         )
-        os.makedirs(artifacts, exist_ok=True)
         plt.savefig(artifacts / f"{tool}_cpu_barplot_{group}.png")
 
     # Create a plot, showing the overhead of xNVMe at iodepth = 1
@@ -273,7 +99,6 @@ def create_plots(args, cijoe, step):
     )
     draw_bar_plot(dset, plot_attributes, ylabel="nanoseconds")
 
-    os.makedirs(artifacts, exist_ok=True)
     plt.savefig(artifacts / f"{tool}_barplot_qd1.png")
 
     return 0

--- a/cijoe/scripts/bench_reporter.py
+++ b/cijoe/scripts/bench_reporter.py
@@ -14,41 +14,40 @@ Retargetable: True
 ------------------
 """
 from pathlib import Path
-from shutil import copyfile
 
 import jinja2
+from reporter import (
+    copy_graphs,
+    create_stylesheet,
+    create_test_setup,
+    create_xnvme_cover,
+    create_xnvme_info,
+)
 
 
 def main(args, cijoe, step):
     """Primary entry-point"""
-
     templates_path = Path(
         step.get("with", {}).get("templates", Path.cwd() / "templates" / "perf_report")
     ).resolve()
-
-    # Files emitted by this script
-    report_path = cijoe.output_path / "artifacts" / "perf_report"
-    cover_path = report_path / "cover.tmpl"
-    body_path = report_path / "report.rst"
-    style_path = report_path / "style.yaml"
-    pdf_path = report_path / "perf.pdf"
-
-    # Can be from a different run / results
-    prefix_path = Path(step.get("with", {}).get("path", cijoe.output_path)).resolve()
-    plot_path = prefix_path / "artifacts"
-
-    report_path.mkdir(parents=False, exist_ok=True)
-
-    # Fill 'report_path' with files needed to produce the .pdf
-    copyfile(templates_path / "style.yaml", style_path, follow_symlinks=False)
-
-    # Copy graphs from results/artifacts into 'report_path'
-    for png_path in plot_path.glob("*.png"):
-        print(png_path)
-        copyfile(png_path, report_path / png_path.name)
+    search_path = Path(step.get("with", {}).get("path", cijoe.output_path)).resolve()
+    artifacts = search_path / "artifacts"
 
     title = step.get("with", {}).get("report_title", "xNVMe")
-    subtitle = step.get("with", {}).get("report_subtitle", "Report")
+    subtitle = step.get("with", {}).get("report_subtitle", "Benchmark Report")
+
+    report_path = cijoe.output_path / "artifacts" / "perf_report"
+    report_path.mkdir(parents=False, exist_ok=True)
+
+    # Files emitted by this script
+    body_path = report_path / "report.rst"
+    pdf_path = report_path / "perf.pdf"
+    style_path = create_stylesheet(templates_path, report_path)
+    cover_path = create_xnvme_cover(templates_path, report_path, title, subtitle)
+    create_xnvme_info(templates_path, report_path)
+    create_test_setup(templates_path, report_path, artifacts)
+
+    copy_graphs(report_path, artifacts)
 
     template_loader = jinja2.FileSystemLoader(templates_path)
     template_env = jinja2.Environment(loader=template_loader)

--- a/cijoe/scripts/benchmark_normalize.py
+++ b/cijoe/scripts/benchmark_normalize.py
@@ -195,6 +195,7 @@ def normalize(args, cijoe, step):
 
         context = {
             "name": options["name"],
+            "label": options["name"],
             "timestamp": fio_output["timestamp"],
             "ioengine": options["ioengine"],
             "iosize": int(options["bs"]),

--- a/cijoe/scripts/latency_plotter.py
+++ b/cijoe/scripts/latency_plotter.py
@@ -17,188 +17,20 @@ fio has:
     This uses matplotlib and numpy for plotting
 """
 import errno
-import hashlib
 import json
 import logging as log
 import os
 import traceback
-from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List
 
 import matplotlib.pyplot as plt
-from cijoe.core.resources import dict_from_yamlfile
-
-OUTPUT_NORMALIZED_FILENAME = "benchmark-output-normalized.json"
-
-PLOT_SCALE = 1.3
-
-Data = Dict[str, Dict[str, List[float | int] | str]]
-
-
-def data_as_a_function_of(data, x="iodepth", y="lat", filter=lambda _: True) -> Data:
-    """Organize and label data with 'y' points as a function of 'x' points"""
-
-    samples = {}
-
-    for ident, metrics in data:
-        context = metrics["ctx"]
-
-        if not filter(metrics):
-            continue
-
-        if ident not in samples:
-            label = context["name"]
-            samples[ident] = {
-                "xys": [],
-                "ident": ident,
-                "label": label,
-                "group": context["group"],
-            }
-
-        samples[ident]["xys"].append((context[x], metrics[y]))
-
-    for ident in samples:
-        samples[ident]["xys"].sort()
-
-    return samples
-
-
-def get_plot_attributes(step):
-    """Load plot-attributes using paths in step"""
-
-    limits_path = Path(step.get("with", {}).get("limits", "plot-limits.yaml"))
-    legends_path = Path(step.get("with", {}).get("legends", "plot-legends.yaml"))
-    styles_path = Path(step.get("with", {}).get("styles", "plot-styles.yaml"))
-
-    return {
-        "limits": dict_from_yamlfile(limits_path),
-        "legends": dict_from_yamlfile(legends_path),
-        "styles": dict_from_yamlfile(styles_path),
-    }
-
-
-def draw_bar_plot(data, plot_attributes, xlabel=None, ylabel=None, y_limit=None):
-    colors = plot_attributes["styles"].get("colors", ["#000000"])
-    hatches = plot_attributes["styles"].get("hatches", ["."])
-    width = 0.20
-
-    groups = list(set(map(lambda item: item["group"], data.values())))
-    is_grouped = len(groups) > 1
-
-    num_bars = len(data.items()) - 1
-    if is_grouped:
-        x_ticks = dict()
-
-        # fiddly stuff to get groups of uneven sizes to have even space between them
-        group_sizes = [
-            (len(list(filter(lambda item: item["group"] == group, data.values()))) + 1)
-            * width
-            for group in groups
-        ]
-        x_tick_info = dict(
-            [(group, [sum(group_sizes[:i]), 0]) for i, group in enumerate(groups)]
-        )
-    else:
-        unique_x_values = map(lambda xy: xy[0], list(data.values())[0]["xys"])
-        x_ticks = dict(
-            [(x, i + (num_bars * width) / 2) for i, x in enumerate(unique_x_values)]
-        )
-
-    if y_limit is None:
-        # map each dataset to its maximum y-value, and find the maximum of these
-        # y-values to ensure that all data is within the limits.
-        max_y_value = max(
-            map(lambda item: max(map(lambda xy: xy[1], item["xys"])), data.values())
-        )
-        y_limit = max_y_value * PLOT_SCALE
-
-    plt.clf()
-    fig, ax = plt.subplots()
-
-    multiplier = 0
-
-    # Sort to ensure engines will get the same colours across
-    # different plots
-    datavalues = list(data.values())
-    datavalues.sort(key=lambda samples: samples["label"])
-
-    for i, samples in enumerate(datavalues):
-        label = samples["label"]
-        attrs = plot_attributes["legends"].get(label, None)
-        if attrs is None:
-            log.error(f"Missing plot-attributes for label({label})")
-            continue
-
-        xs, ys = list(zip(*samples["xys"]))
-
-        if is_grouped:
-            tick_info = x_tick_info[samples["group"]]
-            pos = tick_info[0] + tick_info[1] * width
-            x_tick_info[samples["group"]][1] += 1
-            x_ticks[label] = pos
-            plotted_x = [pos]
-        else:
-            offset = width * multiplier
-            plotted_x = [x + offset for x in range(len(xs))]
-
-        bar = ax.bar(
-            plotted_x,
-            ys,
-            width,
-            label=attrs["legend"],
-            color=colors[i % len(colors)],
-            hatch=hatches[i % len(hatches)],
-        )
-        ax.bar_label(bar, fmt=lambda i: f"{i:,.0f}", padding=3, rotation=90)
-        multiplier += 1
-
-    if is_grouped:
-        fig.subplots_adjust(bottom=0.25)
-
-        # add group names at the top of the plot
-        group_ticks = list(
-            map(
-                lambda group: group[0] + (group[1] - 1) / 2 * width,
-                x_tick_info.values(),
-            )
-        )
-        group_labels = x_tick_info.keys()
-        group_axis = ax.secondary_xaxis(location=1)
-        group_axis.set_xticks(group_ticks, labels=group_labels)
-        group_axis.tick_params("x", length=0)
-
-        # add separators between the groups
-        group_separators = [
-            sum(group_sizes[:i]) - width for i in range(1, len(group_sizes))
-        ]
-        for tick in group_separators:
-            plt.vlines(x=tick, ymin=0, ymax=y_limit, ls=":", lw=1, colors="k")
-        group_axis = ax.secondary_xaxis(location=1)
-        group_axis.set_xticks(group_separators, labels=[])
-        group_axis.tick_params("x", length=15, grid_ls=":")
-    else:
-        plt.legend(
-            bbox_to_anchor=(0, 0.95, 1, 0.2),
-            loc="lower center",
-            ncol=2,
-            facecolor="white",
-            framealpha=1,
-        )
-
-    if xlabel:
-        ax.set_xlabel(xlabel)
-    if ylabel:
-        ax.set_ylabel(ylabel)
-
-    ax.set_xticks(
-        list(x_ticks.values()),
-        list(x_ticks.keys()),
-        rotation=50 if is_grouped else 0,
-        ha="right" if is_grouped else "center",
-    )
-
-    ax.set_ylim([0, y_limit])
+from plotter import (
+    OUTPUT_NORMALIZED_FILENAME,
+    PLOT_SCALE,
+    data_as_a_function_of,
+    draw_bar_plot,
+    plot_attributes_from_step,
+)
 
 
 def create_plots(args, cijoe, step):
@@ -213,7 +45,7 @@ def create_plots(args, cijoe, step):
     with path.open() as jfd:
         data = json.load(jfd)
 
-    plot_attributes = get_plot_attributes(step)
+    plot_attributes = plot_attributes_from_step(step)
 
     y = "lat"
 

--- a/cijoe/scripts/plotter.py
+++ b/cijoe/scripts/plotter.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python
+"""
+Helper functions for plotting benchmark graphs
+==============================================
+
+
+
+.. note::
+    This uses matplotlib and numpy for plotting
+"""
+import logging as log
+from pathlib import Path
+from typing import Dict, List
+
+import matplotlib.pyplot as plt
+from cijoe.core.resources import dict_from_yamlfile
+
+OUTPUT_NORMALIZED_FILENAME = "benchmark-output-normalized.json"
+PLOT_SCALE = 1.5
+BAR_WIDTH = 0.2
+
+Data = Dict[str, Dict[str, List[float | int] | str]]
+
+
+def data_as_a_function_of(data, x="iodepth", y="iops", filter=lambda _: True) -> Data:
+    """Organize and label data with 'y' points as a function of 'x' points"""
+
+    samples = {}
+
+    for ident, metrics in data:
+        context = metrics["ctx"]
+
+        if not filter(metrics):
+            continue
+
+        if ident not in samples:
+            samples[ident] = {
+                "xys": [],
+                "ident": ident,
+                "label": context["label"],
+                "name": context["name"],
+                "group": context["group"],
+            }
+
+        samples[ident]["xys"].append((context[x], metrics[y]))
+
+    for ident in samples:
+        samples[ident]["xys"].sort()
+
+    return samples
+
+
+def plot_attributes_from_step(step):
+    """Load plot-attributes using paths in step"""
+
+    limits_path = Path(step.get("with", {}).get("limits", "plot-limits.yaml"))
+    legends_path = Path(step.get("with", {}).get("legends", "plot-legends.yaml"))
+    styles_path = Path(step.get("with", {}).get("styles", "plot-styles.yaml"))
+
+    return {
+        "limits": dict_from_yamlfile(limits_path),
+        "legends": dict_from_yamlfile(legends_path),
+        "styles": dict_from_yamlfile(styles_path),
+    }
+
+
+def fmt(i):
+    if i > 999:
+        return f"{i:,.0f}"
+    else:
+        return f"{i:,.2f}"
+
+
+def add_bars_to_plot(data, ax, plot_attributes):
+    """
+    Given data, a touple containing (x-values, y-values, series-label), add
+    the bars to the graph `ax`.
+    """
+    colors = plot_attributes["styles"].get("colors", ["#000000"])
+    hatches = plot_attributes["styles"].get("hatches", ["."])
+
+    for i, (xs, ys, label) in enumerate(data):
+        attrs = plot_attributes["legends"].get(label, None)
+        if attrs is None:
+            log.error(f"Missing plot-attributes for label({label})")
+            continue
+
+        bar = ax.bar(
+            xs,
+            ys,
+            BAR_WIDTH,
+            label=attrs["legend"],
+            color=colors[i % len(colors)],
+            hatch=hatches[i % len(hatches)],
+        )
+
+        ax.bar_label(bar, fmt=fmt, padding=3, rotation=90)
+
+
+def draw_scaling_bar_plot(datavalues, plot_attributes, ax):
+    """Draw a bar plot with the given data"""
+
+    num_bars = len(datavalues) - 1
+    unique_x_values = map(lambda xy: xy[0], list(datavalues)[0]["xys"])
+    x_ticks = dict(
+        [
+            (x, (i + (num_bars * BAR_WIDTH) / 2, x))
+            for i, x in enumerate(unique_x_values)
+        ]
+    )
+
+    multiplier = 0
+    bar_data = []
+
+    for samples in datavalues:
+        xs, ys = list(zip(*samples["xys"]))
+
+        offset = BAR_WIDTH * multiplier
+        plotted_x = [x + offset for x in range(len(xs))]
+
+        bar_data.append((plotted_x, ys, samples["label"]))
+        multiplier += 1
+
+    add_bars_to_plot(bar_data, ax, plot_attributes)
+
+    plt.legend(
+        bbox_to_anchor=(0, 0.95, 1, 0.2),
+        loc="upper center",
+        ncol=1,
+        facecolor="white",
+        framealpha=1,
+    )
+
+    ax.set_xticks(
+        list(map(lambda val: val[0], x_ticks.values())),
+        list(map(lambda val: val[1], x_ticks.values())),
+        rotation=0,
+        ha="center",
+    )
+
+
+def draw_grouped_bar_plot(datavalues, plot_attributes, ax, fig, groups, y_limit=None):
+    """Draw a bar plot where data is separated into the given groups."""
+
+    x_ticks = dict()
+
+    # fiddly stuff to get groups of uneven sizes to have even space between them
+    group_sizes = [
+        (len(list(filter(lambda item: item["group"] == group, datavalues))) + 1)
+        * BAR_WIDTH
+        for group in groups
+    ]
+    x_tick_info = dict(
+        [(group, [sum(group_sizes[:i]), 0]) for i, group in enumerate(groups)]
+    )
+
+    bar_data = []
+
+    for samples in datavalues:
+        label = samples["label"]
+        _, ys = list(zip(*samples["xys"]))
+
+        tick_info = x_tick_info[samples["group"]]
+        pos = tick_info[0] + tick_info[1] * BAR_WIDTH
+        x_tick_info[samples["group"]][1] += 1
+        x_ticks[label] = pos, samples["name"]
+        plotted_x = [pos]
+
+        bar_data.append((plotted_x, ys, label))
+
+    add_bars_to_plot(bar_data, ax, plot_attributes)
+
+    fig.subplots_adjust(bottom=0.25)
+
+    # add group names at the top of the plot
+    group_ticks = list(
+        map(
+            lambda group: group[0] + (group[1] - 1) / 2 * BAR_WIDTH,
+            x_tick_info.values(),
+        )
+    )
+    group_labels = x_tick_info.keys()
+    group_axis = ax.secondary_xaxis(location=1)
+    group_axis.set_xticks(group_ticks, labels=group_labels)
+    group_axis.tick_params("x", length=0)
+
+    # add separators between the groups
+    group_separators = [
+        sum(group_sizes[:i]) - BAR_WIDTH for i in range(1, len(group_sizes))
+    ]
+    for tick in group_separators:
+        plt.vlines(x=tick, ymin=0, ymax=y_limit, ls=":", lw=1, colors="k")
+    group_axis = ax.secondary_xaxis(location=1)
+    group_axis.set_xticks(group_separators, labels=[])
+    group_axis.tick_params("x", length=15, grid_ls=":")
+
+    ax.set_xticks(
+        list(map(lambda val: val[0], x_ticks.values())),
+        list(map(lambda val: val[1], x_ticks.values())),
+        rotation=40,
+        ha="right",
+    )
+
+
+def draw_bar_plot(data, plot_attributes, xlabel=None, ylabel=None, y_limit=None):
+    if y_limit is None:
+        # map each dataset to its maximum y-value, and find the maximum of these
+        # y-values to ensure that all data is within the limits.
+        max_y_value = max(
+            map(lambda item: max(map(lambda xy: xy[1], item["xys"])), data.values())
+        )
+        y_limit = max_y_value * PLOT_SCALE
+
+    groups = list(set(map(lambda item: item["group"], data.values())))
+    is_grouped = len(groups) > 1
+
+    # Sort to ensure engines will get the same colours across
+    # different plots
+    datavalues = list(data.values())
+    datavalues.sort(key=lambda samples: samples["label"])
+
+    plt.clf()
+    fig, ax = plt.subplots()
+
+    if is_grouped:
+        draw_grouped_bar_plot(datavalues, plot_attributes, ax, fig, groups, y_limit)
+    else:
+        draw_scaling_bar_plot(datavalues, plot_attributes, ax)
+
+    if xlabel:
+        ax.set_xlabel(xlabel)
+    if ylabel:
+        ax.set_ylabel(ylabel)
+
+    ax.set_ylim([0, y_limit])

--- a/cijoe/workflows/bench.yaml
+++ b/cijoe/workflows/bench.yaml
@@ -45,12 +45,6 @@ steps:
     limits: auxiliary/plot-limits-4k.yaml
     styles: auxiliary/plot-styles.yaml
 
-- name: report_templates
-  uses: reporter_templates
-  with:
-    report_title: "xNVMe in SPDK"
-    report_subtitle: "Performance Report"
-
 - name: report
   uses: bench_reporter
   with:

--- a/cijoe/workflows/benchmark-latency.yaml
+++ b/cijoe/workflows/benchmark-latency.yaml
@@ -39,12 +39,6 @@ steps:
     iosizes: *iosizes
     iodepths: *iodepths
 
-- name: report_templates
-  uses: reporter_templates
-  with:
-    report_title: "xNVMe on {{ config.os.prettyname }}"
-    report_subtitle: "Latency Report"
-
 - name: report
   uses: latency_reporter
   with:


### PR DESCRIPTION
Bump cijoe to latest version and refactor shared functionality into imported script.

Our two workflows "latency" and "bench" that each generate graphs and reports, shared functionality in the plotting and reporting path of the workflows. This funcationliaty could not be put into a shared script before cijoe support the functionality of importing self-made scripts, which was added in v0.9.35.