### PR TITLE
fix(python/bindings): revert to v2.3.4

### DIFF
--- a/python/bindings/requirements.txt
+++ b/python/bindings/requirements.txt
@@ -1,6 +1,6 @@
 # For ctypes-bindings
 black
 clang>=11,<=14.0.6
-ctypeslib2
+ctypeslib2==2.3.4
 # All
 pytest


### PR DESCRIPTION
This is the version before the most recent version, which might have broken our CI. https://pypi.org/project/ctypeslib2/#history