### PR TITLE
fix(toolbox/pkgs): add automake to debian bookworm dependencies

### DIFF
--- a/toolbox/pkgs/debian-bookworm.sh
+++ b/toolbox/pkgs/debian-bookworm.sh
@@ -16,6 +16,7 @@ apt-get -qy --no-install-recommends install apt-utils
 apt-get -qy autoclean
 apt-get -qy install \
  autoconf \
+ automake \
  bash \
  build-essential \
  clang-format \


### PR DESCRIPTION
The SPDK configuration script fails when configuring ISA-L without automake because `aclocal` is not found.

----

I am unsure whether this is necessary in other pkgs scripts? 