### PR TITLE
fix(docs): update CONTRIBUTING.md with correct link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,4 +6,4 @@ SPDX-License-Identifier: BSD-3-Clause
 
 # Contributing
 
-Have a look at [xnvme.io / contributing](https://xnvme.io/docs/latest/contributing/)
+Have a look at [xnvme.io / contributing](https://xnvme.io/contributing/)


### PR DESCRIPTION
This PR fixes a broken link in `CONTRIBUTING.md`. The previous URL no longer exists, and has been updated to point to the correct one (exact same one in `README.md`).