### PR TITLE
CI fixes

### DIFF
--- a/cijoe/configs/perf-lat-windows.toml
+++ b/cijoe/configs/perf-lat-windows.toml
@@ -29,7 +29,8 @@ bin = "C:/Users/root/git/fio/fio.exe"
 [fio.repository]
 remote = "https://github.com/axboe/fio.git"
 path = "C:/Users/root/git/fio"
-tag = "fio-3.38"
+# tag = "fio-3.38"
+tag = "7037b833e175aae32900b73bf597aad08c1d8472" # windows: drop nanosleep and clock_gettime
 
 [fio.engines]
 

--- a/cijoe/scripts/fio_prep.py
+++ b/cijoe/scripts/fio_prep.py
@@ -71,7 +71,7 @@ def fio_commands_windows(repos):
         ("git clean -fdX", repos["path"]),
         (f"git checkout {repos['tag']} || true", repos["path"]),
         ("git rev-parse --short HEAD || true", repos["path"]),
-        ("make", repos["path"]),
+        ("make CFLAGS='-O0'", repos["path"]),
     ]
 
     return commands

--- a/subprojects/packagefiles/spdk/patches/spdk-0001-util-use-libuuid-for-FreeBSD-if-it-is-available.patch
+++ b/subprojects/packagefiles/spdk/patches/spdk-0001-util-use-libuuid-for-FreeBSD-if-it-is-available.patch
@@ -1,0 +1,115 @@
+From 519c2e41b426bf7eabaf5a84d3874dfd644c651f Mon Sep 17 00:00:00 2001
+From: Jim Harris <jim.harris@nvidia.com>
+Date: Sat, 2 Aug 2025 01:39:29 -0700
+Subject: [PATCH] util: use libuuid for FreeBSD if it is available
+
+Define new HAVE_LIBUUID config variable to support this case.
+
+Fixes issue #3696.
+
+Signed-off-by: Jim Harris <jim.harris@nvidia.com>
+Change-Id: I1cd5be242b12361cec3540fb1a68949679d6cd44
+Reviewed-on: https://review.spdk.io/c/spdk/spdk/+/26367
+Tested-by: SPDK Automated Test System <spdkbot@gmail.com>
+Reviewed-by: Boris Glimcher <Boris.Glimcher@emc.com>
+Reviewed-by: Konrad Sztyber <ksztyber@nvidia.com>
+Reviewed-by: Tomasz Zawadzki <tomasz@tzawadzki.com>
+Community-CI: Mellanox Build Bot
+---
+ CONFIG            | 3 +++
+ configure         | 5 +++++
+ lib/util/Makefile | 2 +-
+ lib/util/uuid.c   | 6 ++++--
+ mk/spdk.common.mk | 2 +-
+ 5 files changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/CONFIG b/CONFIG
+index 7e6bd0d19..2abc7bd6c 100644
+--- a/CONFIG
++++ b/CONFIG
+@@ -206,6 +206,9 @@ CONFIG_IDXD_KERNEL=n
+ # arc4random is available in stdlib.h
+ CONFIG_HAVE_ARC4RANDOM=n
+ 
++# libuuid is available
++CONFIG_HAVE_LIBUUID=n
++
+ # uuid_generate_sha1 is available in uuid/uuid.h
+ CONFIG_HAVE_UUID_GENERATE_SHA1=n
+ 
+diff --git a/configure b/configure
+index b564c6a4c..6ef478504 100755
+--- a/configure
++++ b/configure
+@@ -1133,6 +1133,11 @@ if echo -e '#include <stdlib.h>\nint main(void) { arc4random(); return 0; }\n' \
+ 	CONFIG[HAVE_ARC4RANDOM]="y"
+ fi
+ 
++if echo -e '#include <uuid/uuid.h>\nint main(void) { return 0; }\n' \
++	| "${BUILD_CMD[@]}" - -luuid 2> /dev/null; then
++	CONFIG[HAVE_LIBUUID]="y"
++fi
++
+ if echo -e '#include <uuid/uuid.h>\nint main(void) { uuid_generate_sha1(NULL, NULL, NULL, 0); return 0; }\n' \
+ 	| "${BUILD_CMD[@]}" - -luuid 2> /dev/null; then
+ 	CONFIG[HAVE_UUID_GENERATE_SHA1]="y"
+diff --git a/lib/util/Makefile b/lib/util/Makefile
+index bd0050167..d34c392bb 100644
+--- a/lib/util/Makefile
++++ b/lib/util/Makefile
+@@ -14,7 +14,7 @@ C_SRCS = base64.c bit_array.c cpuset.c crc16.c crc32.c crc32c.c crc32_ieee.c crc
+ 	 fd_group.c xor.c zipf.c
+ LIBNAME = util
+ 
+-ifneq ($(OS),FreeBSD)
++ifeq ($(CONFIG_HAVE_LIBUUID),y)
+ LOCAL_SYS_LIBS = -luuid
+ endif
+ 
+diff --git a/lib/util/uuid.c b/lib/util/uuid.c
+index 06f3da6ba..9ab6e0de9 100644
+--- a/lib/util/uuid.c
++++ b/lib/util/uuid.c
+@@ -11,7 +11,7 @@
+ #include <openssl/evp.h>
+ #endif /* SPDK_CONFIG_HAVE_UUID_GENERATE_SHA1 */
+ 
+-#ifndef __FreeBSD__
++#if defined(SPDK_CONFIG_HAVE_LIBUUID)
+ 
+ #include <uuid/uuid.h>
+ 
+@@ -64,7 +64,7 @@ spdk_uuid_set_null(struct spdk_uuid *uuid)
+ 	uuid_clear((void *)uuid);
+ }
+ 
+-#else
++#elif defined(__FreeBSD__)
+ 
+ #include <uuid.h>
+ 
+@@ -141,6 +141,8 @@ spdk_uuid_set_null(struct spdk_uuid *uuid)
+ 	uuid_create_nil((uuid_t *)uuid, NULL);
+ }
+ 
++#else
++#error System must either have libuuid available or be FreeBSD.
+ #endif
+ 
+ int
+diff --git a/mk/spdk.common.mk b/mk/spdk.common.mk
+index 03deb74f8..2630e9e16 100644
+--- a/mk/spdk.common.mk
++++ b/mk/spdk.common.mk
+@@ -336,7 +336,7 @@ CFLAGS   += $(COMMON_CFLAGS) -Wno-pointer-sign -Wstrict-prototypes -Wold-style-d
+ CXXFLAGS += $(COMMON_CFLAGS) -std=c++11
+ 
+ SYS_LIBS += -lrt
+-ifneq ($(OS),FreeBSD)
++ifeq ($(CONFIG_HAVE_LIBUUID),y)
+ SYS_LIBS += -luuid
+ endif
+ SYS_LIBS += -lssl
+-- 
+2.39.5 (Apple Git-154)
+

--- a/toolbox/pkgs/freebsd-13.sh
+++ b/toolbox/pkgs/freebsd-13.sh
@@ -13,7 +13,7 @@ pkg install -qy \
  cunit \
  devel/py-pipx \
  devel/py-pyelftools \
- e2fsprogs-libuuid \
+ libuuid \
  findutils \
  git \
  gmake \

--- a/toolbox/pkgs/freebsd-14.sh
+++ b/toolbox/pkgs/freebsd-14.sh
@@ -13,7 +13,7 @@ pkg install -qy \
  cunit \
  devel/py-pipx \
  devel/py-pyelftools \
- e2fsprogs-libuuid \
+ libuuid \
  findutils \
  git \
  gmake \


### PR DESCRIPTION
### FreeBSD provisioning breaking: switch to libuuid
From e2fsprogs-libuuid to libuuid. It seems the e2fsprogs version has been removed as a port. See commit in the freebsd-ports repository: https://github.com/freebsd/freebsd-ports/commit/e81eda36a8fe2b02133674d52cd27f38a3b65d8b
Error "call to undeclared function 'uuid_generate_sha1'" in SPDK build, possibly also due to the above change. See this issue: https://github.com/spdk/spdk/issues/3696 and the patch to fix it

### perflatwin provisioning: Use latest fio commit
This is the same as my previous commit for the GHA jobs, it just needed to be applied for provisioning perflatwin too: https://github.com/xnvme/xnvme/commit/610a6b74d0973c911d410705b4fea4a61d4d077f