### PR TITLE
fix(cli): default log-health to controller

### DIFF
--- a/tools/xnvme.c
+++ b/tools/xnvme.c
@@ -253,7 +253,8 @@ sub_log_health(struct xnvme_cli *cli)
 	int err;
 
 	if (!cli->given[XNVME_CLI_OPT_NSID]) {
-		nsid = xnvme_dev_get_nsid(cli->args.dev);
+		// Perform log-health on controller as the default
+		nsid = 0xFFFFFFFF;
 	}
 
 	xnvme_cli_pinf("Allocating and clearing buffer...");


### PR DESCRIPTION
log-health of a namespace is optional to implement for the drive, so change the default to log-health of the controller, which is mandatory. This will improve usability, as the default is expected to succeed, and align differences in handling on Windows, Linux and macOS.

Fixes #587 