### PR TITLE
Introduce CUDA memory compatibility

### DIFF
--- a/include/xnvme_cuda_buf.h
+++ b/include/xnvme_cuda_buf.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+bool
+xnvme_buf_is_cuda(const void *buf);
+
+int
+xnvme_cuda_buf_clear(void *buf, size_t nbytes);
+
+int
+xnvme_cuda_buf_memcpy(void *dst, const void *src, size_t nbytes);
+
+int
+xnvme_cuda_buf_diff(const void *expected, const void *actual, size_t nbytes, size_t *diff,
+		    bool print);
+
+int
+xnvme_cuda_buf_fill(void *buf, size_t nbytes, const char *content);

--- a/include/xnvme_host_buf.h
+++ b/include/xnvme_host_buf.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef __INTERNAL_XNVME_HOST_BUF_H
+#define __INTERNAL_XNVME_HOST_BUF_H
+
+int
+xnvme_host_buf_clear(void *buf, size_t nbytes);
+
+int
+xnvme_host_buf_memcpy(void *dst, const void *src, size_t nbytes);
+
+int
+xnvme_host_buf_diff(const void *expected, const void *actual, size_t nbytes, size_t *diff,
+		    bool print);
+
+int
+xnvme_host_buf_fill(void *buf, size_t nbytes, const char *content);
+
+#endif

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -101,6 +101,7 @@ xnvmelib_deps = [
   spdk_dep,
   thread_dep,
   rt_dep,
+  cuda_dep,
 ]
 
 subdir('upcie')

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -72,6 +72,7 @@ xnvmelib_source = [
   'xnvme_dev.c',
   'xnvme_file.c',
   'xnvme_geo.c',
+  'xnvme_host_buf.c',
   'xnvme_ident.c',
   'xnvme_kvs.c',
   'xnvme_lba.c',

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -69,6 +69,7 @@ xnvmelib_source = [
   'xnvme_buf.c',
   'xnvme_cli.c',
   'xnvme_cmd.c',
+  'xnvme_cuda_buf.c',
   'xnvme_dev.c',
   'xnvme_file.c',
   'xnvme_geo.c',

--- a/lib/xnvme_buf.c
+++ b/lib/xnvme_buf.c
@@ -8,6 +8,7 @@
 #include <libxnvme.h>
 #include <xnvme_dev.h>
 #include <xnvme_be.h>
+#include <xnvme_host_buf.h>
 
 void *
 xnvme_buf_virt_alloc(size_t alignment, size_t nbytes)
@@ -90,15 +91,13 @@ xnvme_buf_free(const struct xnvme_dev *dev, void *buf)
 int
 xnvme_buf_clear(void *buf, size_t nbytes)
 {
-	memset(buf, 0, nbytes);
-	return 0;
+	return xnvme_host_buf_clear(buf, nbytes);
 }
 
 int
 xnvme_buf_memcpy(void *dst, const void *src, size_t nbytes)
 {
-	memcpy(dst, src, nbytes);
-	return 0;
+	return xnvme_host_buf_memcpy(dst, src, nbytes);
 }
 
 /**
@@ -182,84 +181,20 @@ xnvme_buf_to_file(void *buf, size_t nbytes, const char *path)
 int
 xnvme_buf_fill(void *buf, size_t nbytes, const char *content)
 {
-	uint8_t *cbuf = buf;
-
-	if (strlen(content) == 1) {
-		memset(cbuf, content[0], nbytes);
-		return 0;
-	}
-
-	if (!strncmp(content, "anum", 4)) {
-		for (size_t i = 0; i < nbytes; ++i) {
-			cbuf[i] = (i % 26) + 65;
-		}
-
-		return 0;
-	}
-
-	if (!strncmp(content, "rand-t", 6)) {
-		srand(time(NULL));
-		for (size_t i = 0; i < nbytes; ++i) {
-			cbuf[i] = (rand() % 26) + 65;
-		}
-
-		return 0;
-	}
-
-	if (!strncmp(content, "rand-k", 6)) {
-		srand(0);
-		for (size_t i = 0; i < nbytes; ++i) {
-			cbuf[i] = (rand() % 26) + 65;
-		}
-
-		return 0;
-	}
-
-	if (!strncmp(content, "zero", 4)) {
-		return xnvme_buf_clear(buf, nbytes);
-	}
-
-	return xnvme_buf_from_file(buf, nbytes, content);
+	return xnvme_host_buf_fill(buf, nbytes, content);
 }
 
 int
 xnvme_buf_diff(const void *expected, const void *actual, size_t nbytes, size_t *diff)
 {
-	const uint8_t *exp = expected;
-	const uint8_t *act = actual;
-
-	for (size_t i = 0; i < nbytes; ++i) {
-		if (exp[i] == act[i]) {
-			continue;
-		}
-
-		*diff += 1;
-	}
-
-	return 0;
+	return xnvme_host_buf_diff(expected, actual, nbytes, diff, false);
 }
 
 int
 xnvme_buf_diff_pr(const void *expected, const void *actual, size_t nbytes, int XNVME_UNUSED(opts))
 {
-	const uint8_t *exp = expected;
-	const uint8_t *act = actual;
 	size_t diff = 0;
-
-	printf("comparison:\n");
-	printf("  diffs:\n");
-	for (size_t i = 0; i < nbytes; ++i) {
-		if (exp[i] == act[i]) {
-			continue;
-		}
-
-		++diff;
-		printf("    - {byte: '%06zu', expected: 0x%" PRIx8 ", actual: 0x%" PRIx8 ")\n", i,
-		       exp[i], act[i]);
-	}
-	printf("  nbytes: %zu\n", nbytes);
-	printf("  nbytes_diff: %zu\n", diff);
-	return 0;
+	return xnvme_host_buf_diff(expected, actual, nbytes, &diff, true);
 }
 
 int

--- a/lib/xnvme_buf.c
+++ b/lib/xnvme_buf.c
@@ -9,6 +9,7 @@
 #include <xnvme_dev.h>
 #include <xnvme_be.h>
 #include <xnvme_host_buf.h>
+#include <xnvme_cuda_buf.h>
 
 void *
 xnvme_buf_virt_alloc(size_t alignment, size_t nbytes)
@@ -91,12 +92,20 @@ xnvme_buf_free(const struct xnvme_dev *dev, void *buf)
 int
 xnvme_buf_clear(void *buf, size_t nbytes)
 {
+	if (xnvme_buf_is_cuda(buf)) {
+		return xnvme_cuda_buf_clear(buf, nbytes);
+	}
+
 	return xnvme_host_buf_clear(buf, nbytes);
 }
 
 int
 xnvme_buf_memcpy(void *dst, const void *src, size_t nbytes)
 {
+	if (xnvme_buf_is_cuda(dst) || xnvme_buf_is_cuda(src)) {
+		return xnvme_cuda_buf_memcpy(dst, src, nbytes);
+	}
+
 	return xnvme_host_buf_memcpy(dst, src, nbytes);
 }
 
@@ -181,12 +190,20 @@ xnvme_buf_to_file(void *buf, size_t nbytes, const char *path)
 int
 xnvme_buf_fill(void *buf, size_t nbytes, const char *content)
 {
+	if (xnvme_buf_is_cuda(buf)) {
+		return xnvme_cuda_buf_fill(buf, nbytes, content);
+	}
+
 	return xnvme_host_buf_fill(buf, nbytes, content);
 }
 
 int
 xnvme_buf_diff(const void *expected, const void *actual, size_t nbytes, size_t *diff)
 {
+	if (xnvme_buf_is_cuda(expected) || xnvme_buf_is_cuda(actual)) {
+		return xnvme_cuda_buf_diff(expected, actual, nbytes, diff, false);
+	}
+
 	return xnvme_host_buf_diff(expected, actual, nbytes, diff, false);
 }
 
@@ -194,6 +211,10 @@ int
 xnvme_buf_diff_pr(const void *expected, const void *actual, size_t nbytes, int XNVME_UNUSED(opts))
 {
 	size_t diff = 0;
+	if (xnvme_buf_is_cuda(expected) || xnvme_buf_is_cuda(actual)) {
+		return xnvme_cuda_buf_diff(expected, actual, nbytes, &diff, true);
+	}
+
 	return xnvme_host_buf_diff(expected, actual, nbytes, &diff, true);
 }
 

--- a/lib/xnvme_cuda_buf.c
+++ b/lib/xnvme_cuda_buf.c
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifdef XNVME_CUDA_ENABLED
+#include <cuda_runtime.h>
+#include <libxnvme.h>
+#include <xnvme_host_buf.h>
+#include <errno.h>
+
+bool
+xnvme_buf_is_cuda(const void *buf)
+{
+	cudaError_t err;
+	struct cudaPointerAttributes attr;
+
+	err = cudaPointerGetAttributes(&attr, buf);
+	if (err != cudaSuccess) {
+		XNVME_DEBUG("FAILED: cudaPointerGetAttributes(buf), err: %s",
+			    cudaGetErrorString(err));
+		return false; // If it fails we assume it is not a CUDA buffer
+	}
+
+	return attr.type == cudaMemoryTypeDevice;
+}
+
+int
+xnvme_cuda_buf_clear(void *buf, size_t nbytes)
+{
+	cudaError_t err;
+
+	err = cudaMemset(buf, 0, nbytes);
+	if (err != cudaSuccess) {
+		XNVME_DEBUG("FAILED: cudaMemset, err: %s", cudaGetErrorString(err));
+		return -EIO;
+	}
+
+	return 0;
+}
+
+int
+xnvme_cuda_buf_memcpy(void *dst, const void *src, size_t nbytes)
+{
+	cudaError_t err;
+
+	err = cudaMemcpy(dst, src, nbytes, cudaMemcpyDefault);
+	if (err != cudaSuccess) {
+		XNVME_DEBUG("FAILED: cudaMemcpy, err: %s", cudaGetErrorString(err));
+		return -EIO;
+	}
+	return 0;
+}
+
+int
+xnvme_cuda_buf_diff(const void *expected, const void *actual, size_t nbytes, size_t *diff,
+		    bool print)
+{
+	void *exp, *act;
+	cudaError_t cu_err;
+	int err;
+
+	exp = malloc(nbytes);
+	if (!exp) {
+		err = -errno;
+		XNVME_DEBUG("FAILED: malloc(exp), errno: %d", err);
+		return err;
+	}
+
+	act = malloc(nbytes);
+	if (!act) {
+		err = -errno;
+		XNVME_DEBUG("FAILED: malloc(act), errno: %d", err);
+		goto exit;
+	}
+
+	cu_err = cudaMemcpy(exp, expected, nbytes, cudaMemcpyDefault);
+	if (cu_err != cudaSuccess) {
+		XNVME_DEBUG("FAILED: cudaMemcpy(expected), err: %s", cudaGetErrorString(cu_err));
+		err = -EIO;
+		goto exit;
+	}
+
+	cu_err = cudaMemcpy(act, actual, nbytes, cudaMemcpyDefault);
+	if (cu_err != cudaSuccess) {
+		XNVME_DEBUG("FAILED: cudaMemcpy(actual), err: %s", cudaGetErrorString(cu_err));
+		err = -EIO;
+		goto exit;
+	}
+
+	err = xnvme_host_buf_diff(exp, act, nbytes, diff, print);
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_host_buf_diff(), err: %d", err);
+		goto exit;
+	}
+
+exit:
+	free(exp);
+	free(act);
+
+	return err;
+}
+
+int
+xnvme_cuda_buf_fill(void *buf, size_t nbytes, const char *content)
+{
+	cudaError_t cu_err;
+	int err;
+	uint8_t *cbuf;
+
+	cbuf = malloc(nbytes);
+	if (!cbuf) {
+		err = -errno;
+		XNVME_DEBUG("FAILED: malloc(cbuf), errno: %d", err);
+		return err;
+	}
+
+	err = xnvme_host_buf_fill(cbuf, nbytes, content);
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_host_buf_fill(%s), err: %d", content, err);
+		goto exit;
+	}
+
+	cu_err = cudaMemcpy(buf, cbuf, nbytes, cudaMemcpyDefault);
+	if (cu_err != cudaSuccess) {
+		XNVME_DEBUG("FAILED: cudaMemcpy, err: %s", cudaGetErrorString(cu_err));
+		err = -EIO;
+		goto exit;
+	}
+exit:
+	free(cbuf);
+	return err;
+}
+#else
+
+#include <libxnvme.h>
+#include <errno.h>
+
+bool
+xnvme_buf_is_cuda(const void *XNVME_UNUSED(buf))
+{
+	return false;
+}
+
+int
+xnvme_cuda_buf_clear(void *XNVME_UNUSED(buf), size_t XNVME_UNUSED(nbytes))
+{
+	XNVME_DEBUG("FAILED: xNVMe was compiled without CUDA");
+	return -ENOTSUP;
+}
+
+int
+xnvme_cuda_buf_memcpy(void *XNVME_UNUSED(dst), const void *XNVME_UNUSED(src),
+		      size_t XNVME_UNUSED(nbytes))
+{
+	XNVME_DEBUG("FAILED: xNVMe was compiled without CUDA");
+	return -ENOTSUP;
+}
+
+int
+xnvme_cuda_buf_diff(const void *XNVME_UNUSED(expected), const void *XNVME_UNUSED(actual),
+		    size_t XNVME_UNUSED(nbytes), size_t *XNVME_UNUSED(diff),
+		    bool XNVME_UNUSED(print))
+{
+	XNVME_DEBUG("FAILED: xNVMe was compiled without CUDA");
+	return -ENOTSUP;
+}
+
+int
+xnvme_cuda_buf_fill(void *XNVME_UNUSED(buf), size_t XNVME_UNUSED(nbytes),
+		    const char *XNVME_UNUSED(content))
+{
+	XNVME_DEBUG("FAILED: xNVMe was compiled without CUDA");
+	return -ENOTSUP;
+}
+#endif

--- a/lib/xnvme_host_buf.c
+++ b/lib/xnvme_host_buf.c
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+#include <libxnvme.h>
+
+int
+xnvme_host_buf_clear(void *buf, size_t nbytes)
+{
+	memset(buf, 0, nbytes);
+	return 0;
+}
+
+int
+xnvme_host_buf_memcpy(void *dst, const void *src, size_t nbytes)
+{
+	memcpy(dst, src, nbytes);
+	return 0;
+}
+
+int
+xnvme_host_buf_diff(const void *expected, const void *actual, size_t nbytes, size_t *diff,
+		    bool print)
+{
+	const uint8_t *exp = expected;
+	const uint8_t *act = actual;
+
+	if (print) {
+		printf("comparison:\n");
+		printf("  diffs:\n");
+	}
+	for (size_t i = 0; i < nbytes; ++i) {
+		if (exp[i] == act[i]) {
+			continue;
+		}
+
+		*diff += 1;
+		if (print) {
+			printf("    - {byte: '%06zu', expected: 0x%" PRIx8 ", actual: 0x%" PRIx8
+			       ")\n",
+			       i, exp[i], act[i]);
+		}
+	}
+	if (print) {
+		printf("  nbytes: %zu\n", nbytes);
+		printf("  nbytes_diff: %zu\n", *diff);
+	}
+
+	return 0;
+}
+
+int
+xnvme_host_buf_fill(void *buf, size_t nbytes, const char *content)
+{
+	uint8_t *cbuf = buf;
+
+	if (strlen(content) == 1) {
+		memset(cbuf, content[0], nbytes);
+		return 0;
+	}
+
+	if (!strncmp(content, "anum", 4)) {
+		for (size_t i = 0; i < nbytes; ++i) {
+			cbuf[i] = (i % 26) + 65;
+		}
+
+		return 0;
+	}
+
+	if (!strncmp(content, "rand-t", 6)) {
+		srand(time(NULL));
+		for (size_t i = 0; i < nbytes; ++i) {
+			cbuf[i] = (rand() % 26) + 65;
+		}
+
+		return 0;
+	}
+
+	if (!strncmp(content, "rand-k", 6)) {
+		srand(0);
+		for (size_t i = 0; i < nbytes; ++i) {
+			cbuf[i] = (rand() % 26) + 65;
+		}
+
+		return 0;
+	}
+
+	if (!strncmp(content, "zero", 4)) {
+		return xnvme_host_buf_clear(buf, nbytes);
+	}
+
+	return xnvme_buf_from_file(buf, nbytes, content);
+}

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ project(
     'b_staticpic=true',
     'b_ndebug=if-release',
   ],
-  meson_version: '>=0.58'
+  meson_version: '>=0.59'
 )
 
 pconf = import('pkgconfig')
@@ -97,6 +97,14 @@ conf_data.set('XNVME_BE_CBI_SYNC_PSYNC_ENABLED', get_option('cbi_sync_psync') an
 
 conf_data.set('XNVME_BE_RAMDISK_ENABLED', get_option('be_ramdisk'))
 conf_data.set('XNVME_BE_UPCIE_ENABLED', get_option('be_upcie') and is_linux)
+
+cuda_dep = dependency(
+  'cuda',
+  version: '12.8',
+  modules: ['cuda'],
+  required: get_option('with-cuda'),
+)
+conf_data.set('XNVME_CUDA_ENABLED', cuda_dep.found() and get_option('with-cuda').allowed())
 
 setupapi_dep = cc.find_library(
   'setupapi',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,6 +3,7 @@ option('with-liburing', type: 'feature', value: 'auto')
 option('with-libvfn', type: 'feature', value: 'auto')
 option('with-isal', type: 'feature', value: 'auto')
 option('with-spdk', type: 'feature', value: 'auto')
+option('with-cuda', type: 'feature', value: 'auto')
 
 option('be_ramdisk', type: 'boolean', value: true)
 option('be_upcie', type: 'boolean', value: true)


### PR DESCRIPTION
These commits changes the functions in the `xnvme_buf` API to be compatible with both device and host memory.
That is, if CUDA is available on the system and the meson feature is not disabled.

In preparation for this, I am introducing a new function `xnvme_buf_copy()` which acts like `memcpy()`, as well as changing our tools, tests, examples to use the `xnvme_buf` API instead of the C standard library equivalents.

Since, I'm already touching the `xnvme_buf_fill()` code path, I decided to give it a little extra love.
  