### PR TITLE
feat(cijoe): bump to v0.9.52

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -406,12 +406,10 @@ jobs:
     - name: CIJOE, install fio
       if: (!contains('focal', matrix.container.ver))
       run: |
-        cd cijoe && cijoe \
+        cd cijoe && cijoe fio_prep \
         --monitor \
         --config "configs/ramdisk.toml" \
-        --workflow "workflows/provision-using-tgz.yaml" \
-        --output "prep-fio-${{ matrix.container.os }}-${{ matrix.container.ver }}" \
-        fio_prep
+        --output "prep-fio-${{ matrix.container.os }}-${{ matrix.container.ver }}"
 
     - name: CIJOE, upload prep-fio
       if: always() && (!contains('focal', matrix.container.ver))
@@ -424,10 +422,9 @@ jobs:
     - name: CIJOE, run test-ramdisk.yaml
       if: (!contains('focal', matrix.container.ver))
       run: |
-        cd cijoe && cijoe \
+        cd cijoe && cijoe "workflows/test-ramdisk.yaml" \
         --monitor \
         --config "configs/ramdisk.toml" \
-        --workflow "workflows/test-ramdisk.yaml" \
         --output "test-${{ matrix.container.os }}-${{ matrix.container.ver }}"
 
     - name: CIJOE, upload test-ramdisk-report
@@ -551,10 +548,9 @@ jobs:
 
     - name: CIJOE, run test-ramdisk.yaml
       run: |
-        cd cijoe && cijoe \
+        cd cijoe && cijoe "workflows/test-ramdisk-macos.yaml" \
         --monitor \
         --config "configs/ramdisk-macos.toml" \
-        --workflow "workflows/test-ramdisk-macos.yaml" \
         --output "test-${{ matrix.runner.os }}-${{ matrix.runner.ver }}"
 
     - name: CIJOE, upload test-ramdisk-report
@@ -705,10 +701,9 @@ jobs:
     - name: CIJOE, run test-ramdisk-windows.yaml
       shell: bash
       run: |
-        cd cijoe; cijoe \
+        cd cijoe; cijoe "workflows/test-ramdisk-windows.yaml" \
         --monitor \
         --config "configs/ramdisk-windows.toml" \
-        --workflow "workflows/test-ramdisk-windows.yaml" \
         --output "test-${{ matrix.runner.os }}-${{ matrix.runner.ver }}"
 
     - name: CIJOE, upload test-ramdisk-report
@@ -800,18 +795,16 @@ jobs:
     # workflows.
     - name: CIJOE, run provision-using-tgz.yaml
       run: |
-        cd cijoe && cijoe \
+        cd cijoe && cijoe "workflows/provision-using-tgz.yaml" \
         --monitor \
         --config "configs/${{ matrix.guest.os }}-${{ matrix.guest.ver }}.toml" \
-        --workflow "workflows/provision-using-tgz.yaml" \
         --output "provision-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
 
     - name: CIJOE, run test.yaml
       run: |
-        cd cijoe && cijoe \
+        cd cijoe && cijoe "workflows/test-${{ matrix.guest.os }}-${{ matrix.guest.ver }}.yaml" \
         --monitor \
         --config "configs/${{ matrix.guest.os }}-${{ matrix.guest.ver }}.toml" \
-        --workflow "workflows/test-${{ matrix.guest.os }}-${{ matrix.guest.ver }}.yaml" \
         --output "test-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
 
     - name: CIJOE, result-log-dump on error
@@ -918,28 +911,25 @@ jobs:
     - name: CIJOE, run macvfn-provision.yaml
       if: matrix.guest.os == 'macos'
       run: |
-        cd cijoe && cijoe \
+        cd cijoe && cijoe "workflows/macvfn-provision.yaml" \
         --monitor \
         --config "configs/${{ matrix.guest.hostname }}.toml" \
-        --workflow "workflows/macvfn-provision.yaml" \
-        --output "provision-macvfn"
+        --output "provision-macvfn" \
 
     - name: CIJOE, run provision-using-tgz.yaml
       run: |
-        cd cijoe && cijoe \
+        cd cijoe && cijoe "workflows/provision-using-tgz.yaml" \
         --monitor \
         --config "configs/${{ matrix.guest.hostname }}.toml" \
-        --workflow "workflows/provision-using-tgz.yaml" \
         --output "provision-${{ matrix.guest.hostname }}" \
         xnvme_source_sync xnvme_build_prep xnvme_build xnvme_install \
         ldconfig xnvme_bindings_py_install_tgz fio_prep
 
     - name: CIJOE, run test.yaml
       run: |
-        cd cijoe && cijoe \
+        cd cijoe && cijoe "workflows/test-${{ matrix.guest.os }}-${{ matrix.guest.ver }}.yaml" \
         --monitor \
         --config "configs/${{ matrix.guest.hostname }}.toml" \
-        --workflow "workflows/test-${{ matrix.guest.os }}-${{ matrix.guest.ver }}.yaml" \
         --output "test-${{ matrix.guest.hostname }}"
 
     - name: CIJOE, result-log-dump on error
@@ -1031,29 +1021,26 @@ jobs:
     - name: CIJOE, provision xnvme from tgz
       run: |
         rm -rf cijoe/xnvme-provisioning
-        cd cijoe && cijoe \
-        --monitor \
+        cd cijoe && cijoe "workflows/provision-using-tgz.yaml" \
+        --monitor  \
         --config "configs/bench-intel.toml" \
-        --workflow "workflows/provision-using-tgz.yaml" \
         --output "xnvme-provisioning" \
         xnvme_source_sync xnvme_build_prep xnvme_build \
         xnvme_install ldconfig fio_prep
 
     - name: CIJOE, run benchmark provisioning
       run: |
-        cd cijoe && cijoe \
+        cd cijoe && cijoe "workflows/benchmark-provisioning-linux.yaml" \
         --monitor \
         --config "configs/bench-intel.toml" \
-        --workflow "workflows/benchmark-provisioning-linux.yaml" \
         --output "benchmark-provisioning"
 
     - name: CIJOE, run bench
       run: |
         rm -rf cijoe/bench-results
-        cd cijoe && cijoe \
+        cd cijoe && cijoe "workflows/bench.yaml" \
         --monitor \
         --config "configs/bench-intel.toml" \
-        --workflow "workflows/bench.yaml" \
         --output "bench-results"
 
     - name: CIJOE, compress xnvme-provisioning
@@ -1155,30 +1142,26 @@ jobs:
     - name: CIJOE, provision xnvme from tgz
       run: |
         rm -rf cijoe/xnvme-${{ matrix.guest.os }}-provisioning
-        cd cijoe && cijoe \
-        --monitor \
+        cd cijoe && cijoe "workflows/provision-using-tgz.yaml" \
+        --monitor  \
         --config "configs/perf-lat-${{ matrix.guest.os }}.toml" \
-        --workflow "workflows/provision-using-tgz.yaml" \
         --output "xnvme-${{ matrix.guest.os }}-provisioning" \
-        xnvme_source_sync xnvme_build_prep xnvme_build \
-        xnvme_install ldconfig fio_prep
+        xnvme_source_sync xnvme_build_prep xnvme_build xnvme_install ldconfig fio_prep
 
     - name: CIJOE, run benchmark provisioning
       run: |
         rm -rf cijoe/latency-${{ matrix.guest.os }}-provisioning
-        cd cijoe && cijoe \
+        cd cijoe && cijoe "workflows/benchmark-provisioning-${{ matrix.guest.os }}.yaml" \
         --monitor \
         --config "configs/perf-lat-${{ matrix.guest.os }}.toml" \
-        --workflow "workflows/benchmark-provisioning-${{ matrix.guest.os }}.yaml" \
         --output "latency-${{ matrix.guest.os }}-provisioning"
 
     - name: CIJOE, run benchmark latency
       run: |
         rm -rf cijoe/latency-${{ matrix.guest.os }}-results
-        cd cijoe && cijoe \
+        cd cijoe && cijoe "workflows/benchmark-latency.yaml" \
         --monitor \
         --config "configs/perf-lat-${{ matrix.guest.os }}.toml" \
-        --workflow "workflows/benchmark-latency.yaml" \
         --output "latency-${{ matrix.guest.os }}-results"
 
     - name: CIJOE, compress xnvme-${{ matrix.guest.os }}-provisioning
@@ -1322,18 +1305,16 @@ jobs:
     # workflows.
     - name: CIJOE, run provision-using-tgz.yaml
       run: |
-        cd cijoe && cijoe \
+        cd cijoe && cijoe "workflows/provision-using-tgz.yaml" \
         --monitor \
         --config "configs/${{ matrix.guest.os }}-${{ matrix.guest.ver }}.toml" \
-        --workflow "workflows/provision-using-tgz.yaml" \
         --output "provision-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
 
     - name: CIJOE, generate documentation
       run: |
-        cd cijoe && cijoe \
+        cd cijoe && cijoe "workflows/docgen.yaml" \
         --monitor \
         --config "configs/${{ matrix.guest.os }}-${{ matrix.guest.ver }}.toml" \
-        --workflow "workflows/docgen.yaml" \
         --output "docgen-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
 
     - name: Checkout site

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ endef
 .PHONY: cijoe
 cijoe:
 	@echo "## xNVMe: cijoe"
-	@pipx install cijoe==v0.9.44 --include-deps --force
+	@pipx install cijoe==v0.9.52 --include-deps --force
 	@pipx inject cijoe matplotlib
 	@pipx inject cijoe numpy
 	@pipx install rst2pdf
@@ -175,7 +175,7 @@ endef
 .PHONY: cijoe-guest-setup-xnvme-using-tgz
 cijoe-guest-setup-xnvme-using-tgz:
 	@echo "## xNVMe: cijoe-guest-setup-xnvme-using-tgz"
-	@cd cijoe && cijoe -w workflows/provision-using-tgz.yaml -l
+	@cd cijoe && cijoe workflows/provision-using-tgz.yaml -l
 	@echo "## xNVME: cijoe-guest-setup-xnvme-using-tgz [DONE]"
 
 define cijoe-guest-setup-xnvme-using-git-help
@@ -184,7 +184,7 @@ endef
 .PHONY: cijoe-guest-setup-xnvme-using-git
 cijoe-guest-setup-xnvme-using-git:
 	@echo "## xNVMe: cijoe-guest-setup-xnvme-using-git"
-	@cd cijoe && cijoe -w workflows/provision-using-git.yaml -l
+	@cd cijoe && cijoe workflows/provision-using-git.yaml -l
 	@echo "## xNVME: cijoe-guest-setup-xnvme-using-git [DONE]"
 
 define cijoe-guest-setup-blank-help
@@ -193,7 +193,7 @@ endef
 .PHONY: cijoe-guest-setup-blank
 cijoe-guest-setup-blank:
 	@echo "## xNVMe: cijoe-guest-setup-blank"
-	@cd cijoe && cijoe -w workflows/provision-using-git.yaml -l \
+	@cd cijoe && cijoe workflows/provision-using-git.yaml -l \
 		guest_kill \
 		guest_init \
 		guest_start \
@@ -206,7 +206,7 @@ endef
 .PHONY: cijoe-guest-start
 cijoe-guest-start:
 	@echo "## xNVMe: cijoe-guest-start"
-	@cd cijoe && cijoe -w workflows/provision-using-git.yaml -l \
+	@cd cijoe && cijoe workflows/provision-using-git.yaml -l \
 		guest_start \
 		guest_check
 	@echo "## xNVMe: cijoe-guest-start [DONE]"
@@ -217,7 +217,7 @@ endef
 .PHONY: cijoe-guest-stop
 cijoe-guest-stop:
 	@echo "## xNVMe: cijoe-guest-stop"
-	@cd cijoe && cijoe -w workflows/provision-using-git.yaml -l \
+	@cd cijoe && cijoe workflows/provision-using-git.yaml -l \
 		guest_kill
 	@echo "## xNVMe: cijoe-guest-stop [DONE]"
 
@@ -227,7 +227,7 @@ endef
 .PHONY: cijoe-setup-xnvme-using-git
 cijoe-setup-xnvme-using-git:
 	@echo "## xNVMe: cijoe-setup-xnvme-using-git"
-	@cd cijoe && cijoe -w workflows/provision-using-git.yaml -l \
+	@cd cijoe && cijoe workflows/provision-using-git.yaml -l \
 		xnvme_source_sync \
 		xnvme_build_prep \
 		xnvme_build \
@@ -243,7 +243,7 @@ endef
 .PHONY: cijoe-setup-xnvme-using-tgz
 cijoe-setup-xnvme-using-tgz:
 	@echo "## xNVMe: cijoe-setup-xnvme-using-tgz"
-	@cd cijoe && cijoe -w workflows/provision-using-tgz.yaml -l \
+	@cd cijoe && cijoe workflows/provision-using-tgz.yaml -l \
 		xnvme_source_sync \
 		xnvme_build_prep \
 		xnvme_build \
@@ -259,7 +259,7 @@ endef
 .PHONY: cijoe-sync-git
 cijoe-sync-git:
 	@echo "## xNVMe: cijoe-sync-git"
-	@cd cijoe && cijoe -w workflows/provision-using-git.yaml -l \
+	@cd cijoe && cijoe workflows/provision-using-git.yaml -l \
 		xnvme_source_sync
 	@echo "## xNVME: cijoe-sync-git [DONE]"
 
@@ -269,7 +269,7 @@ endef
 .PHONY: cijoe-sync-tgz
 cijoe-sync-tgz:
 	@echo "## xNVMe: cijoe-sync-tgz"
-	@cd cijoe && cijoe -w workflows/provision-using-tgz.yaml -l \
+	@cd cijoe && cijoe workflows/provision-using-tgz.yaml -l \
 		xnvme_source_sync
 	@echo "## xNVME: cijoe-sync-tgz [DONE]"
 
@@ -279,7 +279,7 @@ endef
 .PHONY: cijoe-do-docgen
 cijoe-do-docgen:
 	@echo "## xNVMe: cijoe-do-docgen"
-	@cd cijoe && cijoe -w workflows/docgen.yaml -l
+	@cd cijoe && cijoe workflows/docgen.yaml -l
 	@echo "## xNVME: cijoe-do-docgen [DONE]"
 
 define cijoe-do-selftest-help
@@ -297,7 +297,7 @@ endef
 .PHONY: cijoe-do-test-linux
 cijoe-do-test-linux:
 	@echo "## xNVMe: cijoe-do-test-linux"
-	@cd cijoe && cijoe -w workflows/test-debian-bullseye.yaml -l 
+	@cd cijoe && cijoe workflows/test-debian-bullseye.yaml -l 
 	@echo "## xNVME: cijoe-do-test-linux [DONE]"
 
 define cijoe-do-test-freebsd-help
@@ -306,7 +306,7 @@ endef
 .PHONY: cijoe-do-test-freebsd
 cijoe-do-test-freebsd:
 	@echo "## xNVMe: cijoe-do-test-freebsd"
-	@cd cijoe && cijoe -w workflows/test-freebsd-13.yaml -l 
+	@cd cijoe && cijoe workflows/test-freebsd-13.yaml -l 
 	@echo "## xNVME: cijoe-do-test-freebsd [DONE]"
 
 define cijoe-do-benchmark-scale-help
@@ -315,7 +315,7 @@ endef
 .PHONY: cijoe-do-benchmark-scale
 cijoe-do-benchmark-scale:
 	@echo "## xNVMe: cijoe-do-benchmark-scale"
-	@cd cijoe && cijoe -w workflows/bench.yaml -l
+	@cd cijoe && cijoe workflows/bench.yaml -l
 	@echo "## xNVME: cijoe-do-benchmark-scale [DONE]"
 
 define cijoe-do-benchmark-latency-help
@@ -324,7 +324,7 @@ endef
 .PHONY: cijoe-do-benchmark-latency
 cijoe-do-benchmark-latency:
 	@echo "## xNVMe: cijoe-do-benchmark-latency"
-	@cd cijoe && cijoe -w workflows/benchmark_latency.yaml -l
+	@cd cijoe && cijoe workflows/benchmark_latency.yaml -l
 	@echo "## xNVME: cijoe-do-benchmark-latency [DONE]"
 
 
@@ -334,7 +334,7 @@ endef
 .PHONY: cijoe-do-bootimage-debian-bullseye-amd64
 cijoe-do-bootimage-debian-bullseye-amd64:
 	@echo "## xNVMe: cijoe-do-bootimage-debian-bullseye-amd64"
-	@cd cijoe && cijoe -w workflows/bootimg-debian-bullseye-amd64.yaml -l
+	@cd cijoe && cijoe workflows/bootimg-debian-bullseye-amd64.yaml -l
 	@echo "## xNVME: cijoe-do-bootimage-debian-bullseye-amd64 [DONE]"
 
 define cijoe-do-bootimage-freebsd-amd64-help
@@ -343,7 +343,7 @@ endef
 .PHONY: cijoe-do-bootimage-freebsd-amd64
 cijoe-do-bootimage-freebsd-amd64:
 	@echo "## xNVMe: cijoe-do-bootimage-freebsd-amd64"
-	@cd cijoe && cijoe -w workflows/bootimg-freebsd-13-amd64.yaml -l
+	@cd cijoe && cijoe workflows/bootimg-freebsd-13-amd64.yaml -l
 	@echo "## xNVME: cijoe-do-bootimage-freebsd-amd64 [DONE]"
 
 define cijoe-do-linux-kdebs-help
@@ -352,7 +352,7 @@ endef
 .PHONY: cijoe-do-linux-kdebs
 cijoe-do-linux-kdebs:
 	@echo "## xNVMe: cijoe-do-linux-kdebs"
-	@cd cijoe && cijoe -w workflows/build-kdebs.yaml -l
+	@cd cijoe && cijoe workflows/build-kdebs.yaml -l
 	@echo "## xNVME: cijoe-do-linux-kdebs [DONE]"
 
 define cijoe-report-help

--- a/cijoe/auxiliary/cloudinit-debian-meta.meta
+++ b/cijoe/auxiliary/cloudinit-debian-meta.meta
@@ -1,0 +1,2 @@
+instance-id: i-debian-cijoe-guest-64
+local-hostname: cijoe-guest

--- a/cijoe/auxiliary/cloudinit-debian-user-amd64.user
+++ b/cijoe/auxiliary/cloudinit-debian-user-amd64.user
@@ -1,0 +1,27 @@
+#cloud-config
+disable_root: False
+ssh_pwauth: True
+chpasswd:
+  list: |
+    root:root
+  expire: False
+bootcmd:
+- [ sh, -c, "sudo sed -i 's/^GRUB_CMDLINE_LINUX=\"/&intel_iommu=on /' /etc/default/grub" ]
+- [ sh, -c, 'sudo update-grub' ]
+package_update: true
+package_upgrade: true
+packages:
+- htop
+- lshw
+- pciutils
+runcmd:
+  - sed -i -e 's/^.*PermitRootLogin.*$/PermitRootLogin yes/g' /etc/ssh/sshd_config
+  - sed -i -e 's/^.*PermitEmptyPasswords.*$/PermitEmptyPasswords yes/g' /etc/ssh/sshd_config
+  - sed -i -e 's/^.*PasswordAuthentication.*$/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+  - service ssh restart
+final_message: "The system is up, after $UPTIME seconds"
+power_state:
+  mode: poweroff
+  message: So long and thanks for all the fish
+  timeout: 30
+  condition: True

--- a/cijoe/auxiliary/cloudinit-debian-user-arm64.user
+++ b/cijoe/auxiliary/cloudinit-debian-user-arm64.user
@@ -1,0 +1,24 @@
+#cloud-config
+disable_root: False
+ssh_pwauth: True
+chpasswd:
+  list: |
+    root:root
+  expire: False
+package_update: true
+package_upgrade: true
+packages:
+- htop
+- lshw
+- pciutils
+runcmd:
+  - sed -i -e 's/^.*PermitRootLogin.*$/PermitRootLogin yes/g' /etc/ssh/sshd_config
+  - sed -i -e 's/^.*PermitEmptyPasswords.*$/PermitEmptyPasswords yes/g' /etc/ssh/sshd_config
+  - sed -i -e 's/^.*PasswordAuthentication.*$/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+  - service ssh restart
+final_message: "The system is up, after $UPTIME seconds"
+power_state:
+  mode: poweroff
+  message: So long and thanks for all the fish
+  timeout: 30
+  condition: True

--- a/cijoe/auxiliary/cloudinit-freebsd-meta.meta
+++ b/cijoe/auxiliary/cloudinit-freebsd-meta.meta
@@ -1,0 +1,2 @@
+instance-id: i-freebsd-13-64
+local-hostname: freebsd-13

--- a/cijoe/auxiliary/cloudinit-freebsd-user.user
+++ b/cijoe/auxiliary/cloudinit-freebsd-user.user
@@ -1,0 +1,24 @@
+#cloud-config
+disable_root: False
+ssh_pwauth: True
+package_update: true
+package_upgrade: true
+packages:
+- fio
+- htop
+- nvme-cli
+- pciutils
+write_files:
+- path: /etc/ssh/sshd_config
+  content: |
+    PermitRootLogin yes
+    PermitEmptyPasswords yes
+runcmd:
+  - [pw, usermod, root, -w, none]
+  - [sed, -E, -i.bak, 's/auth[[:space:]]+required[[:space:]]+pam_unix\.so[[:space:]]+no_warn[[:space:]]+try_first_pass/& nullok/', /etc/pam.d/sshd]
+final_message: "The system is finally up, after $UPTIME seconds"
+power_state:
+  mode: poweroff
+  message: So long and thanks for all the fish
+  timeout: 30
+  condition: True

--- a/cijoe/configs/bench-intel.toml
+++ b/cijoe/configs/bench-intel.toml
@@ -246,3 +246,7 @@ pcie = "0000:0a:00.0"
 os = "7n1"
 sn = "S5GXNX0T875423K"
 label = "980PRO_1TB"
+
+[qemu]
+default_guest = ""
+default_systemimage = ""

--- a/cijoe/configs/debian-bookworm-arm.toml
+++ b/cijoe/configs/debian-bookworm-arm.toml
@@ -22,14 +22,18 @@ tag = "v7.1.0"
 prefix = "{{ local.env.HOME }}/opt/qemu"
 
 [qemu]
-# system_bin = "{{ local.env.HOME }}/opt/qemu/bin/qemu-system-aarch64"
-system_bin = "/opt/qemu/bin/qemu-system-aarch64"
 img_bin = "qemu-img"
 default_guest = "bookworm_arm64"
+default_systemimage = "debian-12-aarch64"
+
+[qemu.systems.aarch64]
+# bin = "{{ local.env.HOME }}/opt/qemu/bin/qemu-system-aarch64"
+bin = "/opt/qemu/bin/qemu-system-aarch64"
 
 # Used by: qemu.guest_start.py and qemu.guest_kill.py
 [qemu.guests.bookworm_arm64]
 path = "{{ local.env.HOME }}/guests/debian-bookworm-arm64"
+system_label = "aarch64"
 
 # Keyword arguments: joined onto the form: "-cpu host -smp 4 -m 4" etc.
 system_args.kwa = {cpu = "host", smp = 4, m = "6G"}
@@ -44,15 +48,17 @@ system_args.raw = """\
 system_args.tcp_forward = {host = 4200, guest = 22}
 #system_args.host_share = "{{ local.env.HOME }}/git"
 
-# Used by: qemu.guest_init_using_bootimage.py
-init_using_bootimage.url = "https://refenv.fra1.digitaloceanspaces.com/boot_images/debian-bookworm-arm64.qcow2"
-init_using_bootimage.img = "{{ local.env.HOME }}/images/boot_images/debian-bookworm-arm64.qcow2"
+[system-imaging.images.debian-12-aarch64]
+system_label = "aarch64"
 
-# Used by: qemu.guest_init_using_cloudinit
-init_using_cloudinit.url = "https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-arm64-daily.qcow2"
-init_using_cloudinit.img = "{{ local.env.HOME }}/images/cloudinit/debian-12-generic-arm64-daily.qcow2"
-init_using_cloudinit.meta = "{{ resources.auxiliary['qemu.cloudinit-debian-meta'] }}"
-init_using_cloudinit.user = "{{ resources.auxiliary['qemu.cloudinit-debian-user-arm64'] }}"
+cloud.url = "https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-arm64-daily.qcow2"
+cloud.path = "{{ local.env.HOME }}/images/cloudinit/debian-12-generic-arm64-daily.qcow2"
+cloud.metadata_path = "{{ resources.auxiliary['cloudinit-debian-meta'] }}"
+cloud.userdata_path = "{{ resources.auxiliary['cloudinit-debian-user-arm64'] }}"
+
+disk.url = "https://refenv.fra1.digitaloceanspaces.com/boot_images/debian-bookworm-arm64.qcow2"
+disk.path = "{{ local.env.HOME }}/images/boot_images/debian-bookworm-arm64.qcow2"
+
 #pubkey = "keys/guest_key.pub"
 
 [[devices]]

--- a/cijoe/configs/debian-bullseye.toml
+++ b/cijoe/configs/debian-bullseye.toml
@@ -22,14 +22,18 @@ tag = "v7.1.0"
 prefix = "{{ local.env.HOME }}/opt/qemu"
 
 [qemu]
-#system_bin = "{{ local.env.HOME }}/opt/qemu/bin/qemu-system-x86_64"
-system_bin = "/opt/qemu/bin/qemu-system-x86_64"
 img_bin = "qemu-img"
 default_guest = "bullseye_amd64"
+default_systemimage = "debian-11-x86_64"
+
+[qemu.systems.x86_64]
+#bin = "{{ local.env.HOME }}/opt/qemu/bin/qemu-system-x86_64"
+bin = "/opt/qemu/bin/qemu-system-x86_64"
 
 # Used by: qemu.guest_start.py and qemu.guest_kill.py
 [qemu.guests.bullseye_amd64]
 path = "{{ local.env.HOME }}/guests/debian-bullseye-amd64"
+system_label = "x86_64"
 
 # Keyword arguments: joined onto the form: "-cpu host -smp 4 -m 4" etc.
 system_args.kwa = {cpu = "host", smp = 4, m = "6G", accel = "kvm"}
@@ -44,15 +48,17 @@ system_args.raw = """\
 system_args.tcp_forward = {host = 4200, guest = 22}
 #system_args.host_share = "{{ local.env.HOME }}/git"
 
-# Used by: qemu.guest_init_using_bootimage.py
-init_using_bootimage.url = "https://refenv.fra1.digitaloceanspaces.com/boot_images/debian-bullseye-amd64.qcow2"
-init_using_bootimage.img = "{{ local.env.HOME }}/images/boot_images/debian-bullseye-amd64.qcow2"
+[system-imaging.images.debian-11-x86_64]
+system_label = "x86_64"
 
-# Used by: qemu.guest_init_using_cloudinit
-init_using_cloudinit.url = "https://cloud.debian.org/images/cloud/bullseye/daily/latest/debian-11-generic-amd64-daily.qcow2"
-init_using_cloudinit.img = "{{ local.env.HOME }}/images/cloudinit/debian-11-generic-amd64-daily.qcow2"
-init_using_cloudinit.meta = "{{ resources.auxiliary['qemu.cloudinit-debian-meta'] }}"
-init_using_cloudinit.user = "{{ resources.auxiliary['qemu.cloudinit-debian-user-amd64'] }}"
+cloud.url = "https://cloud.debian.org/images/cloud/bullseye/daily/latest/debian-11-generic-amd64-daily.qcow2"
+cloud.path = "{{ local.env.HOME }}/images/cloudinit/debian-11-generic-amd64-daily.qcow2"
+cloud.metadata_path = "{{ resources.auxiliary['cloudinit-debian-meta'] }}"
+cloud.userdata_path = "{{ resources.auxiliary['cloudinit-debian-user-amd64'] }}"
+
+disk.url = "https://refenv.fra1.digitaloceanspaces.com/boot_images/debian-bullseye-amd64.qcow2"
+disk.path = "{{ local.env.HOME }}/images/boot_images/debian-bullseye-amd64.qcow2"
+
 #pubkey = "keys/guest_key.pub"
 
 [[devices]]

--- a/cijoe/configs/freebsd-13.toml
+++ b/cijoe/configs/freebsd-13.toml
@@ -26,14 +26,18 @@ tag = "v8.0.0"
 prefix = "{{ local.env.HOME }}/opt/qemu"
 
 [qemu]
-#system_bin = "{{ local.env.HOME }}/opt/qemu/bin/qemu-system-x86_64"
-system_bin = "/opt/qemu/bin/qemu-system-x86_64"
 img_bin = "qemu-img"
 default_guest = "freebsd_13"
+default_systemimage = "freebsd-13-x86_64"
+
+[qemu.systems.x86_64]
+#bin = "{{ local.env.HOME }}/opt/qemu/bin/qemu-system-x86_64"
+bin = "/opt/qemu/bin/qemu-system-x86_64"
 
 # Used by: qemu.guest_start.py and qemu.guest_kill.py
 [qemu.guests.freebsd_13]
 path = "{{ local.env.HOME }}/guests/freebsd-13-amd64"
+system_label = "x86_64"
 
 # Keyword arguments: joined onto the form: "-cpu host -smp 4 -m 4" etc.
 system_args.kwa = {cpu = "host", smp = 4, m = "12G", accel = "kvm"}
@@ -48,16 +52,18 @@ system_args.raw = """\
 system_args.tcp_forward = {host = 4200, guest = 22}
 #system_args.host_share = "{{ local.env.HOME }}/git"
 
-# Used by: qemu.guest_init_using_bootimage.py
-init_using_bootimage.url = "https://refenv.fra1.digitaloceanspaces.com/boot_images/freebsd-13.1-ksrc-amd64.qcow2"
-init_using_bootimage.img = "{{ local.env.HOME }}/images/boot_images/freebsd-13-amd64.qcow2"
+[system-imaging.images.freebsd-13-x86_64]
+system_label = "x86_64"
 
-# Used by: qemu.guest_init_using_cloudinit
-init_using_cloudinit.url = "https://refenv.fra1.digitaloceanspaces.com/freebsd13-ufs-ksrc.qcow2"
-init_using_cloudinit.img = "{{ local.env.HOME}}/images/cloudinit/freebsd13-ufs-ksrc.qcow2"
-init_using_cloudinit.meta = "{{ resources.auxiliary['qemu.cloudinit-freebsd-meta'] }}"
-init_using_cloudinit.user = "{{ resources.auxiliary['qemu.cloudinit-freebsd-user'] }}"
-#init_using_cloudinit.pubkey = "keys/guest_key.pub"
+cloud.url = "https://refenv.fra1.digitaloceanspaces.com/freebsd13-ufs-ksrc.qcow2"
+cloud.path = "{{ local.env.HOME}}/images/cloudinit/freebsd13-ufs-ksrc.qcow2"
+cloud.metadata_path = "{{ resources.auxiliary['cloudinit-freebsd-meta'] }}"
+cloud.userdata_path = "{{ resources.auxiliary['cloudinit-freebsd-user'] }}"
+
+disk.url = "https://refenv.fra1.digitaloceanspaces.com/boot_images/freebsd-13.1-ksrc-amd64.qcow2"
+disk.path = "{{ local.env.HOME }}/images/boot_images/freebsd-13-amd64.qcow2"
+
+#pubkey = "keys/guest_key.pub"
 
 [[devices]]
 uri = "/dev/nvme0ns1"

--- a/cijoe/configs/freebsd-14.toml
+++ b/cijoe/configs/freebsd-14.toml
@@ -26,14 +26,18 @@ tag = "v8.0.0"
 prefix = "{{ local.env.HOME }}/opt/qemu"
 
 [qemu]
-#system_bin = "{{ local.env.HOME }}/opt/qemu/bin/qemu-system-x86_64"
-system_bin = "/opt/qemu/bin/qemu-system-x86_64"
 img_bin = "qemu-img"
 default_guest = "freebsd_14"
+default_systemimage = "freebsd-14-x86_64"
+
+[qemu.systems.x86_64]
+#bin = "{{ local.env.HOME }}/opt/qemu/bin/qemu-system-x86_64"
+bin = "/opt/qemu/bin/qemu-system-x86_64"
 
 # Used by: qemu.guest_start.py and qemu.guest_kill.py
 [qemu.guests.freebsd_14]
 path = "{{ local.env.HOME }}/guests/freebsd-14-amd64"
+system_label = "x86_64"
 
 # Keyword arguments: joined onto the form: "-cpu host -smp 4 -m 4" etc.
 system_args.kwa = {cpu = "host", smp = 4, m = "12G", accel = "kvm"}
@@ -48,16 +52,18 @@ system_args.raw = """\
 system_args.tcp_forward = {host = 4200, guest = 22}
 #system_args.host_share = "{{ local.env.HOME }}/git"
 
-# Used by: qemu.guest_init_using_bootimage.py
-init_using_bootimage.url = "https://refenv.fra1.digitaloceanspaces.com/boot_images/freebsd-14.1-ksrc-amd64.qcow2"
-init_using_bootimage.img = "{{ local.env.HOME }}/images/boot_images/freebsd-14.1-ksrc-amd64.qcow2"
+[system-imaging.images.freebsd-14-x86_64]
+system_label = "x86_64"
 
-# Used by: qemu.guest_init_using_cloudinit
-init_using_cloudinit.url = "https://refenv.fra1.digitaloceanspaces.com/boot_images/freebsd-14.1-ksrc-amd64.qcow2"
-init_using_cloudinit.img = "{{ local.env.HOME}}/images/cloudinit/freebsd-14.1-ksrc-amd64.qcow2"
-init_using_cloudinit.meta = "{{ resources.auxiliary['qemu.cloudinit-freebsd-meta'] }}"
-init_using_cloudinit.user = "{{ resources.auxiliary['qemu.cloudinit-freebsd-user'] }}"
-#init_using_cloudinit.pubkey = "keys/guest_key.pub"
+cloud.url = "https://refenv.fra1.digitaloceanspaces.com/boot_images/freebsd-14.1-ksrc-amd64.qcow2"
+cloud.path = "{{ local.env.HOME}}/images/cloudinit/freebsd-14.1-ksrc-amd64.qcow2"
+cloud.metadata_path = "{{ resources.auxiliary['cloudinit-freebsd-meta'] }}"
+cloud.userdata_path = "{{ resources.auxiliary['cloudinit-freebsd-user'] }}"
+
+disk.url = "https://refenv.fra1.digitaloceanspaces.com/boot_images/freebsd-14.1-ksrc-amd64.qcow2"
+disk.path = "{{ local.env.HOME }}/images/boot_images/freebsd-14.1-ksrc-amd64.qcow2"
+
+#pubkey = "keys/guest_key.pub"
 
 [[devices]]
 uri = "/dev/nvme0ns1"

--- a/cijoe/configs/perf-lat-freebsd.toml
+++ b/cijoe/configs/perf-lat-freebsd.toml
@@ -76,3 +76,7 @@ pcie = "0000:03:00.0"
 os = "0n1"
 sn = "PHBT718003QR016D"
 label = "INTELM1016G"
+
+[qemu]
+default_guest = ""
+default_systemimage = ""

--- a/cijoe/configs/perf-lat-linux.toml
+++ b/cijoe/configs/perf-lat-linux.toml
@@ -91,3 +91,7 @@ pcie = "0000:03:00.0"
 os = "0n1"
 sn = "PHBT718003QR016D"
 label = "INTELM1016G"
+
+[qemu]
+default_guest = ""
+default_systemimage = ""

--- a/cijoe/configs/perf-lat-windows.toml
+++ b/cijoe/configs/perf-lat-windows.toml
@@ -53,3 +53,7 @@ pcie = "0000:03:00.0"
 os = "0n1"
 sn = "PHBT718003QR016D"
 label = "INTELM1016G"
+
+[qemu]
+default_guest = ""
+default_systemimage = ""

--- a/cijoe/configs/verify-phys-linux.toml
+++ b/cijoe/configs/verify-phys-linux.toml
@@ -106,3 +106,7 @@ uri = "0000:43:00.0"
 nsid = 1
 labels = [ "dev", "pcie", "nvm", "nosgl" ]
 driver_attachment = "userspace"
+
+[qemu]
+default_guest = ""
+default_systemimage = ""

--- a/cijoe/configs/verify-phys-macos.toml
+++ b/cijoe/configs/verify-phys-macos.toml
@@ -58,3 +58,7 @@ uri = "2GB"
 nsid = 1
 labels = [ "dev", "bdev", "nvm", "ramdisk", "scc" ]
 driver_attachment = "kernel"
+
+[qemu]
+default_guest = ""
+default_systemimage = ""

--- a/cijoe/scripts/bdevperf.py
+++ b/cijoe/scripts/bdevperf.py
@@ -8,17 +8,26 @@ import logging as log
 import os
 import shutil
 import traceback
+from argparse import ArgumentParser
 from itertools import product
 from pathlib import Path
 
 
-def main(args, cijoe, step):
-    repetitions = step.get("with", {}).get("repetitions", 3)
-    iosizes = step.get("with", {}).get("iosizes", ["4K"])
-    iodepths = step.get("with", {}).get("iodepths", [1, 2, 4, 8])
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--iosizes", type=str, default=[], nargs="+")
+    parser.add_argument("--iodepths", type=int, default=[], nargs="+")
+    parser.add_argument("--ndevices", type=int, default=1)
+    parser.add_argument("--bdev_confs", type=str, default="/tmp")
 
-    ndevices = str(step.get("with", {}).get("ndevices", "1"))
-    bdev_confs = step.get("with", {}).get("bdev_confs", "/tmp")
+
+def main(args, cijoe):
+    repetitions = args.repetitions
+    iosizes = args.iosizes or ["4K"]
+    iodepths = args.iodepths or [1, 2, 4, 8]
+
+    ndevices = args.ndevices
+    bdev_confs = args.bdev_confs
 
     iopaths = {
         "io_uring_cmd-bdev_xnvme": {

--- a/cijoe/scripts/bdevperf.py
+++ b/cijoe/scripts/bdevperf.py
@@ -4,7 +4,6 @@
 
     Toggling the "conserve_cpu" flag for 'bdev_xnvme'
 """
-import json
 import logging as log
 import os
 import shutil

--- a/cijoe/scripts/bench_plotter.py
+++ b/cijoe/scripts/bench_plotter.py
@@ -26,6 +26,7 @@ import json
 import logging as log
 import os
 import traceback
+from argparse import ArgumentParser
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -34,25 +35,33 @@ from plotter import (
     PLOT_SCALE,
     data_as_a_function_of,
     draw_bar_plot,
-    plot_attributes_from_step,
+    plot_attributes_from_args,
 )
 
 
-def create_plots(args, cijoe, step):
-    search = step.get("with", {}).get("path", args.output)
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--path", type=Path, default=None)
+    parser.add_argument("--tool", choices=["bdevperf", "fio"], default="fio")
+    parser.add_argument("--limits", type=str, default="plot-limits.yaml")
+    parser.add_argument("--legends", type=str, default="plot-legends.yaml")
+    parser.add_argument("--styles", type=str, default="plot-styles.yaml")
+
+
+def create_plots(args, cijoe):
+    search = args.path or args.output
     if not search:
         return errno.EINVAL
     artifacts = args.output / "artifacts"
     os.makedirs(artifacts, exist_ok=True)
 
-    tool = step.get("with", {}).get("tool", "fio")
+    tool = args.tool
     search_for = OUTPUT_NORMALIZED_FILENAME
 
     path = next(Path(search).rglob(search_for))
     with path.open() as jfd:
         data = json.load(jfd)
 
-    plot_attributes = plot_attributes_from_step(step)
+    plot_attributes = plot_attributes_from_args(args)
 
     x = "iodepth"
 
@@ -104,9 +113,9 @@ def create_plots(args, cijoe, step):
     return 0
 
 
-def main(args, cijoe, step):
+def main(args, cijoe):
     try:
-        err = create_plots(args, cijoe, step)
+        err = create_plots(args, cijoe)
         if err:
             return err
     except Exception as exc:

--- a/cijoe/scripts/bench_reporter.py
+++ b/cijoe/scripts/bench_reporter.py
@@ -5,14 +5,10 @@ Produce a report
 
 Create it for the current results or overwrite via step-args.
 
-Step Args
----------
-
-step.with.xnvme_source:  path to xNVMe source (default: config.options.repository.path)
-
 Retargetable: True
 ------------------
 """
+from argparse import ArgumentParser
 from pathlib import Path
 
 import jinja2
@@ -25,16 +21,23 @@ from reporter import (
 )
 
 
-def main(args, cijoe, step):
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--templates", type=Path, default=Path.cwd() / "templates" / "perf_report"
+    )
+    parser.add_argument("--path", type=str, default=None)
+    parser.add_argument("--report_title", type=str, default="xNVMe")
+    parser.add_argument("--report_subtitle", type=str, default="Benchmark Report")
+
+
+def main(args, cijoe):
     """Primary entry-point"""
-    templates_path = Path(
-        step.get("with", {}).get("templates", Path.cwd() / "templates" / "perf_report")
-    ).resolve()
-    search_path = Path(step.get("with", {}).get("path", cijoe.output_path)).resolve()
+    templates_path = args.templates.resolve()
+    search_path = Path(args.path or cijoe.output_path).resolve()
     artifacts = search_path / "artifacts"
 
-    title = step.get("with", {}).get("report_title", "xNVMe")
-    subtitle = step.get("with", {}).get("report_subtitle", "Benchmark Report")
+    title = args.report_title
+    subtitle = args.report_subtitle
 
     report_path = cijoe.output_path / "artifacts" / "perf_report"
     report_path.mkdir(parents=False, exist_ok=True)

--- a/cijoe/scripts/benchmark_normalize.py
+++ b/cijoe/scripts/benchmark_normalize.py
@@ -25,15 +25,11 @@ import errno
 import hashlib
 import json
 import logging as log
-import os
-import pprint
 import re
 import traceback
 from argparse import ArgumentParser
 from pathlib import Path
 
-import matplotlib.pyplot as plt
-import numpy as np
 from cijoe.core.analyser import to_base_unit
 
 

--- a/cijoe/scripts/benchmark_normalize.py
+++ b/cijoe/scripts/benchmark_normalize.py
@@ -29,11 +29,18 @@ import os
 import pprint
 import re
 import traceback
+from argparse import ArgumentParser
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
 from cijoe.core.analyser import to_base_unit
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--path", type=Path, default=None)
+    parser.add_argument("--tool", choices=["bdevperf", "fio"], default="fio")
+
 
 JSON_DUMP = {"indent": 4}
 
@@ -56,7 +63,7 @@ TOTAL_PERF_LINE_REGEX = r"Total\s+\:\s+(?P<iops>\d+\.\d+)\s+(?P<bwps>\d+\.\d+)\s
 LINUXPERF_LINE_REGEX = r"\s*(?P<cpu>\d+\.\d+)%.*bdev_.*_poll\n"
 
 
-def extract_bdevperf(args, cijoe, step):
+def extract_bdevperf(args):
     """
     Traverse 'args.output' for 'bdevperf-output_*.txt' files, and create:
 
@@ -65,7 +72,7 @@ def extract_bdevperf(args, cijoe, step):
       JSON-documents with the file.stem as key.
     """
 
-    search = step.get("with", {}).get("path", args.output)
+    search = args.path or args.output
     if not search:
         return errno.EINVAL
 
@@ -174,7 +181,7 @@ def dict_from_fio_output_file(fpath: Path) -> dict:
         return {}
 
 
-def extract(args, cijoe, step):
+def extract(args):
     """
     Traverse 'args.output' for 'fio-output_*.txt' files, and create:
 
@@ -183,7 +190,7 @@ def extract(args, cijoe, step):
       JSON-documents with the file.stem as key.
     """
 
-    search = step.get("with", {}).get("path", args.output)
+    search = args.path or args.output
     if not search:
         return errno.EINVAL
 
@@ -206,7 +213,7 @@ def extract(args, cijoe, step):
     return 0
 
 
-def normalize(args, cijoe, step):
+def normalize(args):
     """Transform the "compound" fio output into series of 'normalized' data"""
 
     def contextualize(fio_output: dict, stem) -> dict:
@@ -288,9 +295,9 @@ def normalize(args, cijoe, step):
     return 0
 
 
-def main(args, cijoe, step):
+def main(args, cijoe):
     try:
-        tool = step.get("with", {}).get("tool", "fio")
+        tool = args.tool
         if tool == "fio":
             funcs = [extract, normalize]
         elif tool == "bdevperf":
@@ -300,7 +307,7 @@ def main(args, cijoe, step):
             return errno.EINVAL
 
         for func in funcs:
-            err = func(args, cijoe, step)
+            err = func(args)
             if err:
                 return err
     except Exception as exc:

--- a/cijoe/scripts/fio_latency.py
+++ b/cijoe/scripts/fio_latency.py
@@ -215,18 +215,12 @@ class IOURingCmdEngine(KernelEngine):
 @dataclass
 class BdevExternalPreloader(ExternalPreloader):
     def extra_args(self) -> Dict[str, str]:
-        spdk_json_conf = (
-            self.cijoe.config.options.get("spdk", {})
-            .get("build", {})
-            .get("spdk_json_conf")
-        )
+        spdk_json_conf = self.cijoe.getconf("spdk.build.spdk_json_conf")
         return {"--spdk_json_conf": f"{spdk_json_conf}"}
 
     @property
     def filename(self) -> str:
-        return (
-            self.cijoe.config.options.get("spdk", {}).get("build", {}).get("filename")
-        )
+        return self.cijoe.getconf("spdk.build.filename")
 
 
 def determine_engine(
@@ -337,16 +331,16 @@ class FIO:
 
 
 def main(args, cijoe: Cijoe, step: Dict[str, Any]):
-    fio_bin = cijoe.config.options.get("fio", {}).get("bin")
+    fio_bin = cijoe.getconf("fio.bin")
 
     runs_aux_path = step.get("with", {}).get("runs", None)
     if not runs_aux_path:
         log.error("Missing path to auxiliary file describing the runs")
     runs = dict_from_yamlfile(Path(runs_aux_path))["runs"]
 
-    io_engines: CijoeEngines = cijoe.config.options.get("fio", {}).get("engines")
-    devices: List[Device] = list(determine_devices(cijoe.config.options.get("devices")))
-    os_name = cijoe.config.options.get("os", {}).get("name", "")
+    io_engines: CijoeEngines = cijoe.getconf("fio.engines")
+    devices: List[Device] = list(determine_devices(cijoe.getconf("devices")))
+    os_name = cijoe.getconf("os.name", "")
 
     artifacts = Path(args.output) / "artifacts"
     os.makedirs(str(artifacts), exist_ok=True)

--- a/cijoe/scripts/fio_latency.py
+++ b/cijoe/scripts/fio_latency.py
@@ -5,7 +5,6 @@
     Will either keep blocksize or io depth size variable.
 
 """
-import ast
 import logging as log
 import os
 import shutil
@@ -15,7 +14,7 @@ from dataclasses import dataclass
 from enum import Enum
 from itertools import product
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Dict, Iterator, List
 
 from cijoe.core.command import Cijoe
 from cijoe.core.resources import dict_from_yamlfile

--- a/cijoe/scripts/fio_latency.py
+++ b/cijoe/scripts/fio_latency.py
@@ -10,6 +10,7 @@ import logging as log
 import os
 import shutil
 import traceback
+from argparse import ArgumentParser
 from dataclasses import dataclass
 from enum import Enum
 from itertools import product
@@ -24,6 +25,15 @@ LATENCY_TEST_ROOT_DIR: Path = Path("/tmp/")
 
 CijoeEngines = Dict[str, Dict[str, str]]
 CijoeDevices = List[Dict[str, str | int | List[str]]]
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--runs",
+        type=Path,
+        default=None,
+        help="Path to a yaml file, describing the iodepths, iosizes and runs for the latency benchmark",
+    )
 
 
 @dataclass
@@ -330,13 +340,12 @@ class FIO:
         return self.engine.binary(self.bin)
 
 
-def main(args, cijoe: Cijoe, step: Dict[str, Any]):
+def main(args, cijoe: Cijoe):
     fio_bin = cijoe.getconf("fio.bin")
 
-    runs_aux_path = step.get("with", {}).get("runs", None)
-    if not runs_aux_path:
+    if not args.runs:
         log.error("Missing path to auxiliary file describing the runs")
-    runs = dict_from_yamlfile(Path(runs_aux_path))["runs"]
+    runs = dict_from_yamlfile(Path(args.runs))["runs"]
 
     io_engines: CijoeEngines = cijoe.getconf("fio.engines")
     devices: List[Device] = list(determine_devices(cijoe.getconf("devices")))

--- a/cijoe/scripts/fio_prep.py
+++ b/cijoe/scripts/fio_prep.py
@@ -12,7 +12,7 @@ Retargetable: True
 """
 
 
-def main(args, cijoe, step):
+def main(args, cijoe):
     """Configure, build and install fio in 'config.options.fio.build.prefix'"""
 
     repos = cijoe.getconf("fio.repository", {})

--- a/cijoe/scripts/fio_prep.py
+++ b/cijoe/scripts/fio_prep.py
@@ -15,11 +15,11 @@ Retargetable: True
 def main(args, cijoe, step):
     """Configure, build and install fio in 'config.options.fio.build.prefix'"""
 
-    repos = cijoe.config.options.get("fio", {}).get("repository", {})
+    repos = cijoe.getconf("fio.repository", {})
     if not repos:
         return 1
 
-    os_name = cijoe.config.options.get("os", {}).get("name", "")
+    os_name = cijoe.getconf("os.name", "")
 
     if os_name == "windows":
         commands = fio_commands_windows(repos)
@@ -35,8 +35,8 @@ def main(args, cijoe, step):
 
 
 def fio_commands(cijoe, repos):
-    shell = cijoe.config.options.get("cijoe", {}).get("run", {}).get("shell", "sh")
-    os_name = cijoe.config.options.get("os", {}).get("name", "")
+    shell = cijoe.getconf("cijoe.run.shell", "sh")
+    os_name = cijoe.getconf("os.name", "")
 
     make = "gmake" if shell == "csh" or os_name == "macos" else "make"
 
@@ -47,7 +47,7 @@ def fio_commands(cijoe, repos):
         (f"{make} clean", repos["path"]),
     ]
 
-    prefix = cijoe.config.options.get("fio", {}).get("build", {}).get("prefix", {})
+    prefix = cijoe.getconf("fio.build.prefix", {})
     if prefix:
         commands += [
             (f"./configure --prefix={prefix}", repos["path"]),

--- a/cijoe/scripts/freebsd_sysinfo.py
+++ b/cijoe/scripts/freebsd_sysinfo.py
@@ -1,7 +1,7 @@
 import logging as log
 
 
-def main(args, cijoe, step):
+def main(args, cijoe):
     commands = [
         "sysctl -a hw",
         "(dmesg | grep memory) || true",

--- a/cijoe/scripts/git_sync.py
+++ b/cijoe/scripts/git_sync.py
@@ -21,16 +21,27 @@ With the above, then git is utilized for syncing, and the cijoe-scripting takes
 care of the need to switch branch remotely.
 """
 
+import logging as log
+from argparse import ArgumentParser
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--upstream", type=str, required=True)
+    parser.add_argument("--branch", type=str, required=True)
+    parser.add_argument("--remote_alias", type=str, required=True)
+    parser.add_argument("--local_path", type=str, required=True)
+    parser.add_argument("--remote_path", type=str, required=True)
+
 
 def git_remote_from_config(cijoe, remote_path):
     """Returns git-remote URI using configuration cijoe.transport.ssh"""
 
-    hostname = cijoe.getconf("cijoe.transport.ssh.hostname", {})
+    hostname = cijoe.getconf("cijoe.transport.ssh.hostname", None)
     if not hostname:
         return None
 
-    username = cijoe.getconf("cijoe.transport.ssh.username", {})
-    port = cijoe.getconf("cijoe.transport.ssh.port", {})
+    username = cijoe.getconf("cijoe.transport.ssh.username", None)
+    port = cijoe.getconf("cijoe.transport.ssh.port", None)
 
     remote = "ssh://"
     if username:
@@ -43,18 +54,22 @@ def git_remote_from_config(cijoe, remote_path):
     return remote
 
 
-def main(args, cijoe, step):
+def main(args, cijoe):
     """Entry point"""
 
-    repos = step.get("with", {}).get("repository", {})
+    if any(
+        arg not in args
+        for arg in ["upstream", "branch", "remote_alias", "local_path", "remote_path"]
+    ):
+        log.error("missing script arguments")
 
-    local_path = repos.get("path", {}).get("local", "")
+    local_path = args.local_path
 
-    upstream = repos.get("upstream", "")
-    branch = repos.get("branch", "")
+    upstream = args.upstream
+    branch = args.branch
 
-    remote_path = repos.get("path", {}).get("remote", "")
-    remote_alias = repos.get("remote_alias", "")
+    remote_path = args.remote_path
+    remote_alias = args.remote_alias
     remote_url = git_remote_from_config(cijoe, remote_path)
     if not remote_url:
         return 1

--- a/cijoe/scripts/git_sync.py
+++ b/cijoe/scripts/git_sync.py
@@ -25,27 +25,12 @@ care of the need to switch branch remotely.
 def git_remote_from_config(cijoe, remote_path):
     """Returns git-remote URI using configuration cijoe.transport.ssh"""
 
-    hostname = (
-        cijoe.config.options.get("cijoe", {})
-        .get("transport", {})
-        .get("ssh", {})
-        .get("hostname", {})
-    )
+    hostname = cijoe.getconf("cijoe.transport.ssh.hostname", {})
     if not hostname:
         return None
 
-    username = (
-        cijoe.config.options.get("cijoe", {})
-        .get("transport", {})
-        .get("ssh", {})
-        .get("username", {})
-    )
-    port = (
-        cijoe.config.options.get("cijoe", {})
-        .get("transport", {})
-        .get("ssh", {})
-        .get("port", {})
-    )
+    username = cijoe.getconf("cijoe.transport.ssh.username", {})
+    port = cijoe.getconf("cijoe.transport.ssh.port", {})
 
     remote = "ssh://"
     if username:

--- a/cijoe/scripts/latency_plotter.py
+++ b/cijoe/scripts/latency_plotter.py
@@ -21,6 +21,7 @@ import json
 import logging as log
 import os
 import traceback
+from argparse import ArgumentParser
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -29,12 +30,19 @@ from plotter import (
     PLOT_SCALE,
     data_as_a_function_of,
     draw_bar_plot,
-    plot_attributes_from_step,
+    plot_attributes_from_args,
 )
 
 
-def create_plots(args, cijoe, step):
-    search = step.get("with", {}).get("path", args.output)
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--path", type=str, default=None)
+    parser.add_argument("--limits", type=str, default="plot-limits.yaml")
+    parser.add_argument("--legends", type=str, default="plot-legends.yaml")
+    parser.add_argument("--styles", type=str, default="plot-styles.yaml")
+
+
+def create_plots(args):
+    search = args.path or args.output
     if not search:
         return errno.EINVAL
     artifacts = args.output / "artifacts"
@@ -45,7 +53,7 @@ def create_plots(args, cijoe, step):
     with path.open() as jfd:
         data = json.load(jfd)
 
-    plot_attributes = plot_attributes_from_step(step)
+    plot_attributes = plot_attributes_from_args(args)
 
     y = "lat"
 
@@ -112,9 +120,9 @@ def create_plots(args, cijoe, step):
     return 0
 
 
-def main(args, cijoe, step):
+def main(args, cijoe):
     try:
-        err = create_plots(args, cijoe, step)
+        err = create_plots(args)
         if err:
             return err
     except Exception as exc:

--- a/cijoe/scripts/latency_reporter.py
+++ b/cijoe/scripts/latency_reporter.py
@@ -5,17 +5,13 @@ Produce a latency report
 
 Create it for the current results or overwrite via step-args.
 
-Step Args
----------
-
-step.with.xnvme_source:  path to xNVMe source (default: config.options.repository.path)
-
 Retargetable: True
 ------------------
 """
 import errno
 import logging as log
 import re
+from argparse import ArgumentParser
 from collections import defaultdict
 from pathlib import Path
 
@@ -32,17 +28,30 @@ from reporter import (
 PLOT_PATH_REGEX = r".*_GROUP=(?P<group>.+)_TYPE=(?P<type>.+)\.png"
 
 
-def main(args, cijoe, step):
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--runs",
+        type=Path,
+        default=None,
+        help="Path to a yaml file, describing the iodepths, iosizes and runs for the latency benchmark",
+    )
+    parser.add_argument(
+        "--templates", type=Path, default=Path.cwd() / "templates" / "perf_report"
+    )
+    parser.add_argument("--path", type=str, default=None)
+    parser.add_argument("--report_title", type=str, default="xNVMe")
+    parser.add_argument("--report_subtitle", type=str, default="Latency Report")
+
+
+def main(args, cijoe):
     """Primary entry-point"""
 
-    templates_path = Path(
-        step.get("with", {}).get("templates", Path.cwd() / "templates" / "perf_report")
-    ).resolve()
-    search_path = Path(step.get("with", {}).get("path", cijoe.output_path)).resolve()
+    templates_path = args.templates.resolve()
+    search_path = Path(args.path or cijoe.output_path).resolve()
     artifacts = search_path / "artifacts"
 
-    title = step.get("with", {}).get("report_title", "xNVMe")
-    subtitle = step.get("with", {}).get("report_subtitle", "Latency Report")
+    title = args.report_title
+    subtitle = args.report_subtitle
 
     report_path = cijoe.output_path / "artifacts" / "perf_report"
     report_path.mkdir(parents=False, exist_ok=True)
@@ -63,10 +72,10 @@ def main(args, cijoe, step):
     # info for methodology section
     ioengines = cijoe.getconf("fio.engines", {})
 
-    runs_aux_path = step.get("with", {}).get("runs", None)
-    if not runs_aux_path:
+    if not args.runs:
         log.error("Missing path to auxiliary file describing the runs")
-    runs = dict_from_yamlfile(Path(runs_aux_path))
+    runs = dict_from_yamlfile(Path(args.runs))
+
     fio = {
         "iosizes": runs["iosizes"],
         "iodepths": runs["iodepths"],

--- a/cijoe/scripts/latency_reporter.py
+++ b/cijoe/scripts/latency_reporter.py
@@ -61,7 +61,7 @@ def main(args, cijoe, step):
     template_env = jinja2.Environment(loader=template_loader)
 
     # info for methodology section
-    ioengines = cijoe.config.options.get("fio", {}).get("engines", {})
+    ioengines = cijoe.getconf("fio.engines", {})
 
     runs_aux_path = step.get("with", {}).get("runs", None)
     if not runs_aux_path:

--- a/cijoe/scripts/liburing_build.py
+++ b/cijoe/scripts/liburing_build.py
@@ -8,7 +8,6 @@ Retargetable: True
 """
 import errno
 from argparse import ArgumentParser
-from pathlib import Path
 
 
 def add_args(parser: ArgumentParser):

--- a/cijoe/scripts/liburing_build.py
+++ b/cijoe/scripts/liburing_build.py
@@ -16,12 +16,8 @@ from pathlib import Path
 def main(args, cijoe, step):
     """Build liburing"""
 
-    conf = cijoe.config.options.get("liburing", None)
-    if not conf:
-        return errno.EINVAL
-
     liburing_source = step.get("with", {}).get(
-        "liburing_source", conf["repository"]["path"]
+        "liburing_source", cijoe.getconf("liburing.repository.path", None)
     )
 
     commands = [

--- a/cijoe/scripts/liburing_build.py
+++ b/cijoe/scripts/liburing_build.py
@@ -3,22 +3,26 @@
 Build liburing from source
 ==========================
 
-Step Args
----------
-
 Retargetable: True
 ------------------
 """
 import errno
+from argparse import ArgumentParser
 from pathlib import Path
 
 
-def main(args, cijoe, step):
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--liburing_source", type=str, default=None)
+
+
+def main(args, cijoe):
     """Build liburing"""
 
-    liburing_source = step.get("with", {}).get(
-        "liburing_source", cijoe.getconf("liburing.repository.path", None)
+    liburing_source = args.liburing_source or cijoe.getconf(
+        "liburing.repository.path", None
     )
+    if not liburing_source:
+        return errno.EINVAL
 
     commands = [
         "unlink /usr/lib/liburing.so || true",

--- a/cijoe/scripts/linux_kdebs_build_tweaked.py
+++ b/cijoe/scripts/linux_kdebs_build_tweaked.py
@@ -11,26 +11,36 @@ Retargetable: False
 
 It is intended to be run "locally" since, currently the collection of the generated
 .debs are not retrieved via cijoe.get(), doing so would make it retargetable.
-
-Worklet arguments
------------------
-
-with.localversion
 """
 
+from argparse import ArgumentParser, _StoreAction
 from pathlib import Path
 
 
-def main(args, cijoe, step):
+def add_args(parser: ArgumentParser):
+    class StringToBoolAction(_StoreAction):
+        def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, self.dest, values == "true")
+
+    parser.add_argument(
+        "--run_local",
+        choices=["true", "false"],
+        default=True,
+        action=StringToBoolAction,
+    )
+    parser.add_argument("--localversion", type=int, default=0)
+
+
+def main(args, cijoe):
     """Configure, build and collect the build-artifacts"""
 
-    repos = Path(cijoe.config.options["linux"]["repository"]["path"]).resolve()
+    repos = Path(cijoe.getconf("linux.repository.path")).resolve()
     err, _ = cijoe.run(f"[ -d {repos} ]")
     if err:
         return err
 
-    localversion = step.get("with", {}).get("localversion", "custom")
-    run_local = step.get("with", {}).get("run_local", True)
+    localversion = args.localversion
+    run_local = args.run_local
     run = cijoe.run_local if run_local else cijoe.run
 
     commands = [

--- a/cijoe/scripts/linux_nvme_prep.py
+++ b/cijoe/scripts/linux_nvme_prep.py
@@ -5,7 +5,7 @@ Load the NVMe driver with poll-queues and setup misc. block-device options
 from pathlib import Path
 
 
-def main(args, cijoe, step):
+def main(args, cijoe):
     err, _ = cijoe.run("modprobe -r nvme && modprobe nvme poll_queues=1")
     if err:
         return err

--- a/cijoe/scripts/linux_nvme_prep.py
+++ b/cijoe/scripts/linux_nvme_prep.py
@@ -13,7 +13,7 @@ def main(args, cijoe, step):
     for path in sorted(
         [
             Path(dev["uri"]).name
-            for dev in cijoe.config.options.get("devices")
+            for dev in cijoe.getconf("devices")
             if "bdev" in dev["labels"]
         ]
     ):

--- a/cijoe/scripts/linux_setup_hugetlbfs.py
+++ b/cijoe/scripts/linux_setup_hugetlbfs.py
@@ -21,10 +21,8 @@ import logging as log
 def main(args, cijoe, step):
     """Setup hugetlbfs"""
 
-    nr_hugepages = cijoe.config.options.get("hugetlbfs", {}).get("nr_hugepages", 128)
-    mount_point = cijoe.config.options.get("hugetlbfs", {}).get(
-        "mount_point", "/mnt/huge"
-    )
+    nr_hugepages = cijoe.getconf("hugetlbfs.nr_hugepages", 128)
+    mount_point = cijoe.getconf("hugetlbfs.mount_point", "/mnt/huge")
 
     commands = [
         f"echo {nr_hugepages} > /proc/sys/vm/nr_hugepages",

--- a/cijoe/scripts/linux_setup_hugetlbfs.py
+++ b/cijoe/scripts/linux_setup_hugetlbfs.py
@@ -18,7 +18,7 @@ import errno
 import logging as log
 
 
-def main(args, cijoe, step):
+def main(args, cijoe):
     """Setup hugetlbfs"""
 
     nr_hugepages = cijoe.getconf("hugetlbfs.nr_hugepages", 128)

--- a/cijoe/scripts/linux_setup_hugetlbfs.py
+++ b/cijoe/scripts/linux_setup_hugetlbfs.py
@@ -14,7 +14,6 @@ Retargetable: True
 ------------------
 """
 
-import errno
 import logging as log
 
 

--- a/cijoe/scripts/macvfn_build_and_install.py
+++ b/cijoe/scripts/macvfn_build_and_install.py
@@ -15,7 +15,7 @@ import errno
 import logging as log
 
 
-def main(args, cijoe, step):
+def main(args, cijoe):
     """Build and install MacVFN"""
 
     username = cijoe.getconf("cijoe.transport.nonroot", None)

--- a/cijoe/scripts/macvfn_build_and_install.py
+++ b/cijoe/scripts/macvfn_build_and_install.py
@@ -24,13 +24,12 @@ def main(args, cijoe, step):
             "Missing non-root user transport from config. MacVFN must be installed without root access."
         )
 
-    conf = cijoe.config.options.get("macvfn", {})
-    macvfn_source = conf.get("repository", {}).get("path", None)
+    macvfn_source = cijoe.getconf("macvfn.repository.path", None)
     if not macvfn_source:
         log.error("Missing path to MacVFN source.")
         return errno.EINVAL
 
-    os_name = cijoe.config.options.get("os", {}).get("name", "")
+    os_name = cijoe.getconf("os.name", "")
     if os_name != "macos":
         log.error(f"OS requirement: MacOS - was {os_name}")
         return errno.EINVAL

--- a/cijoe/scripts/plotter.py
+++ b/cijoe/scripts/plotter.py
@@ -3,8 +3,6 @@
 Helper functions for plotting benchmark graphs
 ==============================================
 
-
-
 .. note::
     This uses matplotlib and numpy for plotting
 """
@@ -50,12 +48,12 @@ def data_as_a_function_of(data, x="iodepth", y="iops", filter=lambda _: True) ->
     return samples
 
 
-def plot_attributes_from_step(step):
-    """Load plot-attributes using paths in step"""
+def plot_attributes_from_args(args):
+    """Load plot-attributes using paths in args"""
 
-    limits_path = Path(step.get("with", {}).get("limits", "plot-limits.yaml"))
-    legends_path = Path(step.get("with", {}).get("legends", "plot-legends.yaml"))
-    styles_path = Path(step.get("with", {}).get("styles", "plot-styles.yaml"))
+    limits_path = Path(args.limits)
+    legends_path = Path(args.legends)
+    styles_path = Path(args.styles)
 
     return {
         "limits": dict_from_yamlfile(limits_path),

--- a/cijoe/scripts/spdk_bdev_confs_generator.py
+++ b/cijoe/scripts/spdk_bdev_confs_generator.py
@@ -94,7 +94,7 @@ IOPATHS = {
 
 
 def main(args, cijoe, step):
-    duts = copy.deepcopy(cijoe.config.options.get("duts", []))
+    duts = copy.deepcopy(cijoe.getconf("duts", []))
     if not duts:
         log.error("Missing 'duts' section in CIJOE configuration file")
         return 1

--- a/cijoe/scripts/spdk_bdev_confs_generator.py
+++ b/cijoe/scripts/spdk_bdev_confs_generator.py
@@ -24,19 +24,20 @@ The files are created locally in:
 
 and then transferred to:
 
-    step.args.bdev_confs
+    args.bdev_confs
 
 By default this is "/tmp/bdev_confs"
 """
-import argparse
 import copy
 import json
 import logging as log
 import os
-import pprint
-from pathlib import Path
+from argparse import ArgumentParser
 
-from cijoe.core.resources import dict_from_yamlfile
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--bdev_confs", type=str, default="/tmp")
+
 
 IOPATHS = {
     "driver": {
@@ -93,13 +94,13 @@ IOPATHS = {
 }
 
 
-def main(args, cijoe, step):
+def main(args, cijoe):
     duts = copy.deepcopy(cijoe.getconf("duts", []))
     if not duts:
         log.error("Missing 'duts' section in CIJOE configuration file")
         return 1
 
-    bdev_confs = step.get("with", {}).get("bdev_confs", "/tmp")
+    bdev_confs = args.bdev_confs
 
     output_dir = cijoe.output_path / "artifacts" / "bdev_confs"
 

--- a/cijoe/scripts/spdk_build_modded.py
+++ b/cijoe/scripts/spdk_build_modded.py
@@ -18,15 +18,14 @@ from pathlib import Path
 def main(args, cijoe, step):
     """Build SPDK"""
 
-    spdk = cijoe.config.options.get("spdk", None)
-    if not spdk:
+    spdk_source = step.get("with", {}).get(
+        "spdk_source", cijoe.getconf("spdk.repository.path", None)
+    )
+    if not spdk_source:
         return errno.EINVAL
 
-    fio_repos = cijoe.config.options.get("fio", {}).get("repository")
-    # liburing_repos = cijoe.config.options.get("liburing", {}).get("repository")
-
-    spdk_source = step.get("with", {}).get("spdk_source", spdk["repository"]["path"])
-    spdk_prefix = spdk.get("build", {}).get("prefix", None)
+    fio_repos = cijoe.getconf("fio.repository", None)
+    spdk_prefix = cijoe.getconf("spdk.build.prefix", None)
 
     configure = " ".join(
         [

--- a/cijoe/scripts/spdk_build_modded.py
+++ b/cijoe/scripts/spdk_build_modded.py
@@ -1,26 +1,25 @@
 #!/usr/bin/env python3
 """
 Build SPDK from source
-=======================
-
-Step Args
----------
-
-step.with.spdk_source:  path to SPDK source (default: config.options.repository.path)
+======================
 
 Retargetable: True
 ------------------
 """
 import errno
-from pathlib import Path
+from argparse import ArgumentParser
 
 
-def main(args, cijoe, step):
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--spdk_source", type=str, default=None, help="path to SPDK source"
+    )
+
+
+def main(args, cijoe):
     """Build SPDK"""
 
-    spdk_source = step.get("with", {}).get(
-        "spdk_source", cijoe.getconf("spdk.repository.path", None)
-    )
+    spdk_source = args.spdk_source or cijoe.getconf("spdk.repository.path", None)
     if not spdk_source:
         return errno.EINVAL
 

--- a/cijoe/scripts/spdk_build_modded_freebsd.py
+++ b/cijoe/scripts/spdk_build_modded_freebsd.py
@@ -18,15 +18,14 @@ from pathlib import Path
 def main(args, cijoe, step):
     """Build SPDK"""
 
-    spdk = cijoe.config.options.get("spdk", None)
-    if not spdk:
+    spdk_source = step.get("with", {}).get(
+        "spdk_source", cijoe.getconf("spdk.repository.path", None)
+    )
+    if not spdk_source:
         return errno.EINVAL
 
-    fio_repos = cijoe.config.options.get("fio", {}).get("repository")
-    # liburing_repos = cijoe.config.options.get("liburing", {}).get("repository")
-
-    spdk_source = step.get("with", {}).get("spdk_source", spdk["repository"]["path"])
-    spdk_prefix = spdk.get("build", {}).get("prefix", None)
+    fio_repos = cijoe.getconf("fio.repository", None)
+    spdk_prefix = cijoe.getconf("spdk.build.prefix", None)
 
     configure = " ".join(
         [

--- a/cijoe/scripts/spdk_build_modded_freebsd.py
+++ b/cijoe/scripts/spdk_build_modded_freebsd.py
@@ -1,26 +1,25 @@
 #!/usr/bin/env python3
 """
 Build SPDK from source
-=======================
-
-Step Args
----------
-
-step.with.spdk_source:  path to SPDK source (default: config.options.repository.path)
+======================
 
 Retargetable: True
 ------------------
 """
 import errno
-from pathlib import Path
+from argparse import ArgumentParser
 
 
-def main(args, cijoe, step):
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--spdk_source", type=str, default=None, help="path to SPDK source"
+    )
+
+
+def main(args, cijoe):
     """Build SPDK"""
 
-    spdk_source = step.get("with", {}).get(
-        "spdk_source", cijoe.getconf("spdk.repository.path", None)
-    )
+    spdk_source = args.spdk_source or cijoe.getconf("spdk.repository.path", None)
     if not spdk_source:
         return errno.EINVAL
 

--- a/cijoe/scripts/sysinfo_report.py
+++ b/cijoe/scripts/sysinfo_report.py
@@ -343,7 +343,7 @@ def read_hardware_windows(cijoe) -> HardwareSpec | int:
     return 0, (motherboard, cpu, memory, drives)
 
 
-def main(args, cijoe, step):
+def main(args, cijoe):
     operating_system = ""
     kernel = ""
     motherboard = ""

--- a/cijoe/scripts/sysinfo_report.py
+++ b/cijoe/scripts/sysinfo_report.py
@@ -354,8 +354,8 @@ def main(args, cijoe, step):
     bios = ""
     bios_version = ""
 
-    shell = cijoe.config.options.get("cijoe", {}).get("run", {}).get("shell", "sh")
-    os = cijoe.config.options.get("os", {}).get("name", "")
+    shell = cijoe.getconf("cijoe.run.shell", "sh")
+    os = cijoe.getconf("os.name", "")
 
     if os == "windows":
         err, os = read_os_windows(cijoe)

--- a/cijoe/scripts/xnvme_bindings_py_build.py
+++ b/cijoe/scripts/xnvme_bindings_py_build.py
@@ -8,7 +8,6 @@ Retargetable: True
 """
 import errno
 from argparse import ArgumentParser
-from pathlib import Path
 
 
 def add_args(parser: ArgumentParser):

--- a/cijoe/scripts/xnvme_bindings_py_build.py
+++ b/cijoe/scripts/xnvme_bindings_py_build.py
@@ -18,13 +18,13 @@ from pathlib import Path
 def main(args, cijoe, step):
     """Build xNVMe"""
 
-    conf = cijoe.config.options.get("xnvme", None)
-    if not conf:
-        return errno.EINVAL
-
     xnvme_source = Path(
-        step.get("with", {}).get("xnvme_source", conf["repository"]["path"])
+        step.get("with", {}).get(
+            "xnvme_source", cijoe.getconf("xnvme.repository.path", None)
+        )
     )
+    if not xnvme_source:
+        return errno.EINVAL
 
     commands = []
 

--- a/cijoe/scripts/xnvme_bindings_py_build.py
+++ b/cijoe/scripts/xnvme_bindings_py_build.py
@@ -3,26 +3,27 @@
 Build xNVMe bindings for Python
 ===============================
 
-Step Args
----------
-
-step.with.xnvme_source:  path to xNVMe source (default: config.options.repository.path)
-
 Retargetable: True
 ------------------
 """
 import errno
+from argparse import ArgumentParser
 from pathlib import Path
 
 
-def main(args, cijoe, step):
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--xnvme_source",
+        type=str,
+        default=None,
+        help="path to xNVMe source (default: config.xnvme.repository.path)",
+    )
+
+
+def main(args, cijoe):
     """Build xNVMe"""
 
-    xnvme_source = Path(
-        step.get("with", {}).get(
-            "xnvme_source", cijoe.getconf("xnvme.repository.path", None)
-        )
-    )
+    xnvme_source = args.xnvme_source or cijoe.getconf("xnvme.repository.path", None)
     if not xnvme_source:
         return errno.EINVAL
 

--- a/cijoe/scripts/xnvme_bindings_py_install_tgz.py
+++ b/cijoe/scripts/xnvme_bindings_py_install_tgz.py
@@ -33,7 +33,7 @@ import logging as log
 def main(args, cijoe, step):
     """Setup cijoe pipx-env with numpy and xNVMe Python bindings injected"""
 
-    osname = cijoe.config.options.get("os", {}).get("name", "")
+    osname = cijoe.getconf("os.name", "")
     if osname not in ["debian"]:
         log.info("skip python setup")
         return 0

--- a/cijoe/scripts/xnvme_bindings_py_install_tgz.py
+++ b/cijoe/scripts/xnvme_bindings_py_install_tgz.py
@@ -18,7 +18,6 @@ Retargetable: True
 ------------------
 """
 
-import errno
 import logging as log
 from argparse import ArgumentParser
 

--- a/cijoe/scripts/xnvme_bindings_py_install_tgz.py
+++ b/cijoe/scripts/xnvme_bindings_py_install_tgz.py
@@ -14,23 +14,25 @@ The xNVMe Python package will be injected into a pipx-environment named
 'cijoe', thus making cijoe, pytest, and the xNVMe library available within this
 environment.
 
-Step Arguments
---------------
-
-step.with.source: The file listed above is expected to be available in
-'step.with.source', it is also expected that 'step.with.source' is a directory
-containing the xNVMe source in extracted form. That is the content of the
-xnvme-source-tarball.
-
 Retargetable: True
 ------------------
 """
 
 import errno
 import logging as log
+from argparse import ArgumentParser
 
 
-def main(args, cijoe, step):
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--xnvme_source",
+        type=str,
+        default="/tmp/xnvme_source",
+        help="path to xNVMe source",
+    )
+
+
+def main(args, cijoe):
     """Setup cijoe pipx-env with numpy and xNVMe Python bindings injected"""
 
     osname = cijoe.getconf("os.name", "")
@@ -38,10 +40,7 @@ def main(args, cijoe, step):
         log.info("skip python setup")
         return 0
 
-    xnvme_source = step.get("with", {}).get("xnvme_source", "/tmp/xnvme_source")
-    if xnvme_source is None:
-        log.error(f"invalid step({step})")
-        return errno.EINVAL
+    xnvme_source = args.xnvme_source
 
     # NOTE: because pipx (specifically the userpath module it uses) only adds
     # PATH to files read by login-shells, then we cannot use 'pipx ensurepath'

--- a/cijoe/scripts/xnvme_bindings_py_test.py
+++ b/cijoe/scripts/xnvme_bindings_py_test.py
@@ -8,7 +8,6 @@ Retargetable: True
 """
 import errno
 from argparse import ArgumentParser
-from pathlib import Path
 
 
 def add_args(parser: ArgumentParser):

--- a/cijoe/scripts/xnvme_bindings_py_test.py
+++ b/cijoe/scripts/xnvme_bindings_py_test.py
@@ -18,13 +18,13 @@ from pathlib import Path
 def main(args, cijoe, step):
     """Test xNVMe"""
 
-    conf = cijoe.config.options.get("xnvme", None)
-    if not conf:
-        return errno.EINVAL
-
     xnvme_source = Path(
-        step.get("with", {}).get("xnvme_source", conf["repository"]["path"])
+        step.get("with", {}).get(
+            "xnvme_source", cijoe.getconf("xnvme.repository.path", None)
+        )
     )
+    if not xnvme_source:
+        return errno.EINVAL
 
     err, _ = cijoe.run("pytest test_buf.py", cwd=xnvme_source / "python" / "tests")
     if err:

--- a/cijoe/scripts/xnvme_bindings_py_test.py
+++ b/cijoe/scripts/xnvme_bindings_py_test.py
@@ -3,26 +3,27 @@
 Test xNVMe bindings for Python
 ===============================
 
-Step Args
----------
-
-step.with.xnvme_source:  path to xNVMe source (default: config.options.repository.path)
-
 Retargetable: True
 ------------------
 """
 import errno
+from argparse import ArgumentParser
 from pathlib import Path
 
 
-def main(args, cijoe, step):
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--xnvme_source",
+        type=str,
+        default=None,
+        help="path to xNVMe source (default: config.xnvme.repository.path)",
+    )
+
+
+def main(args, cijoe):
     """Test xNVMe"""
 
-    xnvme_source = Path(
-        step.get("with", {}).get(
-            "xnvme_source", cijoe.getconf("xnvme.repository.path", None)
-        )
-    )
+    xnvme_source = args.xnvme_source or cijoe.getconf("xnvme.repository.path", None)
     if not xnvme_source:
         return errno.EINVAL
 

--- a/cijoe/scripts/xnvme_build.py
+++ b/cijoe/scripts/xnvme_build.py
@@ -18,17 +18,13 @@ from pathlib import Path
 def main(args, cijoe, step):
     """Build xNVMe"""
 
-    conf = cijoe.config.options.get("xnvme", None)
-    if not conf:
-        return errno.EINVAL
-
     xnvme_source = step.get("with", {}).get(
-        "xnvme_source", conf.get("repository", {}).get("path", None)
+        "xnvme_source", cijoe.getconf("xnvme.repository.path", None)
     )
     if not xnvme_source:
         return errno.EINVAL
 
-    os_name = cijoe.config.options.get("os", {}).get("name", "")
+    os_name = cijoe.getconf("os.name", "")
 
     commands = [
         "git rev-parse --short HEAD || true",

--- a/cijoe/scripts/xnvme_build.py
+++ b/cijoe/scripts/xnvme_build.py
@@ -3,24 +3,26 @@
 Build xNVMe from source
 =======================
 
-Step Args
----------
-
-step.with.xnvme_source:  path to xNVMe source (default: config.options.repository.path)
-
 Retargetable: True
 ------------------
 """
 import errno
-from pathlib import Path
+from argparse import ArgumentParser
 
 
-def main(args, cijoe, step):
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--xnvme_source",
+        type=str,
+        default=None,
+        help="path to xNVMe source (default: config.xnvme.repository.path)",
+    )
+
+
+def main(args, cijoe):
     """Build xNVMe"""
 
-    xnvme_source = step.get("with", {}).get(
-        "xnvme_source", cijoe.getconf("xnvme.repository.path", None)
-    )
+    xnvme_source = args.xnvme_source or cijoe.getconf("xnvme.repository.path", None)
     if not xnvme_source:
         return errno.EINVAL
 

--- a/cijoe/scripts/xnvme_build_prep.py
+++ b/cijoe/scripts/xnvme_build_prep.py
@@ -29,17 +29,13 @@ from pathlib import Path
 
 
 def main(args, cijoe, step):
-    osinfo = cijoe.config.options.get("os", None)
+    osinfo = cijoe.getconf("os", None)
     if not osinfo:
         log.err("cijoe.config.options is missing 'os'")
         return errno.EINVAL
 
-    conf = cijoe.config.options.get("xnvme", None)
-    if not conf:
-        return errno.EINVAL
-
     xnvme_source = step.get("with", {}).get(
-        "xnvme_source", conf.get("repository", {}).get("path", None)
+        "xnvme_source", cijoe.getconf("xnvme.repository.path", None)
     )
     if not xnvme_source:
         return errno.EINVAL

--- a/cijoe/scripts/xnvme_build_prep.py
+++ b/cijoe/scripts/xnvme_build_prep.py
@@ -12,31 +12,30 @@ Needs an ``os`` key describing the operating system by name and version, example
       name: 'debian'
       version: 'bullseye'
 
-Step Arguments
---------------
-
-Requires a 'xnvme_source' pointing to the root of the xnvme source
-
-    with:
-      xnvme_source: '/tmp/xnvme_source'
-
 Retargetable: True
 ------------------
 """
 import errno
 import logging as log
-from pathlib import Path
+from argparse import ArgumentParser
 
 
-def main(args, cijoe, step):
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--xnvme_source",
+        type=str,
+        default=None,
+        help="path to xNVMe source (default: config.xnvme.repository.path)",
+    )
+
+
+def main(args, cijoe):
     osinfo = cijoe.getconf("os", None)
     if not osinfo:
-        log.err("cijoe.config.options is missing 'os'")
+        log.err("missing config value(os)")
         return errno.EINVAL
 
-    xnvme_source = step.get("with", {}).get(
-        "xnvme_source", cijoe.getconf("xnvme.repository.path", None)
-    )
+    xnvme_source = args.xnvme_source or cijoe.getconf("xnvme.repository.path", None)
     if not xnvme_source:
         return errno.EINVAL
 

--- a/cijoe/scripts/xnvme_clean.py
+++ b/cijoe/scripts/xnvme_clean.py
@@ -18,11 +18,11 @@ from pathlib import Path
 def main(args, cijoe, step):
     """Clean xNVMe"""
 
-    conf = cijoe.config.options.get("xnvme", None)
-    if not conf:
+    xnvme_source = step.get("with", {}).get(
+        "xnvme_source", cijoe.getconf("xnvme.repository.path", None)
+    )
+    if not xnvme_source:
         return errno.EINVAL
-
-    xnvme_source = step.get("with", {}).get("xnvme_source", conf["repository"]["path"])
 
     commands = [
         "make clean",

--- a/cijoe/scripts/xnvme_clean.py
+++ b/cijoe/scripts/xnvme_clean.py
@@ -3,24 +3,26 @@
 Clean xNVMe from source / repository
 ====================================
 
-Step Args
----------
-
-step.with.xnvme_source: path to xNVMe source (default: config.options.repository.path)
-
 Retargetable: True
 ------------------
 """
 import errno
-from pathlib import Path
+from argparse import ArgumentParser
 
 
-def main(args, cijoe, step):
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--xnvme_source",
+        type=str,
+        default=None,
+        help="path to xNVMe source (default: config.xnvme.repository.path)",
+    )
+
+
+def main(args, cijoe):
     """Clean xNVMe"""
 
-    xnvme_source = step.get("with", {}).get(
-        "xnvme_source", cijoe.getconf("xnvme.repository.path", None)
-    )
+    xnvme_source = args.xnvme_source or cijoe.getconf("xnvme.repository.path", None)
     if not xnvme_source:
         return errno.EINVAL
 

--- a/cijoe/scripts/xnvme_docgen.py
+++ b/cijoe/scripts/xnvme_docgen.py
@@ -8,7 +8,6 @@ Retargetable: True
 ------------------
 """
 
-import errno
 import logging as log
 from argparse import ArgumentParser
 from pathlib import Path

--- a/cijoe/scripts/xnvme_docgen.py
+++ b/cijoe/scripts/xnvme_docgen.py
@@ -4,28 +4,27 @@ Prepare for documentation generation
 
 Install requirements/dependencies, check binaries and library paths
 
-Step Arguments
---------------
-
-step.with.xnvme_source: The files listed above are expected to be available in
-'step.with.xnvme_source', it is also expected that 'step.with.xnvme_source' is a directory
-containing the xNVMe source in extracted form. That is the content of the
-xnvme-source-tarball.
-
 Retargetable: True
 ------------------
 """
 
 import errno
 import logging as log
+from argparse import ArgumentParser
 from pathlib import Path
 
 
-def main(args, cijoe, step):
-    xnvme_source = step.get("with", {}).get("xnvme_source", "/tmp/xnvme_source")
-    if xnvme_source is None:
-        log.error(f"invalid step({step})")
-        return errno.EINVAL
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--xnvme_source",
+        type=str,
+        default="/tmp/xnvme_source",
+        help="path to xNVMe source, expected to contain the requirements and dependencies for docgen.",
+    )
+
+
+def main(args, cijoe):
+    xnvme_source = args.xnvme_source
 
     commands = [
         "./toolbox/pkgs/docgen.sh",

--- a/cijoe/scripts/xnvme_guest_start_nvme.py
+++ b/cijoe/scripts/xnvme_guest_start_nvme.py
@@ -24,9 +24,15 @@ Retargetable: false
 """
 import errno
 import logging as log
+from argparse import ArgumentParser
 from pathlib import Path
 
 from cijoe.qemu.wrapper import Guest
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--nvme_img_root", type=str, default=None)
+    parser.add_argument("--guest_name", type=str, default=None)
 
 
 def qemu_nvme_args(nvme_img_root):
@@ -255,13 +261,18 @@ def qemu_nvme_args(nvme_img_root):
     return drives, nvme
 
 
-def main(args, cijoe, step):
+def main(args, cijoe):
     """Start a qemu guest"""
 
     drive_size = "8G"
-    guest = Guest(cijoe, cijoe.config)
+    guest_name = args.guest_name or cijoe.getconf("qemu.default_guest")
+    if not guest_name:
+        log.error("missing config value(qemu.guest_name)")
+        return 1
 
-    nvme_img_root = Path(step.get("with", {}).get("nvme_img_root", guest.guest_path))
+    guest = Guest(cijoe, cijoe.config, guest_name)
+
+    nvme_img_root = Path(args.nvme_img_root or guest.guest_path)
 
     drives, nvme_args = qemu_nvme_args(nvme_img_root)
 

--- a/cijoe/scripts/xnvme_install.py
+++ b/cijoe/scripts/xnvme_install.py
@@ -8,7 +8,6 @@ Retargetable: True
 """
 import errno
 from argparse import ArgumentParser
-from pathlib import Path
 
 
 def add_args(parser: ArgumentParser):

--- a/cijoe/scripts/xnvme_install.py
+++ b/cijoe/scripts/xnvme_install.py
@@ -16,12 +16,8 @@ from pathlib import Path
 
 
 def main(args, cijoe, step):
-    conf = cijoe.config.options.get("xnvme", None)
-    if not conf:
-        return errno.EINVAL
-
     xnvme_source = step.get("with", {}).get(
-        "xnvme_source", conf.get("repository", {}).get("path", None)
+        "xnvme_source", cijoe.getconf("xnvme.repository.path", None)
     )
     if not xnvme_source:
         return errno.EINVAL

--- a/cijoe/scripts/xnvme_install.py
+++ b/cijoe/scripts/xnvme_install.py
@@ -3,22 +3,25 @@
 Install xNVMe from previously built source
 ==========================================
 
-Step Args
----------
-
-step.with.xnvme_source:  path to xNVMe source (default: config.options.repository.path)
-
 Retargetable: True
 ------------------
 """
 import errno
+from argparse import ArgumentParser
 from pathlib import Path
 
 
-def main(args, cijoe, step):
-    xnvme_source = step.get("with", {}).get(
-        "xnvme_source", cijoe.getconf("xnvme.repository.path", None)
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--xnvme_source",
+        type=str,
+        default=None,
+        help="path to xNVMe source (default: config.xnvme.repository.path)",
     )
+
+
+def main(args, cijoe):
+    xnvme_source = args.xnvme_source or cijoe.getconf("xnvme.repository.path", None)
     if not xnvme_source:
         return errno.EINVAL
 

--- a/cijoe/scripts/xnvme_kldconfig.py
+++ b/cijoe/scripts/xnvme_kldconfig.py
@@ -10,7 +10,7 @@ Retargetable: True
 
 
 def main(args, cijoe, step):
-    osname = cijoe.config.options.get("os", {}).get("name", None)
+    osname = cijoe.getconf("os.name", None)
     if not osname:
         return 0
     if osname != "freebsd":

--- a/cijoe/scripts/xnvme_kldconfig.py
+++ b/cijoe/scripts/xnvme_kldconfig.py
@@ -8,15 +8,24 @@ Retargetable: True
 ------------------
 """
 
+from argparse import ArgumentParser
 
-def main(args, cijoe, step):
-    osname = cijoe.getconf("os.name", None)
-    if not osname:
-        return 0
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--xnvme_source",
+        type=str,
+        default="/tmp/xnvme_source",
+        help="path to xNVMe source",
+    )
+
+
+def main(args, cijoe):
+    osname = cijoe.getconf("os.name", "")
     if osname != "freebsd":
         return 0
 
-    xnvme_source = step.get("with", {}).get("xnvme_source", "/tmp/xnvme_source")
+    xnvme_source = args.xnvme_source
 
     cijoe.run(f"kldconfig -i -m -vv {xnvme_source}/subprojects/spdk/dpdk/build/kmod")
     return 0

--- a/cijoe/scripts/xnvme_source_from_tgz.py
+++ b/cijoe/scripts/xnvme_source_from_tgz.py
@@ -10,24 +10,34 @@ xNVMe GitHUB artifacts:
 Transfers the above artifacts from step.with.artifacts, to
 step.with.xnvme_sources and extracts the content of xnvme.tar.gz
 
-Step Arguments
---------------
-
-step.with.artifacts: path to where the GitHUB artifacts are located locally
-step.with.xnvme_source: path to where the GitHUB artifacts should transferred to
-
 Retargetable: True
 ------------------
 """
 
 import logging as log
+from argparse import ArgumentParser
 
 
-def main(args, cijoe, step):
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--artifacts",
+        type=str,
+        default="/tmp/artifacts",
+        help="path to where the GitHub artifacts are located locally",
+    )
+    parser.add_argument(
+        "--xnvme_source",
+        type=str,
+        default="/tmp/xnvme_source",
+        help="path to where the GitHUB artifacts should transferred to",
+    )
+
+
+def main(args, cijoe):
     """Transfer artifacts"""
 
-    artifacts = step.get("with", {}).get("artifacts", "/tmp/artifacts")
-    xnvme_source = step.get("with", {}).get("xnvme_source", "/tmp/xnvme_source")
+    artifacts = args.artifacts
+    xnvme_source = args.xnvme_source
 
     _, _ = cijoe.run(
         f'[ -d "{xnvme_source}" ] && mv "{xnvme_source}" "{xnvme_source}-$(date +%Y%m%d%H%M%S)" || true'

--- a/cijoe/tests/apps/fio_fancy.py
+++ b/cijoe/tests/apps/fio_fancy.py
@@ -101,9 +101,7 @@ def setup_ioengine(param, env, engine_name, cijoe, device, xnvme_opts, spdk_opts
     @returns env, param
     """
 
-    engine = (
-        cijoe.config.options.get("fio", {}).get("engines", {}).get(engine_name, None)
-    )
+    engine = cijoe.getconf(f"fio.engines.{engine_name}", None)
     if engine is None:
         log.error(f"fio.engine({engine_name}) not in configuration")
         return False

--- a/cijoe/tests/conftest.py
+++ b/cijoe/tests/conftest.py
@@ -30,7 +30,7 @@ from .xnvme_be_combinations import get_combinations
 def xnvme_be_opts(options=None, only_labels=[]):
     """Produce a list of "sensible" backend configurations"""
 
-    osname = pytest.cijoe_instance.config.options.get("os", {}).get("name", "linux")
+    osname = pytest.cijoe_instance.getconf("os.name", "linux")
     if osname == "debian":
         osname = "linux"
 
@@ -76,7 +76,7 @@ def xnvme_be_opts(options=None, only_labels=[]):
 def cijoe_config_get_all_devices(labels):
     """Returns the 'device-dict' from every device in 'cijoe_cfg' with the given 'label'"""
     devices = []
-    for device in pytest.cijoe_instance.config.options.get("devices", []):
+    for device in pytest.cijoe_instance.getconf("devices", []):
         if not (set(labels) - set(device["labels"])):
             devices.append(device)
 
@@ -86,7 +86,7 @@ def cijoe_config_get_all_devices(labels):
 def cijoe_config_get_device(labels):
     """Returns the 'device-dict' from 'devices' in 'cijoe_cfg' with the given 'label'"""
 
-    for device in pytest.cijoe_instance.config.options.get("devices", []):
+    for device in pytest.cijoe_instance.getconf("devices", []):
         if not (set(labels) - set(device["labels"])):
             return device
 
@@ -172,11 +172,11 @@ def xnvme_setup(labels=[], opts=[]):
 
 def fabrics_setup(cijoe):
     """Setup fabrics"""
-    xnvme_conf = cijoe.config.options.get("xnvme", None)
-    if not xnvme_conf:
+    xnvme_conf_path = cijoe.getconf("xnvme.repository.sync.remote_path", None)
+    if not xnvme_conf_path:
         return errno.EINVAL
 
-    xnvme_path = Path(xnvme_conf["repository"]["sync"]["remote_path"])
+    xnvme_path = Path(xnvme_conf_path)
     rpc = xnvme_path / "subprojects" / "spdk" / "scripts" / "rpc.py"
     ip = "127.0.0.1"
     port = "4420"

--- a/cijoe/tests/linkandload/test_xnvme_consumption.py
+++ b/cijoe/tests/linkandload/test_xnvme_consumption.py
@@ -64,9 +64,7 @@ def test_library_consumption(cijoe):
     Verify that xNVMe is consumable via dynamic loading, shared linking, static linking
     """
 
-    compiler = (
-        cijoe.config.options.get("build", {}).get("compiler", {}).get("bin", "gcc")
-    )
+    compiler = cijoe.getconf("build.compiler.bin", "gcc")
 
     usages = [
         ("shared", "loading", "pkg-config xnvme --cflags"),

--- a/cijoe/workflows/benchmark-latency.yaml
+++ b/cijoe/workflows/benchmark-latency.yaml
@@ -28,7 +28,6 @@ steps:
 - name: plot
   uses: latency_plotter
   with:
-    tool: fio
     legends: auxiliary/plot-latency-legends.yaml
     limits: auxiliary/plot-latency-limits.yaml
     styles: auxiliary/plot-styles.yaml

--- a/cijoe/workflows/bootimg-debian-bullseye-amd64.yaml
+++ b/cijoe/workflows/bootimg-debian-bullseye-amd64.yaml
@@ -11,12 +11,19 @@ doc: |
 steps:
 - name: guest_kill
   uses: qemu.guest_kill
+  with:
+    guest_name: bullseye_amd64
 
-- name: guest_cloudinit
-  uses: qemu.guest_init_using_cloudinit
+- name: guest_initialize
+  uses: qemu.guest_initialize
+  with:
+    guest_name: bullseye_amd64
+    system_image_name: debian-11-x86_64
 
-- name: guest_firstboot
+- name: guest_start
   uses: xnvme_guest_start_nvme
+  with:
+    guest_name: bullseye_amd64
 
 - name: guest_check
   run: |

--- a/cijoe/workflows/bootimg-freebsd-13-amd64.yaml
+++ b/cijoe/workflows/bootimg-freebsd-13-amd64.yaml
@@ -32,14 +32,21 @@ doc: |
   * Upload it to DigitalOcean
 
 steps:
-- name: kill
+- name: guest_kill
   uses: qemu.guest_kill
+  with:
+    guest_name: freebsd_13
 
-- name: initialize
-  uses: qemu.guest_init_using_bootimage
+- name: guest_initialize
+  uses: qemu.guest_initialize
+  with:
+    guest_name: freebsd_13
+    system_image_name: freebsd-13-x86_64
 
-- name: start
+- name: guest_start
   uses: xnvme_guest_start_nvme
+  with:
+    guest_name: freebsd_13
 
 - name: check
   run: |

--- a/cijoe/workflows/bootimg-freebsd-14-amd64.yaml
+++ b/cijoe/workflows/bootimg-freebsd-14-amd64.yaml
@@ -32,14 +32,21 @@ doc: |
   * Upload it to DigitalOcean
 
 steps:
-- name: kill
+- name: guest_kill
   uses: qemu.guest_kill
+  with:
+    guest_name: freebsd_14
 
-- name: initialize
-  uses: qemu.guest_init_using_bootimage
+- name: guest_initialize
+  uses: qemu.guest_initialize
+  with:
+    guest_name: freebsd_14
+    system_image_name: freebsd-14-x86_64
 
-- name: start
+- name: guest_start
   uses: xnvme_guest_start_nvme
+  with:
+    guest_name: freebsd_14
 
 - name: check
   run: |

--- a/cijoe/workflows/provision-using-git.yaml
+++ b/cijoe/workflows/provision-using-git.yaml
@@ -17,12 +17,19 @@ doc: |
 steps:
 - name: guest_kill
   uses: qemu.guest_kill
+  with:
+    guest_name: "{{ config.qemu.default_guest }}"
 
-- name: guest_init
-  uses: qemu.guest_init_using_bootimage
+- name: guest_initialize
+  uses: qemu.guest_initialize
+  with:
+    guest_name: "{{ config.qemu.default_guest }}"
+    system_image_name: "{{ config.qemu.default_systemimage }}"
 
 - name: guest_start
   uses: xnvme_guest_start_nvme
+  with:
+    guest_name: "{{ config.qemu.default_guest }}"
 
 - name: guest_check
   run: |
@@ -31,13 +38,11 @@ steps:
 - name: xnvme_source_sync
   uses: git_sync
   with:
-    repository:
-      upstream: '{{ config.xnvme.repository.remote }}'
-      branch: '{{ config.xnvme.repository.sync.branch }}'
-      remote_alias: '{{ config.xnvme.repository.sync.remote_alias }}'
-      path:
-        local: '{{ config.xnvme.repository.path }}'
-        remote: '{{ config.xnvme.repository.sync.remote_path }}'
+    upstream: '{{ config.xnvme.repository.remote }}'
+    branch: '{{ config.xnvme.repository.sync.branch }}'
+    remote_alias: '{{ config.xnvme.repository.sync.remote_alias }}'
+    local_path: '{{ config.xnvme.repository.path }}'
+    remote_path: '{{ config.xnvme.repository.sync.remote_path }}'
 
 - name: xnvme_build_prep
   uses: xnvme_build_prep
@@ -64,5 +69,3 @@ steps:
 
 - name: fio_prep
   uses: fio_prep
-  with:
-    xnvme_source: '{{ config.xnvme.repository.sync.remote_path }}'

--- a/cijoe/workflows/provision-using-no-auto.yaml
+++ b/cijoe/workflows/provision-using-no-auto.yaml
@@ -17,12 +17,19 @@ doc: |
 steps:
 - name: guest_kill
   uses: qemu.guest_kill
+  with:
+    guest_name: "{{ config.qemu.default_guest }}"
 
-- name: guest_init
-  uses: qemu.guest_init_using_bootimage
+- name: guest_initialize
+  uses: qemu.guest_initialize
+  with:
+    guest_name: "{{ config.qemu.default_guest }}"
+    system_image_name: "{{ config.qemu.default_systemimage }}"
 
 - name: guest_start
   uses: xnvme_guest_start_nvme
+  with:
+    guest_name: "{{ config.qemu.default_guest }}"
 
 - name: guest_check
   run: |
@@ -62,5 +69,3 @@ steps:
 
 - name: fio_prep
   uses: fio_prep
-  with:
-    xnvme_source: '{{ config.xnvme.repository.sync.remote_path }}'

--- a/cijoe/workflows/provision-using-tgz.yaml
+++ b/cijoe/workflows/provision-using-tgz.yaml
@@ -18,12 +18,19 @@ doc: |
 steps:
 - name: guest_kill
   uses: qemu.guest_kill
+  with:
+    guest_name: "{{ config.qemu.default_guest }}"
 
-- name: guest_init
-  uses: qemu.guest_init_using_bootimage
+- name: guest_initialize
+  uses: qemu.guest_initialize
+  with:
+    guest_name: "{{ config.qemu.default_guest }}"
+    system_image_name: "{{ config.qemu.default_systemimage }}"
 
 - name: guest_start
   uses: xnvme_guest_start_nvme
+  with:
+    guest_name: "{{ config.qemu.default_guest }}"
 
 - name: guest_check
   run: |
@@ -60,5 +67,3 @@ steps:
 
 - name: fio_prep
   uses: fio_prep
-  with:
-    xnvme_source: '{{ config.xnvme.repository.sync.remote_path }}'

--- a/cijoe/workflows/test-debian-bookworm.yaml
+++ b/cijoe/workflows/test-debian-bookworm.yaml
@@ -14,16 +14,16 @@ steps:
   with:
     args: '{{ config.xnvme.repository.sync.remote_path }}/python/tests -s -k "not fabrics and not vfio"'
     run_local: false
-    random-order: false
+    random_order: false
 
 - name: test_os
   uses: core.testrunner
   with:
     args: '-k "(not pcie) and (not compare) and (not format)" tests'
-    random-order: false
+    random_order: false
 
 - name: test_pcie
   uses: core.testrunner
   with:
     args: '-k "pcie and (not compare) and (not format)" tests'
-    random-order: false
+    random_order: false

--- a/cijoe/workflows/test-debian-bullseye.yaml
+++ b/cijoe/workflows/test-debian-bullseye.yaml
@@ -14,28 +14,28 @@ steps:
   with:
     args: '{{ config.xnvme.repository.sync.remote_path }}/python/tests -k "not fabrics and not vfio"'
     run_local: false
-    random-order: false
+    random_order: false
 
 - name: test_ramdisk
   uses: core.testrunner
   with:
     args: '-k "ramdisk" tests'
-    random-order: false
+    random_order: false
 
 - name: test_os
   uses: core.testrunner
   with:
     args: '-k "(not ramdisk) and (not pcie) and (not fabrics)" tests'
-    random-order: false
+    random_order: false
 
 - name: test_pcie
   uses: core.testrunner
   with:
     args: '-k "pcie" tests'
-    random-order: false
+    random_order: false
 
 - name: test_fabrics
   uses: core.testrunner
   with:
     args: '-k "fabrics" tests'
-    random-order: false
+    random_order: false

--- a/cijoe/workflows/test-freebsd-13.yaml
+++ b/cijoe/workflows/test-freebsd-13.yaml
@@ -15,16 +15,16 @@ steps:
   uses: core.testrunner
   with:
     args: '-k "ramdisk" tests'
-    random-order: false
+    random_order: false
 
 - name: test_os
   uses: core.testrunner
   with:
     args: '-k "(not ramdisk) and (not pcie) and (not fabrics)" tests'
-    random-order: false
+    random_order: false
 
 - name: test_pcie
   uses: core.testrunner
   with:
     args: '-k "pcie" tests'
-    random-order: false
+    random_order: false

--- a/cijoe/workflows/test-freebsd-14.yaml
+++ b/cijoe/workflows/test-freebsd-14.yaml
@@ -15,16 +15,16 @@ steps:
   uses: core.testrunner
   with:
     args: '-k "ramdisk" tests'
-    random-order: false
+    random_order: false
 
 - name: test_os
   uses: core.testrunner
   with:
     args: '-k "(not ramdisk) and (not pcie) and (not fabrics)" tests'
-    random-order: false
+    random_order: false
 
 - name: test_pcie
   uses: core.testrunner
   with:
     args: '-k "pcie" tests'
-    random-order: false
+    random_order: false

--- a/cijoe/workflows/test-macos-sonoma.yaml
+++ b/cijoe/workflows/test-macos-sonoma.yaml
@@ -16,4 +16,4 @@ steps:
   uses: core.testrunner
   with:
     args: '-k "pcie and not compare" tests'
-    random-order: false
+    random_order: false

--- a/docs/tutorial/devs/index.rst
+++ b/docs/tutorial/devs/index.rst
@@ -273,10 +273,12 @@ system, look specifically for these entries:
 .. code-block:: bash
 
   [qemu]
-  # system_bin = "{{ local.env.HOME }}/opt/qemu/bin/qemu-system-aarch64"
-  system_bin = "/opt/qemu/bin/qemu-system-aarch64"
   img_bin = "qemu-img"
   default_guest = "bookworm_arm64"
+
+  [qemu.systems.aarch64]
+  # bin = "{{ local.env.HOME }}/opt/qemu/bin/qemu-system-aarch64"
+  bin = "/opt/qemu/bin/qemu-system-aarch64"
 
   [xnvme.repository]
   upstream = "https://github.com/OpenMPDK/xNVMe.git"
@@ -606,7 +608,7 @@ configured:
 
 .. code-block:: bash
 
-  cijoe -c configs/debian-bullseye.toml -w provision.yaml
+  cijoe -c configs/debian-bullseye.toml provision.yaml
 
 .. tip::
    It will likely fail with the error::
@@ -624,13 +626,13 @@ The ``debian-bullseye-amd64.qcow2`` is created by:
 
 .. code-block:: bash
 
-  cijoe -c configs/debian-bullseye.toml -w workflows/bootimg-debian-bullseye-amd64.yaml
+  cijoe -c configs/debian-bullseye.toml workflows/bootimg-debian-bullseye-amd64.yaml
 
 The ``freebsd-13.1-ksrc-amd64.qcow2`` is created by:
 
 .. code-block:: bash
 
-  cijoe -c configs/freebsd-13.toml -w workflows/bootimg-freebsd-13-amd64.yaml
+  cijoe -c configs/freebsd-13.toml workflows/bootimg-freebsd-13-amd64.yaml
 
 Remote dev
 ----------


### PR DESCRIPTION
Firstly, this changes all instances of `cijoe.config.options.get(....)` to `cijoe.getconf(...)`, which is just a leftover that we've never gotten around to fix.

Secondly, the upgrade from cijoe v0.9.44 to v0.9.52 comes with a lot of refactorisation, which therefore makes the second commit quite large, and it would not be possible to do in smaller chunks, as these changes do not work individually.

- Remove `--workflow` argument, as this is no longer part of the cijoe cli. The workflow has been changed to a positional argument.
- Refactor config- and workflow files for new Qemu module setup.
- Add argparse arguments to scripts instead of step arguments and remove the step parameter