### PR TITLE
fix(cijoe/enum): remove be opt from backend test

### DIFF
--- a/cijoe/tests/logic/test_xnvme_tests_enum.py
+++ b/cijoe/tests/logic/test_xnvme_tests_enum.py
@@ -37,7 +37,7 @@ def test_multi(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be"])
+@xnvme_parametrize(labels=["dev"], opts=[])
 def test_backend(cijoe, device, be_opts, cli_args):
     err, _ = cijoe.run("xnvme_tests_enum backend")
     assert not err


### PR DESCRIPTION
The test doesn't use the flag, so no reason to include it