### PR TITLE
fix(be/spdk): don't detach in-use enumerated controllers

### DIFF
--- a/cijoe/tests/logic/test_xnvme_tests_enum.py
+++ b/cijoe/tests/logic/test_xnvme_tests_enum.py
@@ -8,7 +8,7 @@ def test_open(cijoe, device, be_opts, cli_args):
     if be_opts["be"] == "ramdisk":
         pytest.skip(reason="[be=ramdisk] does not support enumeration")
     if be_opts["be"] == "driverkit":
-        pytest.skip(reason="[be=driverkit] does not support repeatedly enumerating")
+        pytest.skip(reason="[be=driverkit] does not support enumeration")
 
     if "fabrics" in device["labels"]:
         err, _ = cijoe.run(
@@ -16,6 +16,22 @@ def test_open(cijoe, device, be_opts, cli_args):
         )
     else:
         err, _ = cijoe.run(f"xnvme_tests_enum open --count 4 --be {be_opts['be']}")
+    assert not err
+
+
+@xnvme_parametrize(labels=["dev"], opts=["be"])
+def test_keep_open(cijoe, device, be_opts, cli_args):
+    if be_opts["be"] == "ramdisk":
+        pytest.skip(reason="[be=ramdisk] does not support enumeration")
+    if be_opts["be"] in ["vfio"]:
+        pytest.skip(reason=f"[be={be_opts['be']}] keep open not supported")
+
+    if "fabrics" in device["labels"]:
+        err, _ = cijoe.run(
+            f"xnvme_tests_enum keep_open --uri {device['uri']} --be {be_opts['be']}"
+        )
+    else:
+        err, _ = cijoe.run(f"xnvme_tests_enum keep_open --be {be_opts['be']}")
     assert not err
 
 


### PR DESCRIPTION
If `XNVME_ENUMERATE_DEV_KEEP_OPEN` is returned from the callback during enumeration, the SPDK controller underlying the open device must not be detached. Only deref the controller if the device is closed. Conditionally detach controllers only if their reference count is zero.

It is now valid for a controller to have a reference count of zero and not be cleaned up yet. Entries in the reference count array may not be reused if the controller pointer is non-null. A controller with a zero reference count may be still be incremented later. A new cleanup routine allows deferred detachment of all controllers with a zero refcount.

This change is an attempt to fix #565.