### PR TITLE
fix(ci/qcow2): prepare for building qcow2 images automatically

### DIFF
--- a/cijoe/workflows/bootimg-debian-bullseye-amd64.yaml
+++ b/cijoe/workflows/bootimg-debian-bullseye-amd64.yaml
@@ -30,10 +30,20 @@ steps:
     apt-get -qy install aptitude
     aptitude -q -y -f install git
 
-- name: linux_install_kdebs
-  uses: linux.transfer_and_install_kdebs
+- name: xnvme_source_sync
+  uses: xnvme_source_from_tgz
   with:
-    local_kdebs_dir: "_kdebs"
+    artifacts: '/tmp/artifacts'
+    xnvme_source: '{{ config.xnvme.repository.sync.remote_path }}'
+
+- name: xnvme_build_prep
+  uses: xnvme_build_prep
+  with:
+    xnvme_source: '{{ config.xnvme.repository.sync.remote_path }}'
+
+- name: remove_source
+  run: |
+    rm -rf {{ config.xnvme.repository.sync.remote_path }}
 
 - name: guest_grub_default
   run: |
@@ -44,3 +54,8 @@ steps:
 
 - name: guest_info
   uses: linux.sysinfo
+
+- name: guest_shutdown
+  run: |
+    sync
+    systemctl poweroff

--- a/cijoe/workflows/bootimg-freebsd-14-amd64.yaml
+++ b/cijoe/workflows/bootimg-freebsd-14-amd64.yaml
@@ -1,0 +1,82 @@
+---
+doc: |
+  This prepares a boot.img from an official FreeBSD virtual machine image (BASIC-CI)
+
+  The basic-ci images is altered by the addition of:
+
+  * git
+  * vim
+  * htop
+  * python3 (with pip)
+  * Kernel source
+
+  And the removal of
+
+  * /usr/lib/debug
+    - Removing as an image less than 5GB is needed for storage on DigitalOcean Spaces
+
+  Previously, we used the unoffical cloud-init images, however, these are now stale.
+  This method applied here works for our needs, however, having cloud-init would be.
+
+  This script assumes that the bootimg config has the basic ci image, it can be retrieve
+
+  * wget https://download.freebsd.org/releases/CI-IMAGES/14.1-RELEASE/amd64/Latest/FreeBSD-14.1-RELEASE-amd64-BASIC-CI.raw.xz
+  * xz --decompress FreeBSD-14.1-RELEASE-amd64-BASIC-CI.raw.xz
+  * qemu-img convert FreeBSD-14.1-RELEASE-amd64-BASIC-CI.raw FreeBSD-14.1-RELEASE-amd64-BASIC-CI.qcow2 -O qcow2
+
+  After creating, then
+
+  * Shut down the guest
+  * Convert the image (with compression)
+    - qemu-img convert boot.img /tmp/freebsd-14.1-ksrc-amd64.qcow2 -O qcow2 -c
+  * Upload it to DigitalOcean
+
+steps:
+- name: kill
+  uses: qemu.guest_kill
+
+- name: initialize
+  uses: qemu.guest_init_using_bootimage
+
+- name: start
+  uses: xnvme_guest_start_nvme
+
+- name: check
+  run: |
+    hostname
+    uname -a
+
+- name: update_packages
+  run: |
+    env ASSUME_ALWAYS_YES=yes pkg update -f
+    env ASSUME_ALWAYS_YES=yes pkg upgrade -fy
+    env ASSUME_ALWAYS_YES=yes pkg install -y git vim htop python3
+    python3 -m ensurepip
+
+- name: xnvme_source_sync
+  uses: xnvme_source_from_tgz
+  with:
+    artifacts: '/tmp/artifacts'
+    xnvme_source: '{{ config.xnvme.repository.sync.remote_path }}'
+
+- name: xnvme_build_prep
+  uses: xnvme_build_prep
+  with:
+    xnvme_source: '{{ config.xnvme.repository.sync.remote_path }}'
+
+- name: remove_source
+  run: |
+    rm -rf {{ config.xnvme.repository.sync.remote_path }}
+
+- name: kernel_source
+  run: |
+    fetch https://download.freebsd.org/releases/amd64/14.1-RELEASE/src.txz
+    tar xzfp src.txz -C /
+    rm src.txz || true
+    pkg clean -ay
+    rm -rf /usr/lib/debug/
+
+- name: guest_shutdown
+  run: |
+    sync
+    shutdown -p now


### PR DESCRIPTION
This is necessary for the github actions in this repo:
https://github.com/xnvme/xnvme-qcow2/