### PR TITLE
fix(api/ident): remove unused macro definitions

### DIFF
--- a/include/libxnvme_ident.h
+++ b/include/libxnvme_ident.h
@@ -8,14 +8,6 @@
 
 #define XNVME_IDENT_URI_LEN 384
 
-#define XNVME_IDENT_SCHM_LEN 5
-#define XNVME_IDENT_TRGT_LEN 155
-#define XNVME_IDENT_OPTS_LEN 160
-#define XNVME_IDENT_OPTS_SEP '?'
-#define XNVME_IDENT_OPT_MAX  20
-
-#define XNVME_IDENT_URI_LEN_MIN (XNVME_IDENT_SCHM_LEN + 1)
-
 /**
  * Representation of device identifiers once decoded from text-representation
  *


### PR DESCRIPTION
These definitions were originally used when xNVMe employed a "schema" to encode options into the device identifier string, e.g.:

  "/dev/nvme0n1?nsid=2&async=io_uring"

This approach was replaced by `xnvme_opts`. However, these definitions have lingered since then and are now being removed as part of the API cleanup in preparation for code generation.