### PR TITLE
fix(cijoe/latency): move run argument to aux file

### DIFF
--- a/cijoe/auxiliary/bench-latency-runs.yaml
+++ b/cijoe/auxiliary/bench-latency-runs.yaml
@@ -1,0 +1,8 @@
+---
+iodepths: &iodepths [1, 2, 4, 8, 16]
+iosizes: &iosizes [512, 1024, 2048, 4096, 8192, 16384, 32768, 65536]
+runs:
+- iosizes: [4096]
+  iodepths: *iodepths
+- iosizes: *iosizes
+  iodepths: [1]

--- a/cijoe/scripts/fio_latency.py
+++ b/cijoe/scripts/fio_latency.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
 from cijoe.core.command import Cijoe
+from cijoe.core.resources import dict_from_yamlfile
 
 LATENCY_TEST_SIZE: str = "100%"
 LATENCY_TEST_ROOT_DIR: Path = Path("/tmp/")
@@ -337,7 +338,12 @@ class FIO:
 
 def main(args, cijoe: Cijoe, step: Dict[str, Any]):
     fio_bin = cijoe.config.options.get("fio", {}).get("bin")
-    runs = step.get("with", {}).get("runs", [])
+
+    runs_aux_path = step.get("with", {}).get("runs", None)
+    if not runs_aux_path:
+        log.error("Missing path to auxiliary file describing the runs")
+    runs = dict_from_yamlfile(Path(runs_aux_path))["runs"]
+
     io_engines: CijoeEngines = cijoe.config.options.get("fio", {}).get("engines")
     devices: List[Device] = list(determine_devices(cijoe.config.options.get("devices")))
     os_name = cijoe.config.options.get("os", {}).get("name", "")

--- a/cijoe/scripts/latency_reporter.py
+++ b/cijoe/scripts/latency_reporter.py
@@ -20,6 +20,7 @@ from collections import defaultdict
 from pathlib import Path
 
 import jinja2
+from cijoe.core.resources import dict_from_yamlfile
 from reporter import (
     copy_graphs,
     create_stylesheet,
@@ -61,11 +62,14 @@ def main(args, cijoe, step):
 
     # info for methodology section
     ioengines = cijoe.config.options.get("fio", {}).get("engines", {})
-    iosizes = step.get("with", {}).get("iosizes", [])
-    iodepths = step.get("with", {}).get("iodepths", [])
+
+    runs_aux_path = step.get("with", {}).get("runs", None)
+    if not runs_aux_path:
+        log.error("Missing path to auxiliary file describing the runs")
+    runs = dict_from_yamlfile(Path(runs_aux_path))
     fio = {
-        "iosizes": iosizes,
-        "iodepths": iodepths,
+        "iosizes": runs["iosizes"],
+        "iodepths": runs["iodepths"],
         "ioengines": [{"name": e} for e in ioengines],
     }
 

--- a/cijoe/workflows/benchmark-latency.yaml
+++ b/cijoe/workflows/benchmark-latency.yaml
@@ -20,11 +20,7 @@ steps:
 - name: benchmark
   uses: fio_latency
   with:
-    runs:
-    - iosizes: [4096]
-      iodepths: &iodepths [1, 2, 4, 8, 16]
-    - iosizes: &iosizes [512, 1024, 2048, 4096, 8192, 16384, 32768, 65536]
-      iodepths: [1]
+    runs: auxiliary/bench-latency-runs.yaml
 
 - name: normalize
   uses: benchmark_normalize
@@ -36,14 +32,11 @@ steps:
     legends: auxiliary/plot-latency-legends.yaml
     limits: auxiliary/plot-latency-limits.yaml
     styles: auxiliary/plot-styles.yaml
-    iosizes: *iosizes
-    iodepths: *iodepths
 
 - name: report
   uses: latency_reporter
   with:
     report_title: "xNVMe on {{ config.os.prettyname }}"
     report_subtitle: "Latency Report"
-    iosizes: *iosizes
-    iodepths: *iodepths
+    runs: auxiliary/bench-latency-runs.yaml
 


### PR DESCRIPTION
In a newer version of cijoe, only primitive types or lists of primitive types will be allowed as values in the step.with dict. Therefore, we move the 'runs' argument to an auxiliary file in order to get ready for this.