### PR TITLE
fix(enum): fix silent failure

### DIFF
--- a/cijoe/tests/logic/test_xnvme_tests_enum.py
+++ b/cijoe/tests/logic/test_xnvme_tests_enum.py
@@ -5,8 +5,8 @@ from ..conftest import XnvmeDriver, xnvme_parametrize
 
 @xnvme_parametrize(labels=["dev"], opts=["be"])
 def test_open(cijoe, device, be_opts, cli_args):
-    if be_opts["be"] == "ramdisk":
-        pytest.skip(reason="[be=ramdisk] does not support enumeration")
+    if be_opts["be"] in ["ramdisk", "vfio"]:
+        pytest.skip(reason=f"[be={be_opts['be']}] does not support enumeration")
     if be_opts["be"] == "driverkit":
         pytest.skip(reason="[be=driverkit] does not support enumeration")
 
@@ -21,10 +21,8 @@ def test_open(cijoe, device, be_opts, cli_args):
 
 @xnvme_parametrize(labels=["dev"], opts=["be"])
 def test_keep_open(cijoe, device, be_opts, cli_args):
-    if be_opts["be"] == "ramdisk":
-        pytest.skip(reason="[be=ramdisk] does not support enumeration")
-    if be_opts["be"] in ["vfio"]:
-        pytest.skip(reason=f"[be={be_opts['be']}] keep open not supported")
+    if be_opts["be"] in ["ramdisk", "vfio"]:
+        pytest.skip(reason=f"[be={be_opts['be']}] does not support enumeration")
 
     if "fabrics" in device["labels"]:
         err, _ = cijoe.run(
@@ -39,8 +37,8 @@ def test_keep_open(cijoe, device, be_opts, cli_args):
 def test_multi(cijoe, device, be_opts, cli_args):
     if be_opts["be"] == "spdk":
         pytest.skip(reason="[be=spdk] does not support repeatedly enumerating")
-    if be_opts["be"] == "ramdisk":
-        pytest.skip(reason="[be=ramdisk] does not support enumeration")
+    if be_opts["be"] in ["ramdisk", "vfio"]:
+        pytest.skip(reason=f"[be={be_opts['be']}] does not support enumeration")
     if be_opts["be"] == "driverkit":
         pytest.skip(reason="[be=driverkit] does not support repeatedly enumerating")
 

--- a/cijoe/tests/logic/test_xnvme_tests_enum.py
+++ b/cijoe/tests/logic/test_xnvme_tests_enum.py
@@ -8,7 +8,7 @@ def test_open(cijoe, device, be_opts, cli_args):
     if be_opts["be"] in ["ramdisk", "vfio"]:
         pytest.skip(reason=f"[be={be_opts['be']}] does not support enumeration")
     if be_opts["be"] == "driverkit":
-        pytest.skip(reason="[be=driverkit] does not support enumeration")
+        pytest.skip(reason="[be=driverkit] does not support repeatedly opening devices")
 
     if "fabrics" in device["labels"]:
         err, _ = cijoe.run(
@@ -35,12 +35,12 @@ def test_keep_open(cijoe, device, be_opts, cli_args):
 
 @xnvme_parametrize(labels=["dev"], opts=["be"])
 def test_multi(cijoe, device, be_opts, cli_args):
-    if be_opts["be"] == "spdk":
-        pytest.skip(reason="[be=spdk] does not support repeatedly enumerating")
     if be_opts["be"] in ["ramdisk", "vfio"]:
         pytest.skip(reason=f"[be={be_opts['be']}] does not support enumeration")
-    if be_opts["be"] == "driverkit":
-        pytest.skip(reason="[be=driverkit] does not support repeatedly enumerating")
+    if be_opts["be"] in ["driverkit", "spdk"]:
+        pytest.skip(
+            reason=f"[be={be_opts['be']}] does not support repeatedly enumerating"
+        )
 
     if "fabrics" in device["labels"]:
         err, _ = cijoe.run(


### PR DESCRIPTION
`xnvme_enumerate()` would always return a success, even if enumeration failed.
Now only `err=-ENOSYS` is suppressed, and only if a backend is not specified.