### PR TITLE
feat(ci/fio): bump fio tag to v3.41

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -637,8 +637,7 @@ jobs:
         rm -rf C:/tmp/fio
         git clone https://github.com/axboe/fio.git C:/tmp/fio
         cd C:/tmp/fio
-        # git checkout fio-3.38
-        git checkout 7037b833e175aae32900b73bf597aad08c1d8472 # windows: drop nanosleep and clock_gettime
+        git checkout fio-3.41
         git rev-parse --short HEAD
         make clean
         make CFLAGS="-O0"

--- a/cijoe/configs/ax42-windows.toml
+++ b/cijoe/configs/ax42-windows.toml
@@ -95,8 +95,7 @@ bin = "C:/Users/odus/git/fio/fio.exe"
 [fio.repository]
 remote = "https://github.com/axboe/fio.git"
 path = "C:/Users/odus/git/fio"
-# tag = "fio-3.38"
-tag = "7037b833e175aae32900b73bf597aad08c1d8472" # windows: drop nanosleep and clock_gettime
+tag = "fio-3.41"
 
 [fio.engines]
 null = {type = "builtin", group = "null", device = "bdev"}


### PR DESCRIPTION
We used fio tag `7037b833e175aae32900b73bf597aad08c1d8472` because of build issues on Windows. This commit has been added in release 3.41 of fio. Should solve first point in #599 