### PR TITLE
feat(bench/latency): reduce number of iosize variations

### DIFF
--- a/cijoe/auxiliary/bench-latency-runs.yaml
+++ b/cijoe/auxiliary/bench-latency-runs.yaml
@@ -1,6 +1,6 @@
 ---
 iodepths: &iodepths [1, 2, 4, 8, 16]
-iosizes: &iosizes [512, 1024, 2048, 4096, 8192, 16384, 32768, 65536]
+iosizes: &iosizes [512, 4096, 16384, 65536]
 runs:
 - iosizes: [4096]
   iodepths: *iodepths


### PR DESCRIPTION
Reduce the number of I/O sizes tested, removing less informative sizes like 1K and 2K. The benchmark’s primary goal is to detect regressions in backend implementations, which can still be achieved while shortening runtime by focusing on more relevant I/O sizes.

linux: 50 -> 36
freebsd:  31 -> 22
windows: 26 -> 20

Cutting about 30min of the running time. When all ressources are available, then it won't be visible on the total elapsed time of the pipeline, however, as soon as multiple PRs are worked on, then it dramatically cuts down the waiting time.