### PR TITLE
fix(cijoe): add `./` as prefix to local file for `pipx inject`

### DIFF
--- a/cijoe/scripts/xnvme_bindings_py_install_tgz.py
+++ b/cijoe/scripts/xnvme_bindings_py_install_tgz.py
@@ -63,7 +63,7 @@ def main(args, cijoe, step):
         "pipx ensurepath",
         "pipx install cijoe==v0.9.34 --include-deps",
         "pipx inject cijoe numpy",
-        "pipx inject cijoe xnvme-py-sdist.tar.gz",
+        "pipx inject cijoe ./xnvme-py-sdist.tar.gz",
         "cijoe --version",
         "pytest --version",
     ]


### PR DESCRIPTION
Without this prefix, the command fails on our physical Linux machine.