### PR TITLE
refactor(api/znd)!: replace report-MACROs with getters

### DIFF
--- a/include/libxnvme_znd.h
+++ b/include/libxnvme_znd.h
@@ -183,15 +183,12 @@ xnvme_znd_zrwa_flush(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t lba);
  * it and provides MACRO-accessors and helper-functions to retrieve
  * zone-descriptors and when supported, extensions.
  *
- * For simplicity then only use the macros below when accessing the report entries:
+ * For simplicity then only use getter function when accessing the report entries:
  *
- * ZND_REPORT_DESCR(rprt, nth)	- Access the 'nth' descriptor (zero-based)
- * ZND_REPORT_DEXT(rprt, nth)	- Access the 'nth' descr. extension (zero-based)
+ * xnvme_znd_report_get_descr(report, index, **descr, **ext)
  *
  * However, when zdes_bytes is 0, then `descr` is accessible as a regular array
- * When zdes > 0, then the ZND_REPORT_DESCR should be used to access Zone
- * Descriptors and ZND_REPORT_DEXT should be used to access Zone Descriptor
- * extension
+ * When zdes > 0.
  *
  * @struct xnvme_znd_report
  */
@@ -218,24 +215,29 @@ XNVME_STATIC_ASSERT(sizeof(struct xnvme_znd_report) == 64, "Incorrect size")
 
 /**
  * Access Zone Descriptors, by entry index, in the given znd_report
+ *
+ * @param index Index, 0-based, of the entry in the report
+ * @param report Pointer to the the ::xnvme_znd_report to get descriptor from
+ * @param descr Pointer the descriptor will be assigned to
+ * @param ext Pointer the extended descriptor will be assigned to
+ *
+ * @return On success, 0 is returned. On error, negative `errno` is returned.
+ *
+ * NOTE: the MACRO is kept for backwards compatibility with the upstream fio io-engine.
  */
+int
+xnvme_znd_report_get_descr(const struct xnvme_znd_report *report, uint32_t index,
+			   struct xnvme_spec_znd_descr **descr, void **ext);
+
 #define XNVME_ZND_REPORT_DESCR(rprt, nth) \
 	((struct xnvme_spec_znd_descr *)&(rprt->storage[nth * rprt->zrent_nbytes]))
-
-/**
- * Access Zone Descriptors Extensions, by entry index, in the given znd_report
- */
-#define XNVME_ZND_REPORT_DEXT(rprt, nth) \
-	((!rprt->extended)               \
-		 ? NULL                  \
-		 : ((void *)&rprt->storage[nth * rprt->zrent_nbytes + rprt->zd_nbytes]))
 
 /**
  * Prints the given ::xnvme_znd_report to the given stream
  *
  * @param stream output stream used for printing
  * @param report pointer to the the ::xnvme_znd_report to print
- * @param flags
+ * @param flags printer options, see ::xnvme_pr
  *
  * @return On success, the number of characters printed is returned.
  */

--- a/lib/libxnvme.map
+++ b/lib/libxnvme.map
@@ -422,22 +422,23 @@
 		xnvme_ver_pr;
 
 		# libxnvme_znd.h
-		xnvme_znd_dev_get_ns;
-		xnvme_znd_dev_get_ctrlr;
-		xnvme_znd_dev_get_lbafe;
-		xnvme_znd_mgmt_recv;
+		xnvme_znd_append;
 		xnvme_znd_descr_from_dev;
 		xnvme_znd_descr_from_dev_in_state;
-		xnvme_znd_stat;
+		xnvme_znd_dev_get_ctrlr;
+		xnvme_znd_dev_get_lbafe;
+		xnvme_znd_dev_get_ns;
 		xnvme_znd_log_changes_from_dev;
+		xnvme_znd_mgmt_recv;
 		xnvme_znd_mgmt_send;
-		xnvme_znd_append;
-		xnvme_znd_zrwa_flush;
 		xnvme_znd_report;
-		xnvme_znd_report_fpr;
-		xnvme_znd_report_pr;
-		xnvme_znd_report_from_dev;
 		xnvme_znd_report_find_arbitrary;
+		xnvme_znd_report_fpr;
+		xnvme_znd_report_from_dev;
+		xnvme_znd_report_get_descr;
+		xnvme_znd_report_pr;
+		xnvme_znd_stat;
+		xnvme_znd_zrwa_flush;
 		
 	local:
 		*;

--- a/lib/xnvme_znd.c
+++ b/lib/xnvme_znd.c
@@ -192,6 +192,31 @@ xnvme_znd_report_from_dev(struct xnvme_dev *dev, uint64_t slba, size_t limit, ui
 }
 
 int
+xnvme_znd_report_get_descr(const struct xnvme_znd_report *report, uint32_t index,
+			   struct xnvme_spec_znd_descr **descr, void **ext)
+{
+	if (index >= report->nentries) {
+		XNVME_DEBUG("FAILED: index(%" PRIu32 ") >= report->nentries(%" PRIu32 ")", index,
+			    report->nentries);
+		return -EINVAL;
+	}
+	if (ext && (!report->extended)) {
+		XNVME_DEBUG("FAILED: gave 'ext' but report does not contain extensions.");
+		return -EINVAL;
+	}
+
+	if (descr) {
+		*descr = (struct xnvme_spec_znd_descr *)&(
+			report->storage[index * report->zrent_nbytes]);
+	}
+	if (ext) {
+		*ext = (void *)&report->storage[index * report->zrent_nbytes + report->zd_nbytes];
+	}
+
+	return 0;
+}
+
+int
 xnvme_znd_report_find_arbitrary(const struct xnvme_znd_report *report,
 				enum xnvme_spec_znd_state state, uint64_t *zlba, int opts)
 {
@@ -202,9 +227,14 @@ xnvme_znd_report_find_arbitrary(const struct xnvme_znd_report *report,
 
 	for (uint32_t ci = 0; ci < report->nentries; ++ci) {
 		const uint64_t idx = (arb++) % ((uint64_t)report->nentries);
-		struct xnvme_spec_znd_descr *zdescr = NULL;
+		struct xnvme_spec_znd_descr *zdescr;
+		int err;
 
-		zdescr = XNVME_ZND_REPORT_DESCR(report, idx);
+		err = xnvme_znd_report_get_descr(report, idx, &zdescr, NULL);
+		if (err) {
+			XNVME_DEBUG("xnvme_znd_report_get_descr(), err: %d", err);
+			return err;
+		}
 
 		if ((zdescr->zs == state) && (zdescr->zt == XNVME_SPEC_ZND_TYPE_SEQWR) &&
 		    (zdescr->zcap)) {
@@ -503,7 +533,14 @@ xnvme_znd_report_fpr(FILE *stream, const struct xnvme_znd_report *report, int fl
 
 	wrtn += fprintf(stream, "\n");
 	for (uint32_t idx = 0; idx < report->nentries; ++idx) {
-		struct xnvme_spec_znd_descr *descr = XNVME_ZND_REPORT_DESCR(report, idx);
+		struct xnvme_spec_znd_descr *descr;
+		int err;
+
+		err = xnvme_znd_report_get_descr(report, idx, &descr, NULL);
+		if (err) {
+			XNVME_DEBUG("xnvme_znd_report_get_descr(), err: %d", err);
+			return err;
+		}
 
 		wrtn += fprintf(stream, "    - {");
 		wrtn += xnvme_spec_znd_descr_fpr_yaml(stream, descr, 0, ", ");

--- a/tests/znd_explicit_open.c
+++ b/tests/znd_explicit_open.c
@@ -21,6 +21,7 @@ test_open_zdptr(struct xnvme_cli *cli)
 	uint64_t zidx = 0;
 
 	struct xnvme_znd_report *before = NULL, *after = NULL;
+	struct xnvme_spec_znd_descr *descr;
 
 	int err;
 
@@ -55,7 +56,11 @@ test_open_zdptr(struct xnvme_cli *cli)
 	xnvme_cli_pinf("Scan for empty and sequential write ctx. zone");
 
 	for (uint64_t idx = 0; idx < before->nentries; ++idx) {
-		struct xnvme_spec_znd_descr *descr = XNVME_ZND_REPORT_DESCR(before, idx);
+		err = xnvme_znd_report_get_descr(before, idx, &descr, NULL);
+		if (err) {
+			XNVME_DEBUG("xnvme_znd_report_get_descr(), err: %d", err);
+			return err;
+		}
 
 		if (cli->given[XNVME_CLI_OPT_SLBA] && (cli->args.lba != descr->zslba)) {
 			continue;
@@ -74,10 +79,15 @@ test_open_zdptr(struct xnvme_cli *cli)
 		goto exit;
 	}
 
-	xnvme_cli_pinf("Using: {zslba: 0x%016lx, zidx: %zu}", zslba, zidx);
+	err = xnvme_znd_report_get_descr(before, zidx, &descr, NULL);
+	if (err) {
+		XNVME_DEBUG("xnvme_znd_report_get_descr(), zidx: %" PRIu64 " err: %d", zidx, err);
+		return err;
+	}
 
+	xnvme_cli_pinf("Using: {zslba: 0x%016lx, zidx: %zu}", zslba, zidx);
 	xnvme_cli_pinf("Before");
-	xnvme_spec_znd_descr_pr(XNVME_ZND_REPORT_DESCR(before, zidx), XNVME_PR_DEF);
+	xnvme_spec_znd_descr_pr(descr, XNVME_PR_DEF);
 
 	err = xnvme_znd_mgmt_send(&ctx, nsid, zslba, false, XNVME_SPEC_ZND_CMD_MGMT_SEND_RESET,
 				  0x0, NULL);
@@ -106,12 +116,23 @@ test_open_zdptr(struct xnvme_cli *cli)
 		goto exit;
 	}
 
-	xnvme_spec_znd_descr_pr(XNVME_ZND_REPORT_DESCR(before, zidx), XNVME_PR_DEF);
+	err = xnvme_znd_report_get_descr(before, zidx, &descr, NULL);
+	if (err) {
+		XNVME_DEBUG("xnvme_znd_report_get_descr(), zidx: %" PRIu64 " err: %d", zidx, err);
+		return err;
+	}
+	xnvme_spec_znd_descr_pr(descr, XNVME_PR_DEF);
 
 	{
+		void *zde_after;
+
 		// Verification
-		struct xnvme_spec_znd_descr *descr = XNVME_ZND_REPORT_DESCR(after, zidx);
-		uint8_t *zde_after = XNVME_ZND_REPORT_DEXT(after, zidx);
+		err = xnvme_znd_report_get_descr(after, zidx, &descr, &zde_after);
+		if (err) {
+			XNVME_DEBUG("xnvme_znd_report_get_descr(), zidx: %" PRIu64 " err: %d",
+				    zidx, err);
+			return err;
+		}
 
 		if (xnvme_buf_diff(zde, zde_after, zde_nbytes)) {
 			xnvme_buf_diff_pr(zde, descr, zde_nbytes, XNVME_PR_DEF);


### PR DESCRIPTION
To improve the portability of the xNVMe API, macros cannot be used across FFI boundaries. For example, when macros are used as helper tools in a C API, they are not accessible to consumers of the xNVMe API in languages like Python or Rust.

Therefore, convert these macros into functions.