### PR TITLE
vfio phy mapping

### DIFF
--- a/lib/xnvme_be_vfio_mem.c
+++ b/lib/xnvme_be_vfio_mem.c
@@ -68,7 +68,7 @@ xnvme_be_vfio_buf_vtophys(const struct xnvme_dev *dev, void *buf, uint64_t *phys
 	struct xnvme_be_vfio_state *state = (void *)dev->be.state;
 	struct iommu_ctx *ctx = state->ctrl->pci.dev.ctx;
 
-	if (iommu_translate_vaddr(ctx, buf, phys)) {
+	if (!iommu_translate_vaddr(ctx, buf, phys)) {
 		XNVME_DEBUG("FAILED: iommu_translate_vaddr(-, %p): %s\n", buf, strerror(errno));
 		return -EIO;
 	}


### PR DESCRIPTION
This PR introduces two fixes to the vfio (libvfn) backend.

The PR ensures that `xnvme_be_vfio_buf_alloc`, actually sets the PHY pointer when the physical address is also needed. This is when the user calls `xnvme_buf_phys_alloc` where the physical address is also needed.

This PR also fixes an issue where `xnvme_be_vfio_buf_vtophys` interpreted the return-code of `iommu_translate_vaddr`  in the wrong way (it returns 1/true on success).
