### PR TITLE
Refactor xNVMe BUF API to have error handling

### DIFF
--- a/examples/xnvme_io_async.c
+++ b/examples/xnvme_io_async.c
@@ -78,6 +78,7 @@ sub_async_read(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(buf, rng.nbytes, "zero");
 	if (err) {
 		xnvme_cli_perr("xnvme_buf_fill()", err);
@@ -211,6 +212,7 @@ sub_async_write(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(buf, rng.nbytes,
 			     cli->args.data_input ? cli->args.data_input : "anum");
 	if (err) {

--- a/examples/xnvme_single_async.c
+++ b/examples/xnvme_single_async.c
@@ -75,7 +75,12 @@ main(int argc, char **argv)
 		xnvme_cli_perr("xnvme_buf_alloc()", errno);
 		goto exit;
 	}
-	xnvme_buf_clear(buf, buf_nbytes);
+
+	err = xnvme_buf_clear(buf, buf_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	// This block would typically be a loop as more than a single command would be submitted
 	{

--- a/examples/xnvme_single_async_efd.c
+++ b/examples/xnvme_single_async_efd.c
@@ -46,7 +46,12 @@ sub_async_read(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_clear(buf, buf_nbytes);
+
+	err = xnvme_buf_clear(buf, buf_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	completion_fd = xnvme_queue_get_completion_fd(queue);
 	if (completion_fd <= 0) {

--- a/examples/xnvme_single_sync.c
+++ b/examples/xnvme_single_sync.c
@@ -43,7 +43,12 @@ main(int argc, char **argv)
 		xnvme_cli_perr("xnvme_buf_alloc()", errno);
 		goto exit;
 	}
-	xnvme_buf_clear(buf, buf_nbytes);
+
+	err = xnvme_buf_clear(buf, buf_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	// This block would typically be a loop as more than a single command would be submitted
 	{

--- a/examples/zoned_io_async.c
+++ b/examples/zoned_io_async.c
@@ -88,6 +88,7 @@ sub_async_read(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(buf, buf_nbytes, "zero");
 	if (err) {
 		xnvme_cli_perr("xnvme_buf_fill()", err);
@@ -231,6 +232,7 @@ sub_async_write(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(buf, buf_nbytes,
 			     cli->args.data_input ? cli->args.data_input : "anum");
 	if (err) {
@@ -370,6 +372,7 @@ sub_async_append(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(buf, buf_nbytes,
 			     cli->args.data_input ? cli->args.data_input : "anum");
 	if (err) {

--- a/examples/zoned_io_sync.c
+++ b/examples/zoned_io_sync.c
@@ -50,6 +50,7 @@ sub_sync_read(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(buf, buf_nbytes, "zero");
 	if (err) {
 		xnvme_cli_perr("xnvme_buf_fill()", err);
@@ -134,6 +135,7 @@ sub_sync_write(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(buf, buf_nbytes,
 			     cli->args.data_input ? cli->args.data_input : "anum");
 	if (err) {
@@ -211,6 +213,7 @@ sub_sync_append(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(buf, buf_nbytes,
 			     cli->args.data_input ? cli->args.data_input : "anum");
 	if (err) {

--- a/include/libxnvme_buf.h
+++ b/include/libxnvme_buf.h
@@ -169,9 +169,9 @@ xnvme_buf_fill(void *buf, size_t nbytes, const char *content);
  * @param buf Pointer to the buffer to fill with zeroes
  * @param nbytes Amount of bytes to fill with zeroes in buf
  *
- * @return Returns the first argument.
+ * @return On success, 0 is returned. On error, negative `errno` is returned.
  */
-void *
+int
 xnvme_buf_clear(void *buf, size_t nbytes);
 
 /**

--- a/include/libxnvme_buf.h
+++ b/include/libxnvme_buf.h
@@ -175,16 +175,17 @@ int
 xnvme_buf_clear(void *buf, size_t nbytes);
 
 /**
- * Returns the number of bytes where expected is different from actual
+ * Compare two buffers and count the number of differing bytes.
  *
- * @param expected Pointer to buffer of "expected" content
- * @param actual Pointer to buffer to compare to "expected"
- * @param nbytes Amount of bytes to compare
+ * @param expected Pointer to buffer containing the expected data
+ * @param actual Pointer to buffer to compare against the expected data
+ * @param nbytes Number of bytes to compare
+ * @param diff Output pointer storing the number of differing bytes
  *
- * @return On success, returns number of bytes that differ
+ * @return 0 on success, negative `errno` on error.
  */
-size_t
-xnvme_buf_diff(const void *expected, const void *actual, size_t nbytes);
+int
+xnvme_buf_diff(const void *expected, const void *actual, size_t nbytes, size_t *diff);
 
 /**
  * Prints the number and value of bytes where expected is different from actual
@@ -193,8 +194,10 @@ xnvme_buf_diff(const void *expected, const void *actual, size_t nbytes);
  * @param actual Pointer to buffer to compare to "expected"
  * @param nbytes Amount of bytes to compare
  * @param opts printer options, see ::xnvme_pr
+ *
+ * @return On success, 0 is returned. On error, negative `errno` is returned.
  */
-void
+int
 xnvme_buf_diff_pr(const void *expected, const void *actual, size_t nbytes, int opts);
 
 /**

--- a/lib/xnvme_buf.c
+++ b/lib/xnvme_buf.c
@@ -215,25 +215,24 @@ xnvme_buf_fill(void *buf, size_t nbytes, const char *content)
 	return xnvme_buf_from_file(buf, nbytes, content);
 }
 
-size_t
-xnvme_buf_diff(const void *expected, const void *actual, size_t nbytes)
+int
+xnvme_buf_diff(const void *expected, const void *actual, size_t nbytes, size_t *diff)
 {
 	const uint8_t *exp = expected;
 	const uint8_t *act = actual;
-	size_t diff = 0;
 
 	for (size_t i = 0; i < nbytes; ++i) {
 		if (exp[i] == act[i]) {
 			continue;
 		}
 
-		++diff;
+		*diff += 1;
 	}
 
-	return diff;
+	return 0;
 }
 
-void
+int
 xnvme_buf_diff_pr(const void *expected, const void *actual, size_t nbytes, int XNVME_UNUSED(opts))
 {
 	const uint8_t *exp = expected;
@@ -253,6 +252,7 @@ xnvme_buf_diff_pr(const void *expected, const void *actual, size_t nbytes, int X
 	}
 	printf("  nbytes: %zu\n", nbytes);
 	printf("  nbytes_diff: %zu\n", diff);
+	return 0;
 }
 
 int

--- a/lib/xnvme_buf.c
+++ b/lib/xnvme_buf.c
@@ -87,10 +87,11 @@ xnvme_buf_free(const struct xnvme_dev *dev, void *buf)
 	xnvme_buf_phys_free(dev, buf);
 }
 
-void *
+int
 xnvme_buf_clear(void *buf, size_t nbytes)
 {
-	return memset(buf, 0, nbytes);
+	memset(buf, 0, nbytes);
+	return 0;
 }
 
 /**
@@ -208,9 +209,7 @@ xnvme_buf_fill(void *buf, size_t nbytes, const char *content)
 	}
 
 	if (!strncmp(content, "zero", 4)) {
-		xnvme_buf_clear(buf, nbytes);
-
-		return 0;
+		return xnvme_buf_clear(buf, nbytes);
 	}
 
 	return xnvme_buf_from_file(buf, nbytes, content);

--- a/lib/xnvme_dev.c
+++ b/lib/xnvme_dev.c
@@ -209,7 +209,12 @@ _dev_idfy_csi(struct xnvme_dev *dev, struct xnvme_spec_idfy *idfy_ns,
 
 	struct xnvme_spec_znd_idfy_ns *zns = (void *)idfy_ns;
 
-	xnvme_buf_clear(idfy_ctrlr, sizeof(*idfy_ctrlr));
+	err = xnvme_buf_clear(idfy_ctrlr, sizeof(*idfy_ctrlr));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_clear(idfy_ctrlr), err: %d", err);
+		return err;
+	}
+
 	ctx = xnvme_cmd_ctx_from_dev(dev);
 	err = xnvme_adm_idfy_ctrlr_csi(&ctx, XNVME_SPEC_CSI_ZONED, idfy_ctrlr);
 	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
@@ -217,7 +222,12 @@ _dev_idfy_csi(struct xnvme_dev *dev, struct xnvme_spec_idfy *idfy_ns,
 		goto not_zns;
 	}
 
-	xnvme_buf_clear(idfy_ns, sizeof(*idfy_ns));
+	err = xnvme_buf_clear(idfy_ns, sizeof(*idfy_ns));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_clear(idfy_ns), err: %d", err);
+		return err;
+	}
+
 	ctx = xnvme_cmd_ctx_from_dev(dev);
 	err = xnvme_adm_idfy_ns_csi(&ctx, dev->ident.nsid, XNVME_SPEC_CSI_ZONED, idfy_ns);
 	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
@@ -244,7 +254,12 @@ not_zns:
 	struct xnvme_spec_fs_idfy_ctrlr *fs_ctrlr = (void *)idfy_ctrlr;
 	struct xnvme_spec_fs_idfy_ns *fs_ns = (void *)idfy_ns;
 
-	xnvme_buf_clear(idfy_ctrlr, sizeof(*idfy_ctrlr));
+	err = xnvme_buf_clear(idfy_ctrlr, sizeof(*idfy_ctrlr));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_clear(idfy_ctrlr), err: %d", err);
+		return err;
+	}
+
 	ctx = xnvme_cmd_ctx_from_dev(dev);
 	err = xnvme_adm_idfy_ctrlr_csi(&ctx, XNVME_SPEC_CSI_FS, idfy_ctrlr);
 	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
@@ -256,7 +271,12 @@ not_zns:
 		goto not_fs;
 	}
 
-	xnvme_buf_clear(idfy_ns, sizeof(*idfy_ns));
+	err = xnvme_buf_clear(idfy_ns, sizeof(*idfy_ns));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_clear(idfy_ns), err: %d", err);
+		return err;
+	}
+
 	ctx = xnvme_cmd_ctx_from_dev(dev);
 	err = xnvme_adm_idfy_ns_csi(&ctx, dev->ident.nsid, XNVME_SPEC_CSI_FS, idfy_ns);
 	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
@@ -280,7 +300,12 @@ not_fs:
 
 	// Attempt to identify NVM
 
-	xnvme_buf_clear(idfy_ctrlr, sizeof(*idfy_ctrlr));
+	err = xnvme_buf_clear(idfy_ctrlr, sizeof(*idfy_ctrlr));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_clear(idfy_ctrlr), err: %d", err);
+		return err;
+	}
+
 	ctx = xnvme_cmd_ctx_from_dev(dev);
 	err = xnvme_adm_idfy_ctrlr_csi(&ctx, XNVME_SPEC_CSI_NVM, idfy_ctrlr);
 	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
@@ -288,7 +313,12 @@ not_fs:
 		goto not_nvm;
 	}
 
-	xnvme_buf_clear(idfy_ns, sizeof(*idfy_ns));
+	err = xnvme_buf_clear(idfy_ns, sizeof(*idfy_ns));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_clear(idfy_ns), err: %d", err);
+		return err;
+	}
+
 	ctx = xnvme_cmd_ctx_from_dev(dev);
 	err = xnvme_adm_idfy_ns_csi(&ctx, dev->ident.nsid, XNVME_SPEC_CSI_NVM, idfy_ns);
 	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
@@ -335,7 +365,12 @@ _dev_idfy(struct xnvme_dev *dev)
 	}
 
 	// Retrieve idfy-ctrlr
-	xnvme_buf_clear(idfy_ctrlr, sizeof(*idfy_ctrlr));
+	err = xnvme_buf_clear(idfy_ctrlr, sizeof(*idfy_ctrlr));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_clear(idfy_ctrlr), err: %d", err);
+		return err;
+	}
+
 	ctx = xnvme_cmd_ctx_from_dev(dev);
 	err = xnvme_adm_idfy_ctrlr(&ctx, idfy_ctrlr);
 	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
@@ -353,7 +388,12 @@ _dev_idfy(struct xnvme_dev *dev)
 	}
 
 	// Retrieve idfy-ns
-	xnvme_buf_clear(idfy_ns, sizeof(*idfy_ns));
+	err = xnvme_buf_clear(idfy_ns, sizeof(*idfy_ns));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_clear(idfy_ns), err: %d", err);
+		return err;
+	}
+
 	ctx = xnvme_cmd_ctx_from_dev(dev);
 	err = xnvme_adm_idfy_ns(&ctx, dev->ident.nsid, idfy_ns);
 	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -270,40 +270,40 @@ static int
 enumerate_controller(const char *uri, struct xnvme_opts *opts, xnvme_enumerate_cb cb_func,
 		     void *cb_args)
 {
-	struct xnvme_opts ctrl_opts = *opts;
-	struct xnvme_dev *ctrl_dev;
+	struct xnvme_opts ctrlr_opts = *opts;
+	struct xnvme_dev *ctrlr_dev;
 	struct xnvme_spec_idfy *idfy_buf;
 	struct xnvme_cmd_ctx ctx;
 	uint32_t *nslist;
 	int err;
 
-	ctrl_opts.nsid = 0;
-	ctrl_dev = xnvme_dev_open(uri, &ctrl_opts);
-	if (!ctrl_dev) {
+	ctrlr_opts.nsid = 0;
+	ctrlr_dev = xnvme_dev_open(uri, &ctrlr_opts);
+	if (!ctrlr_dev) {
 		XNVME_DEBUG("FAILED: xnvme_dev_open(%s) for controller", uri);
 		return -errno;
 	}
 
-	idfy_buf = xnvme_buf_alloc(ctrl_dev, sizeof(*idfy_buf));
+	idfy_buf = xnvme_buf_alloc(ctrlr_dev, sizeof(*idfy_buf));
 	if (!idfy_buf) {
 		XNVME_DEBUG("FAILED: xnvme_buf_alloc()");
-		xnvme_dev_close(ctrl_dev);
+		xnvme_dev_close(ctrlr_dev);
 		return -ENOMEM;
 	}
 
 	err = xnvme_buf_clear(idfy_buf, sizeof(*idfy_buf));
 	if (err) {
 		XNVME_DEBUG("FAILED: xnvme_buf_clear(), err: %d", err);
-		xnvme_buf_free(ctrl_dev, idfy_buf);
+		xnvme_buf_free(ctrlr_dev, idfy_buf);
 		return err;
 	}
 
-	ctx = xnvme_cmd_ctx_from_dev(ctrl_dev);
+	ctx = xnvme_cmd_ctx_from_dev(ctrlr_dev);
 	err = xnvme_adm_idfy(&ctx, XNVME_SPEC_IDFY_NSLIST, 0, 0, 0, 0, idfy_buf);
 	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
 		XNVME_DEBUG("FAILED: Identify Active NS List, err: %d", err);
-		xnvme_buf_free(ctrl_dev, idfy_buf);
-		xnvme_dev_close(ctrl_dev);
+		xnvme_buf_free(ctrlr_dev, idfy_buf);
+		xnvme_dev_close(ctrlr_dev);
 		return err ? err : -EIO;
 	}
 
@@ -325,8 +325,8 @@ enumerate_controller(const char *uri, struct xnvme_opts *opts, xnvme_enumerate_c
 		}
 	}
 
-	xnvme_buf_free(ctrl_dev, idfy_buf);
-	xnvme_dev_close(ctrl_dev);
+	xnvme_buf_free(ctrlr_dev, idfy_buf);
+	xnvme_dev_close(ctrlr_dev);
 	return 0;
 }
 

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -290,7 +290,13 @@ enumerate_controller(const char *uri, struct xnvme_opts *opts, xnvme_enumerate_c
 		xnvme_dev_close(ctrl_dev);
 		return -ENOMEM;
 	}
-	xnvme_buf_clear(idfy_buf, sizeof(*idfy_buf));
+
+	err = xnvme_buf_clear(idfy_buf, sizeof(*idfy_buf));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_clear(), err: %d", err);
+		xnvme_buf_free(ctrl_dev, idfy_buf);
+		return err;
+	}
 
 	ctx = xnvme_cmd_ctx_from_dev(ctrl_dev);
 	err = xnvme_adm_idfy(&ctx, XNVME_SPEC_IDFY_NSLIST, 0, 0, 0, 0, idfy_buf);

--- a/tests/compare.c
+++ b/tests/compare.c
@@ -51,7 +51,12 @@ test_compare(struct xnvme_cli *cli)
 		XNVME_DEBUG("Failed: allocating write buffer");
 		goto exit;
 	}
-	xnvme_buf_fill(buf, nbytes, "anum");
+
+	err = xnvme_buf_fill(buf, nbytes, "anum");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	// Write data to the buffer
 	nsid = xnvme_dev_get_nsid(dev);

--- a/tests/copy.c
+++ b/tests/copy.c
@@ -30,6 +30,7 @@ test_copy(struct xnvme_cli *cli)
 	char *wbuf = NULL, *rbuf = NULL;
 	struct xnvme_spec_nvm_scopy_fmt_zero *source_range = NULL;
 	uint64_t nlb, nbytes, sdlba, slba;
+	size_t diff = 0;
 	int err;
 
 	switch (geo->type) {
@@ -142,8 +143,17 @@ test_copy(struct xnvme_cli *cli)
 
 	// Compare LBA's
 	xnvme_cli_pinf("Comparing wbuf and rbuf");
-	if (xnvme_buf_diff(wbuf, rbuf, nbytes)) {
-		xnvme_buf_diff_pr(wbuf, rbuf, nbytes, XNVME_PR_DEF);
+	err = xnvme_buf_diff(wbuf, rbuf, nbytes, &diff);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_diff()", err);
+		goto exit;
+	}
+	if (diff) {
+		err = xnvme_buf_diff_pr(wbuf, rbuf, nbytes, XNVME_PR_DEF);
+		if (err) {
+			xnvme_cli_perr("xnvme_buf_diff_pr()", err);
+			goto exit;
+		}
 		err = -EIO;
 		goto exit;
 	}

--- a/tests/copy.c
+++ b/tests/copy.c
@@ -89,7 +89,12 @@ test_copy(struct xnvme_cli *cli)
 		XNVME_DEBUG("Failed: allocating write buffer");
 		goto exit;
 	}
-	xnvme_buf_fill(wbuf, nbytes, "anum");
+
+	err = xnvme_buf_fill(wbuf, nbytes, "anum");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	rbuf = xnvme_buf_alloc(dev, nbytes);
 	if (!rbuf) {
@@ -97,7 +102,12 @@ test_copy(struct xnvme_cli *cli)
 		XNVME_DEBUG("Failed: allocating read buffer");
 		goto exit;
 	}
-	xnvme_buf_fill(rbuf, nbytes, "0");
+
+	err = xnvme_buf_fill(rbuf, nbytes, "0");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	source_range = xnvme_buf_alloc(dev, sizeof(*source_range));
 	if (!source_range) {

--- a/tests/ioworker.c
+++ b/tests/ioworker.c
@@ -280,7 +280,11 @@ iowork_from_cli(struct xnvme_cli *cli, struct iowork *work)
 {
 	int err;
 
-	xnvme_buf_fill(work, sizeof(*work), "zero");
+	err = xnvme_buf_fill(work, sizeof(*work), "zero");
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_fill(), err: %d", err);
+		return err;
+	}
 
 	work->dev = cli->args.dev;
 	work->nsid = xnvme_dev_get_nsid(work->dev);
@@ -313,7 +317,12 @@ iowork_from_cli(struct xnvme_cli *cli, struct iowork *work)
 		XNVME_DEBUG("FAILED: xnvme_buf_alloc(data), err: %d", errno);
 		goto failed;
 	}
-	xnvme_buf_fill(work->wbuf, work->range.nbytes, "rand-t");
+
+	err = xnvme_buf_fill(work->wbuf, work->range.nbytes, "rand-t");
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_fill(), err: %d", err);
+		goto failed;
+	}
 
 	work->rbuf = xnvme_buf_alloc(cli->args.dev, work->range.nbytes);
 	if (!work->rbuf) {
@@ -321,7 +330,12 @@ iowork_from_cli(struct xnvme_cli *cli, struct iowork *work)
 		XNVME_DEBUG("FAILED: xnvme_buf_alloc(buf), err: %d", errno);
 		goto failed;
 	}
-	xnvme_buf_fill(work->rbuf, work->io.nbytes, "zero");
+
+	err = xnvme_buf_fill(work->rbuf, work->io.nbytes, "zero");
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_fill(), err: %d", err);
+		goto failed;
+	}
 
 	err = xnvme_queue_init(work->dev, work->qdepth * 2, 0, &work->queue);
 	if (err) {
@@ -347,7 +361,12 @@ iowork_from_cli(struct xnvme_cli *cli, struct iowork *work)
 			XNVME_DEBUG("FAILED: xnvme_buf_alloc(vec), err: %d", errno);
 			goto failed;
 		}
-		xnvme_buf_fill(worker->vec, sizeof(*worker->vec) * worker->vec_cnt, "zero");
+
+		err = xnvme_buf_fill(worker->vec, sizeof(*worker->vec) * worker->vec_cnt, "zero");
+		if (err) {
+			XNVME_DEBUG("FAILED: xnvme_buf_fill(), err: %d", err);
+			goto failed;
+		}
 	}
 
 	return 0;

--- a/tests/ioworker.c
+++ b/tests/ioworker.c
@@ -380,11 +380,15 @@ start_workers(struct iowork *work)
 static int
 final(struct iowork work, int err)
 {
-	size_t diff;
+	size_t diff = 0;
+	int _err;
 	xnvme_cli_pinf("exit-stats: {submitted: %u, completed: %u, ecount: %u}",
 		       work.stats.nsubmissions, work.stats.ncompletions, work.stats.nerrors);
 
-	diff = xnvme_buf_diff(work.wbuf, work.rbuf, work.range.nbytes);
+	_err = xnvme_buf_diff(work.wbuf, work.rbuf, work.range.nbytes, &diff);
+	if (_err) {
+		xnvme_cli_perr("xnvme_buf_diff()", _err);
+	}
 	iowork_teardown(&work);
 
 	if (err || (work.stats.nerrors) || diff) {

--- a/tests/kvs.c
+++ b/tests/kvs.c
@@ -65,7 +65,12 @@ kvs_io(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_clear(rbuf, kv_val_nbytes);
+
+	err = xnvme_buf_clear(rbuf, kv_val_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	xnvme_cli_pinf("Sending xnvme_kvs_retrieve command");
 	err = xnvme_kvs_retrieve(&ctx, nsid, kv_key, kv_key_nbytes, rbuf, kv_val_nbytes, 0);

--- a/tests/kvs.c
+++ b/tests/kvs.c
@@ -17,6 +17,7 @@ kvs_io(struct xnvme_cli *cli)
 	void *rbuf = NULL;
 	uint8_t kv_key_nbytes = 0;
 	size_t kv_val_nbytes = 0;
+	size_t diff = 0;
 	int err;
 
 	if (cli->given[XNVME_CLI_OPT_KV_KEY]) {
@@ -84,8 +85,18 @@ kvs_io(struct xnvme_cli *cli)
 	xnvme_cli_pinf("KV Value retrieved: '%s'", rbuf);
 
 	xnvme_cli_pinf("Comparing wbuf and rbuf");
-	if (xnvme_buf_diff(dbuf, rbuf, kv_val_nbytes)) {
-		xnvme_buf_diff_pr(dbuf, rbuf, kv_val_nbytes, XNVME_PR_DEF);
+	err = xnvme_buf_diff(dbuf, rbuf, kv_val_nbytes, &diff);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_diff()", err);
+		goto exit;
+	}
+	if (diff) {
+		err = xnvme_buf_diff_pr(dbuf, rbuf, kv_val_nbytes, XNVME_PR_DEF);
+		if (err) {
+			xnvme_cli_perr("xnvme_buf_diff_pr()", err);
+			goto exit;
+		}
+		err = -EIO;
 		goto exit;
 	}
 exit:

--- a/tests/lblk.c
+++ b/tests/lblk.c
@@ -78,6 +78,7 @@ read_and_compare_lba_range(uint8_t *rbuf, const uint8_t *cbuf, const uint64_t rn
 {
 	int err = 0;
 	uint64_t read_bytes = 0;
+	size_t diff = 0;
 	*compared_bytes = 0;
 	xnvme_cli_pinf("Reading and comparing in LBA range [%ld,%ld]", rng_slba, rng_slba + nlb);
 
@@ -95,8 +96,18 @@ read_and_compare_lba_range(uint8_t *rbuf, const uint8_t *cbuf, const uint64_t rn
 		}
 
 		read_bytes = r_nlb * geo->lba_nbytes;
-		if (xnvme_buf_diff(cbuf, rbuf, read_bytes)) {
-			xnvme_buf_diff_pr(cbuf, rbuf, read_bytes, XNVME_PR_DEF);
+
+		err = xnvme_buf_diff(cbuf, rbuf, read_bytes, &diff);
+		if (err) {
+			xnvme_cli_perr("xnvme_buf_diff()", err);
+			goto exit;
+		}
+		if (diff) {
+			err = xnvme_buf_diff_pr(cbuf, rbuf, read_bytes, XNVME_PR_DEF);
+			if (err) {
+				xnvme_cli_perr("xnvme_buf_diff_pr()", err);
+				goto exit;
+			}
 			err = -EIO;
 			goto exit;
 		}
@@ -158,6 +169,7 @@ sub_io(struct xnvme_cli *cli)
 	uint8_t *wbuf = NULL, *rbuf = NULL;
 	int err;
 	uint64_t written_bytes = 0;
+	size_t diff = 0;
 
 	switch (geo->type) {
 	case XNVME_GEO_CONVENTIONAL:
@@ -229,8 +241,18 @@ sub_io(struct xnvme_cli *cli)
 	}
 
 	xnvme_cli_pinf("Comparing wbuf and rbuf");
-	if (xnvme_buf_diff(wbuf, rbuf, buf_nbytes)) {
-		xnvme_buf_diff_pr(wbuf, rbuf, buf_nbytes, XNVME_PR_DEF);
+	err = xnvme_buf_diff(wbuf, rbuf, buf_nbytes, &diff);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_diff()", err);
+		goto exit;
+	}
+	if (diff) {
+		err = xnvme_buf_diff_pr(wbuf, rbuf, buf_nbytes, XNVME_PR_DEF);
+		if (err) {
+			xnvme_cli_perr("xnvme_buf_diff_pr()", err);
+			goto exit;
+		}
+		err = -EIO;
 		goto exit;
 	}
 

--- a/tests/lblk.c
+++ b/tests/lblk.c
@@ -126,7 +126,11 @@ fill_lba_range_and_write_buffer_with_pattern(uint8_t *wbuf, size_t buf_nbytes, u
 {
 	int err;
 
-	xnvme_buf_fill(wbuf, buf_nbytes, pattern);
+	err = xnvme_buf_fill(wbuf, buf_nbytes, pattern);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	*written_bytes = 0;
 	for (uint64_t slba = rng_slba; slba <= rng_elba; slba += mdts_naddr) {
@@ -338,7 +342,11 @@ test_write_zeroes(struct xnvme_cli *cli)
 	xnvme_cli_pinf("Wrote zeroes to LBA range [%ld,%ld]", rng_slba, rng_elba);
 
 	// Set the rbuf to != 0 so we know that we read zeroes
-	xnvme_buf_fill(rbuf, buf_nbytes, "a");
+	err = xnvme_buf_fill(rbuf, buf_nbytes, "a");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	err = xnvme_buf_clear(wbuf, buf_nbytes);
 	if (err) {

--- a/tests/lblk.c
+++ b/tests/lblk.c
@@ -207,7 +207,12 @@ sub_io(struct xnvme_cli *cli)
 
 	xnvme_cli_pinf("Read scattered payload within LBA range [slba,elba]");
 
-	xnvme_buf_clear(rbuf, buf_nbytes);
+	err = xnvme_buf_clear(rbuf, buf_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
+
 	for (uint64_t count = 0; count < mdts_naddr; ++count) {
 		struct xnvme_cmd_ctx ctx = xnvme_cmd_ctx_from_dev(dev);
 		size_t rbuf_ofz = count * geo->lba_nbytes;
@@ -283,7 +288,12 @@ test_write_zeroes(struct xnvme_cli *cli)
 	}
 	xnvme_cli_pinf("Written bytes %ld with !", written_bytes);
 
-	xnvme_buf_clear(rbuf, buf_nbytes);
+	err = xnvme_buf_clear(rbuf, buf_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
+
 	err = read_and_compare_lba_range(rbuf, wbuf, rng_slba, nlb, mdts_naddr, geo, dev, nsid,
 					 &compared_bytes);
 	if (err) {
@@ -307,7 +317,13 @@ test_write_zeroes(struct xnvme_cli *cli)
 
 	// Set the rbuf to != 0 so we know that we read zeroes
 	xnvme_buf_fill(rbuf, buf_nbytes, "a");
-	xnvme_buf_clear(wbuf, buf_nbytes);
+
+	err = xnvme_buf_clear(wbuf, buf_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
+
 	err = read_and_compare_lba_range(rbuf, wbuf, rng_slba, nlb, mdts_naddr, geo, dev, nsid,
 					 &compared_bytes);
 	if (err) {
@@ -369,7 +385,12 @@ test_write_uncorrectable(struct xnvme_cli *cli)
 		goto exit;
 	}
 
-	xnvme_buf_clear(rbuf, buf_nbytes);
+	err = xnvme_buf_clear(rbuf, buf_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
+
 	err = read_and_compare_lba_range(rbuf, wbuf, rng_slba, nlb, mdts_naddr, geo, dev, nsid,
 					 &compared_bytes);
 	if (err) {

--- a/tests/scc.c
+++ b/tests/scc.c
@@ -296,12 +296,20 @@ _scopy_helper(struct xnvme_cli *cli, uint64_t tlbas)
 	}
 
 	{
-		size_t diff;
+		size_t diff = 0;
 
-		diff = xnvme_buf_diff(dbuf, vbuf, buf_nbytes);
+		err = xnvme_buf_diff(dbuf, vbuf, buf_nbytes, &diff);
+		if (err) {
+			xnvme_cli_perr("xnvme_buf_diff()", err);
+			goto exit;
+		}
 		if (diff) {
 			xnvme_cli_pinf("verification failed, diff: %zu", diff);
-			xnvme_buf_diff_pr(dbuf, vbuf, buf_nbytes, XNVME_PR_DEF);
+			err = xnvme_buf_diff_pr(dbuf, vbuf, buf_nbytes, XNVME_PR_DEF);
+			if (err) {
+				xnvme_cli_perr("xnvme_buf_diff_pr()", err);
+				goto exit;
+			}
 			err = -EIO;
 			goto exit;
 		}

--- a/tests/scc.c
+++ b/tests/scc.c
@@ -170,7 +170,12 @@ _scopy_helper(struct xnvme_cli *cli, uint64_t tlbas)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_clear(range, sizeof(*range));
+
+	err = xnvme_buf_clear(range, sizeof(*range));
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	// Buffers for verification
 	buf_nbytes = tlbas * geo->lba_nbytes;

--- a/tests/scc.c
+++ b/tests/scc.c
@@ -191,8 +191,18 @@ _scopy_helper(struct xnvme_cli *cli, uint64_t tlbas)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_fill(dbuf, buf_nbytes, "anum");
-	xnvme_buf_fill(vbuf, buf_nbytes, "zero");
+
+	err = xnvme_buf_fill(dbuf, buf_nbytes, "anum");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
+
+	err = xnvme_buf_fill(vbuf, buf_nbytes, "zero");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	// TODO: Currently, only a single entry is added per row, construct the
 	// range in fancier ways, that is, distributed different over the

--- a/tests/xnvme_file.c
+++ b/tests/xnvme_file.c
@@ -30,7 +30,12 @@ test_file_fsync(struct xnvme_cli *cli)
 		xnvme_file_close(fh);
 		return err;
 	}
-	xnvme_buf_fill(buf, bytes_per_write, "anum");
+
+	err = xnvme_buf_fill(buf, bytes_per_write, "anum");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	for (size_t i = 0; i < num_writes; i++) {
 		struct xnvme_cmd_ctx ctx = xnvme_file_get_cmd_ctx(fh);
@@ -80,7 +85,12 @@ file_write_ascii(const char *path, size_t nbytes, struct xnvme_opts *opts)
 		xnvme_file_close(fh);
 		return err;
 	}
-	xnvme_buf_fill(buf, nbytes, "anum");
+
+	err = xnvme_buf_fill(buf, nbytes, "anum");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	ctx = xnvme_file_get_cmd_ctx(fh);
 	err = xnvme_file_pwrite(&ctx, buf, nbytes, 0);

--- a/tests/xnvme_file.c
+++ b/tests/xnvme_file.c
@@ -18,15 +18,17 @@ test_file_fsync(struct xnvme_cli *cli)
 
 	fh = xnvme_file_open(output_path, &opts);
 	if (fh == NULL) {
-		xnvme_cli_perr("xnvme_file_open()", errno);
-		return -errno;
+		err = -errno;
+		xnvme_cli_perr("xnvme_file_open()", err);
+		return err;
 	}
 
 	buf = xnvme_buf_alloc(fh, bytes_per_write);
 	if (!buf) {
-		xnvme_cli_perr("xnvme_buf_alloc()", errno);
+		err = -errno;
+		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		xnvme_file_close(fh);
-		return -errno;
+		return err;
 	}
 	xnvme_buf_fill(buf, bytes_per_write, "anum");
 
@@ -35,20 +37,21 @@ test_file_fsync(struct xnvme_cli *cli)
 
 		err = xnvme_file_pwrite(&ctx, buf, bytes_per_write, 0);
 		if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+			err = err ? err : -EIO;
 			xnvme_cli_perr("xnvme_file_pwrite()", err);
-			return err;
+			goto exit;
 		}
 
 		err = xnvme_file_sync(fh);
 		if (err) {
 			xnvme_cli_perr("xnvme_file_sync()", err);
-			return err;
+			goto exit;
 		}
 	}
-
+exit:
 	xnvme_buf_free(fh, buf);
 	xnvme_file_close(fh);
-	return 0;
+	return err;
 }
 
 /**
@@ -65,28 +68,32 @@ file_write_ascii(const char *path, size_t nbytes, struct xnvme_opts *opts)
 
 	fh = xnvme_file_open(path, opts);
 	if (fh == NULL) {
-		xnvme_cli_perr("xnvme_file_open()", errno);
-		return -errno;
+		err = -errno;
+		xnvme_cli_perr("xnvme_file_open()", err);
+		return err;
 	}
 
 	buf = xnvme_buf_alloc(fh, nbytes);
 	if (!buf) {
-		xnvme_cli_perr("xnvme_buf_alloc()", errno);
+		err = -errno;
+		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		xnvme_file_close(fh);
-		return -errno;
+		return err;
 	}
 	xnvme_buf_fill(buf, nbytes, "anum");
 
 	ctx = xnvme_file_get_cmd_ctx(fh);
 	err = xnvme_file_pwrite(&ctx, buf, nbytes, 0);
 	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		err = err ? err : -EIO;
 		xnvme_cli_perr("xnvme_file_pwrite()", err);
-		return err;
+		goto exit;
 	}
 
+exit:
 	xnvme_buf_free(fh, buf);
 	xnvme_file_close(fh);
-	return 0;
+	return err;
 }
 
 /**

--- a/tests/znd_append.c
+++ b/tests/znd_append.c
@@ -88,8 +88,18 @@ cmd_verify(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_fill(dbuf, buf_nbytes, "anum");
-	xnvme_buf_fill(vbuf, buf_nbytes, "zero");
+
+	err = xnvme_buf_fill(dbuf, buf_nbytes, "anum");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
+
+	err = xnvme_buf_fill(vbuf, buf_nbytes, "zero");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	xnvme_cli_pinf("Using XNVME_CMD_ASYNC mode");
 

--- a/tests/znd_append.c
+++ b/tests/znd_append.c
@@ -165,12 +165,20 @@ cmd_verify(struct xnvme_cli *cli)
 
 	// Verify
 	{
-		size_t diff;
+		size_t diff = 0;
 
-		diff = xnvme_buf_diff(dbuf, vbuf, buf_nbytes);
+		err = xnvme_buf_diff(dbuf, vbuf, buf_nbytes, &diff);
+		if (err) {
+			xnvme_cli_perr("xnvme_buf_diff()", err);
+			goto exit;
+		}
 		if (diff) {
 			xnvme_cli_pinf("verification failed, diff: %zu", diff);
-			xnvme_buf_diff_pr(dbuf, vbuf, buf_nbytes, XNVME_PR_DEF);
+			err = xnvme_buf_diff_pr(dbuf, vbuf, buf_nbytes, XNVME_PR_DEF);
+			if (err) {
+				xnvme_cli_perr("xnvme_buf_diff_pr()", err);
+				goto exit;
+			}
 			err = -EIO;
 			goto exit;
 		}

--- a/tests/znd_explicit_open.c
+++ b/tests/znd_explicit_open.c
@@ -38,6 +38,7 @@ test_open_zdptr(struct xnvme_cli *cli)
 		err = -errno;
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(zde, zde_nbytes, "anum");
 	if (err) {
 		xnvme_cli_perr("xnvme_buf_fill()", err);

--- a/tests/znd_explicit_open.c
+++ b/tests/znd_explicit_open.c
@@ -125,6 +125,7 @@ test_open_zdptr(struct xnvme_cli *cli)
 
 	{
 		void *zde_after;
+		size_t diff = 0;
 
 		// Verification
 		err = xnvme_znd_report_get_descr(after, zidx, &descr, &zde_after);
@@ -134,8 +135,18 @@ test_open_zdptr(struct xnvme_cli *cli)
 			return err;
 		}
 
-		if (xnvme_buf_diff(zde, zde_after, zde_nbytes)) {
-			xnvme_buf_diff_pr(zde, descr, zde_nbytes, XNVME_PR_DEF);
+		err = xnvme_buf_diff(zde, zde_after, zde_nbytes, &diff);
+		if (err) {
+			xnvme_cli_perr("xnvme_buf_diff()", err);
+			goto exit;
+		}
+
+		if (diff) {
+			err = xnvme_buf_diff_pr(zde, descr, zde_nbytes, XNVME_PR_DEF);
+			if (err) {
+				xnvme_cli_perr("xnvme_buf_diff_pr()", err);
+				goto exit;
+			}
 			err = -EIO;
 			goto exit;
 		}

--- a/tests/znd_zrwa.c
+++ b/tests/znd_zrwa.c
@@ -189,6 +189,7 @@ test_flush(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(dbuf, dbuf_nbytes, "anum");
 	if (err) {
 		xnvme_cli_perr("xnvme_buf_fill()", err);
@@ -302,6 +303,7 @@ test_flush_implicit(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(dbuf, dbuf_nbytes, "anum");
 	if (err) {
 		xnvme_cli_perr("xnvme_buf_fill()", err);

--- a/tools/kvs.c
+++ b/tools/kvs.c
@@ -126,7 +126,12 @@ cmd_retrieve(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_clear(dbuf, dbuf_nbytes);
+
+	err = xnvme_buf_clear(dbuf, dbuf_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	xnvme_cli_pinf("Sending xnvme_kvs_retrieve command");
 	err = xnvme_kvs_retrieve(&ctx, nsid, cli->args.kv_key, strlen(cli->args.kv_key), dbuf,
@@ -278,7 +283,12 @@ cmd_list(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_clear(dbuf, dbuf_nbytes);
+
+	err = xnvme_buf_clear(dbuf, dbuf_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	XNVME_DEBUG("Sending xnvme_kvs_list command");
 

--- a/tools/lblk.c
+++ b/tools/lblk.c
@@ -155,7 +155,12 @@ sub_read(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_clear(dbuf, dbuf_nbytes);
+
+	err = xnvme_buf_clear(dbuf, dbuf_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	if (mbuf_nbytes) {
 		xnvme_cli_pinf("Alloc/clear mbuf, mbuf_nbytes: %zu", mbuf_nbytes);
@@ -165,7 +170,12 @@ sub_read(struct xnvme_cli *cli)
 			xnvme_cli_perr("xnvme_buf_alloc()", err);
 			goto exit;
 		}
-		xnvme_buf_clear(mbuf, mbuf_nbytes);
+
+		err = xnvme_buf_clear(mbuf, mbuf_nbytes);
+		if (err) {
+			xnvme_cli_perr("xnvme_buf_clear()", err);
+			goto exit;
+		}
 	}
 
 	xnvme_cli_pinf("Sending the command...");
@@ -685,10 +695,18 @@ sub_write_read_pi(struct xnvme_cli *cli)
 		goto exit;
 	}
 
-	xnvme_buf_clear(dbuf, dbuf_nbytes);
+	err = xnvme_buf_clear(dbuf, dbuf_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	if (mbuf_nbytes) {
-		xnvme_buf_clear(mbuf, mbuf_nbytes);
+		err = xnvme_buf_clear(mbuf, mbuf_nbytes);
+		if (err) {
+			xnvme_cli_perr("xnvme_buf_clear()", err);
+			goto exit;
+		}
 	}
 
 	xnvme_prep_nvm(&ctx, XNVME_SPEC_NVM_OPC_READ, nsid, slba, nlb);

--- a/tools/lblk.c
+++ b/tools/lblk.c
@@ -241,6 +241,7 @@ sub_write(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(dbuf, dbuf_nbytes,
 			     cli->args.data_input ? cli->args.data_input : "anum");
 	if (err) {
@@ -256,6 +257,7 @@ sub_write(struct xnvme_cli *cli)
 			xnvme_cli_perr("xnvme_buf_alloc()", err);
 			goto exit;
 		}
+
 		err = xnvme_buf_fill(mbuf, mbuf_nbytes, "anum");
 		if (err) {
 			xnvme_cli_perr("xnvme_buf_fill()", err);
@@ -515,6 +517,7 @@ sub_write_directive(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(dbuf, dbuf_nbytes,
 			     cli->args.data_input ? cli->args.data_input : "anum");
 	if (err) {
@@ -530,6 +533,7 @@ sub_write_directive(struct xnvme_cli *cli)
 			xnvme_cli_perr("xnvme_buf_alloc()", err);
 			goto exit;
 		}
+
 		err = xnvme_buf_fill(mbuf, mbuf_nbytes, "anum");
 		if (err) {
 			xnvme_cli_perr("xnvme_buf_fill()", err);
@@ -613,6 +617,7 @@ sub_write_read_pi(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(dbuf, dbuf_nbytes,
 			     cli->args.data_input ? cli->args.data_input : "anum");
 	if (err) {
@@ -628,6 +633,7 @@ sub_write_read_pi(struct xnvme_cli *cli)
 			xnvme_cli_perr("xnvme_buf_alloc()", err);
 			goto exit;
 		}
+
 		err = xnvme_buf_fill(mbuf, mbuf_nbytes, "anum");
 		if (err) {
 			xnvme_cli_perr("xnvme_buf_fill()", err);
@@ -775,6 +781,7 @@ sub_compare(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(dbuf, dbuf_nbytes,
 			     cli->args.data_input ? cli->args.data_input : "anum");
 	if (err) {
@@ -790,6 +797,7 @@ sub_compare(struct xnvme_cli *cli)
 			xnvme_cli_perr("xnvme_buf_alloc()", err);
 			goto exit;
 		}
+
 		err = xnvme_buf_fill(mbuf, mbuf_nbytes,
 				     cli->args.meta_input ? cli->args.meta_input : "anum");
 		if (err) {

--- a/tools/xdd.c
+++ b/tools/xdd.c
@@ -99,7 +99,12 @@ copy_async(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", errno);
 		goto exit;
 	}
-	xnvme_buf_fill(buf, buf_nbytes, "zero");
+
+	err = xnvme_buf_fill(buf, buf_nbytes, "zero");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	err = xnvme_queue_init(src_dev, qdepth, 0, &queue);
 	if (err) {
@@ -224,7 +229,12 @@ copy_sync(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_fill(buf, buf_nbytes, "zero");
+
+	err = xnvme_buf_fill(buf, buf_nbytes, "zero");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	xnvme_cli_pinf("copy-sync: {src: %s, dst: %s, tbytes: %zu, buf_nbytes: %zu, iosize: %zu, "
 		       "start_offset: %zu}",

--- a/tools/xdd.c
+++ b/tools/xdd.c
@@ -194,6 +194,7 @@ copy_sync(struct xnvme_cli *cli)
 	struct xnvme_opts dst_opts = {.wronly = 1, .create = 1, .direct = cli->args.direct};
 	size_t buf_nbytes, tbytes, iosize, start_offset;
 	char *buf = NULL;
+	int err;
 
 	src_uri = cli->args.data_input;
 	dst_uri = cli->args.data_output;
@@ -204,20 +205,23 @@ copy_sync(struct xnvme_cli *cli)
 
 	src_dev = xnvme_file_open(src_uri, &src_opts);
 	if (!src_dev) {
-		xnvme_cli_perr("xnvme_file_open(src)", errno);
-		return errno;
+		err = -errno;
+		xnvme_cli_perr("xnvme_file_open(src)", err);
+		return err;
 	}
 	dst_dev = xnvme_file_open(dst_uri, &dst_opts);
 	if (!dst_dev) {
-		xnvme_cli_perr("xnvme_file_open(dst)", errno);
+		err = -errno;
+		xnvme_cli_perr("xnvme_file_open(dst)", err);
 		xnvme_file_close(src_dev);
-		return errno;
+		return err;
 	}
 
 	buf_nbytes = iosize;
 	buf = xnvme_buf_alloc(dst_dev, buf_nbytes);
 	if (!buf) {
-		xnvme_cli_perr("xnvme_buf_alloc()", errno);
+		err = -errno;
+		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
 	xnvme_buf_fill(buf, buf_nbytes, "zero");
@@ -232,18 +236,19 @@ copy_sync(struct xnvme_cli *cli)
 		struct xnvme_cmd_ctx src_ctx = xnvme_file_get_cmd_ctx(src_dev);
 		struct xnvme_cmd_ctx dst_ctx = xnvme_file_get_cmd_ctx(dst_dev);
 		size_t nbytes = XNVME_MIN_U64(iosize, tbytes - (ofz - start_offset));
-		ssize_t res;
 
-		res = xnvme_file_pread(&src_ctx, buf, nbytes, ofz);
-		if (res || xnvme_cmd_ctx_cpl_status(&src_ctx)) {
-			xnvme_cli_perr("xnvme_file_pread(src)", res);
+		err = xnvme_file_pread(&src_ctx, buf, nbytes, ofz);
+		if (err || xnvme_cmd_ctx_cpl_status(&src_ctx)) {
+			err = err ? err : -EIO;
+			xnvme_cli_perr("xnvme_file_pread(src)", err);
 			xnvme_cmd_ctx_pr(&src_ctx, XNVME_PR_DEF);
 			goto exit;
 		}
 
-		res = xnvme_file_pwrite(&dst_ctx, buf, nbytes, ofz - start_offset);
-		if (res || xnvme_cmd_ctx_cpl_status(&dst_ctx)) {
-			xnvme_cli_perr("xnvme_file_pwrite(dst)", res);
+		err = xnvme_file_pwrite(&dst_ctx, buf, nbytes, ofz - start_offset);
+		if (err || xnvme_cmd_ctx_cpl_status(&dst_ctx)) {
+			err = err ? err : -EIO;
+			xnvme_cli_perr("xnvme_file_pwrite(dst)", err);
 			xnvme_cmd_ctx_pr(&dst_ctx, XNVME_PR_DEF);
 			goto exit;
 		}
@@ -256,7 +261,7 @@ exit:
 	xnvme_buf_free(dst_dev, buf);
 	xnvme_file_close(src_dev);
 	xnvme_file_close(dst_dev);
-	return 0;
+	return err;
 }
 
 static struct xnvme_cli_sub g_subs[] = {

--- a/tools/xnvme.c
+++ b/tools/xnvme.c
@@ -310,7 +310,12 @@ sub_log_health(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_clear(log, log_nbytes);
+
+	err = xnvme_buf_clear(log, log_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	xnvme_cli_pinf("Retrieving SMART / health log page ...");
 	err = xnvme_adm_log(&ctx, XNVME_SPEC_LOG_HEALTH, 0x0, 0, nsid, 0, log, log_nbytes);
@@ -355,7 +360,12 @@ sub_log_erri(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_clear(log, log_nbytes);
+
+	err = xnvme_buf_clear(log, log_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	xnvme_cli_pinf("Retrieving error-info-log ...");
 	err = xnvme_adm_log(&ctx, XNVME_SPEC_LOG_ERRI, 0x0, 0x0, 0xFFFFFFFF, 0, log, log_nbytes);
@@ -397,7 +407,12 @@ sub_log_sanitize(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_clear(log, log_nbytes);
+
+	err = xnvme_buf_clear(log, log_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	xnvme_cli_pinf("Retrieving Sanitize log page ...");
 	err = xnvme_adm_log(&ctx, XNVME_SPEC_LOG_SANITIZE, 0x0, 0, nsid, 0, log, log_nbytes);
@@ -445,7 +460,12 @@ sub_log_fdp_config(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_clear(log, log_nbytes);
+
+	err = xnvme_buf_clear(log, log_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	xnvme_prep_adm_log(&ctx, XNVME_SPEC_LOG_FDPCONF, 0x0, 0, nsid, 0, log_nbytes);
 	ctx.cmd.log.lsi = egi;
@@ -492,7 +512,12 @@ sub_log_ruhu(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_clear(log, log_nbytes);
+
+	err = xnvme_buf_clear(log, log_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	xnvme_cli_pinf("Retrieving ruhu-log ...");
 	xnvme_prep_adm_log(&ctx, XNVME_SPEC_LOG_FDPRUHU, 0x0, 0, nsid, 0, log_nbytes);
@@ -539,7 +564,12 @@ sub_log_fdp_stats(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_clear(log, log_nbytes);
+
+	err = xnvme_buf_clear(log, log_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	xnvme_prep_adm_log(&ctx, XNVME_SPEC_LOG_FDPSTATS, 0x0, 0, nsid, 0, log_nbytes);
 	ctx.cmd.log.lsi = egi;
@@ -587,7 +617,12 @@ sub_log_fdp_events(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_clear(log, log_nbytes);
+
+	err = xnvme_buf_clear(log, log_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	xnvme_cli_pinf("Retrieving fdp-events-log ...");
 	xnvme_prep_adm_log(&ctx, XNVME_SPEC_LOG_FDPEVENTS, 0x0, 0, nsid, 0, log_nbytes);
@@ -701,7 +736,12 @@ sub_gfeat(struct xnvme_cli *cli)
 			xnvme_cli_perr("xnvme_buf_alloc()", err);
 			goto exit;
 		}
-		xnvme_buf_clear(dbuf, dbuf_nbytes);
+
+		err = xnvme_buf_clear(dbuf, dbuf_nbytes);
+		if (err) {
+			xnvme_cli_perr("xnvme_buf_clear()", err);
+			goto exit;
+		}
 	}
 
 	xnvme_cli_pinf("cmd_gfeat: {nsid: 0x%x, fid: 0x%x, sel: 0x%x}", nsid, fid, sel);
@@ -930,7 +970,12 @@ sub_ruhs(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_clear(ruhs, ruhs_nbytes);
+
+	err = xnvme_buf_clear(ruhs, ruhs_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	xnvme_cli_pinf("Retrieving ruhs ...");
 	err = xnvme_nvm_mgmt_recv(&ctx, nsid, XNVME_SPEC_IO_MGMT_RECV_RUHS, 0, ruhs, ruhs_nbytes);

--- a/tools/xnvme.c
+++ b/tools/xnvme.c
@@ -812,6 +812,7 @@ sub_sfeat(struct xnvme_cli *cli)
 			xnvme_cli_perr("xnvme_buf_alloc()", err);
 			goto exit;
 		}
+
 		err = xnvme_buf_fill(dbuf, dbuf_nbytes, cli->args.data_input);
 		if (err) {
 			xnvme_cli_perr("xnvme_buf_fill()", err);

--- a/tools/xnvme_file.c
+++ b/tools/xnvme_file.c
@@ -121,21 +121,24 @@ dump_sync(struct xnvme_cli *cli)
 	const char *fpath;
 	size_t buf_nbytes, tbytes, iosize;
 	char *buf;
+	int err;
 
 	fpath = cli->args.data_output;
 	iosize = cli->given[XNVME_CLI_OPT_IOSIZE] ? cli->args.iosize : IOSIZE_DEF;
 
 	fh = xnvme_file_open(fpath, &opts);
 	if (!fh) {
-		xnvme_cli_perr("xnvme_file_open(fh)", errno);
-		return errno;
+		err = -errno;
+		xnvme_cli_perr("xnvme_file_open(fh)", err);
+		return err;
 	}
 	tbytes = cli->args.data_nbytes;
 
 	buf_nbytes = tbytes;
 	buf = xnvme_buf_alloc(fh, buf_nbytes);
 	if (!buf) {
-		xnvme_cli_perr("xnvme_buf_alloc()", errno);
+		err = -errno;
+		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
 	xnvme_buf_fill(buf, buf_nbytes, "anum");
@@ -148,11 +151,11 @@ dump_sync(struct xnvme_cli *cli)
 	for (size_t ofz = 0; ofz < tbytes; ofz += iosize) {
 		struct xnvme_cmd_ctx ctx = xnvme_file_get_cmd_ctx(fh);
 		size_t nbytes = XNVME_MIN_U64(iosize, tbytes - ofz);
-		ssize_t res;
 
-		res = xnvme_file_pwrite(&ctx, buf + ofz, nbytes, ofz);
-		if (res || xnvme_cmd_ctx_cpl_status(&ctx)) {
-			xnvme_cli_perr("xnvme_file_pwrite(fh)", res);
+		err = xnvme_file_pwrite(&ctx, buf + ofz, nbytes, ofz);
+		if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+			err = err ? err : -EIO;
+			xnvme_cli_perr("xnvme_file_pwrite(fh)", err);
 			xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
 			goto exit;
 		}
@@ -164,7 +167,7 @@ dump_sync(struct xnvme_cli *cli)
 exit:
 	xnvme_buf_free(fh, buf);
 	xnvme_file_close(fh);
-	return 0;
+	return err;
 }
 
 int
@@ -183,14 +186,16 @@ dump_sync_iovec(struct xnvme_cli *cli)
 	size_t ofz = 0;
 	int dvec_cnt = cli->args.vec_cnt;
 	char *buf;
+	int err;
 
 	fpath = cli->args.data_output;
 	iosize = cli->given[XNVME_CLI_OPT_IOSIZE] ? cli->args.iosize : IOSIZE_DEF;
 
 	fh = xnvme_file_open(fpath, &opts);
 	if (!fh) {
-		xnvme_cli_perr("xnvme_file_open(fh)", errno);
-		return errno;
+		err = -errno;
+		xnvme_cli_perr("xnvme_file_open(fh)", err);
+		return err;
 	}
 	tbytes = cli->args.data_nbytes;
 	tbytes_left = tbytes;
@@ -198,7 +203,8 @@ dump_sync_iovec(struct xnvme_cli *cli)
 	buf_nbytes = tbytes;
 	buf = xnvme_buf_alloc(fh, buf_nbytes);
 	if (!buf) {
-		xnvme_cli_perr("xnvme_buf_alloc()", errno);
+		err = -errno;
+		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
 	xnvme_buf_fill(buf, buf_nbytes, "anum");
@@ -218,7 +224,6 @@ dump_sync_iovec(struct xnvme_cli *cli)
 	for (int i = 0; i < nios; i++) {
 		struct iovec dvec[dvec_cnt];
 		int ndvec = XNVME_MIN_U64(dvec_cnt, (tbytes_left + iosize - 1) / iosize);
-		int res;
 		size_t nbytes = 0;
 
 		for (int k = 0; k < ndvec; k++) {
@@ -230,9 +235,10 @@ dump_sync_iovec(struct xnvme_cli *cli)
 			nbytes += iov_len;
 		}
 
-		res = xnvme_cmd_pass_iov(&ctx, dvec, ndvec, nbytes, NULL, 0);
-		if (res || xnvme_cmd_ctx_cpl_status(&ctx)) {
-			xnvme_cli_perr("xnvme_cmd_pass_iov(fh)", res);
+		err = xnvme_cmd_pass_iov(&ctx, dvec, ndvec, nbytes, NULL, 0);
+		if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+			err = err ? err : -EIO;
+			xnvme_cli_perr("xnvme_cmd_pass_iov(fh)", err);
 			xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
 			goto exit;
 		}
@@ -244,7 +250,7 @@ dump_sync_iovec(struct xnvme_cli *cli)
 exit:
 	xnvme_buf_free(fh, buf);
 	xnvme_file_close(fh);
-	return 0;
+	return err;
 }
 
 int
@@ -266,15 +272,17 @@ dump_async(struct xnvme_cli *cli)
 
 	fh = xnvme_file_open(fpath, &opts);
 	if (fh == NULL) {
-		xnvme_cli_perr("xnvme_file_open(fh)", errno);
-		return errno;
+		err = -errno;
+		xnvme_cli_perr("xnvme_file_open(fh)", err);
+		return err;
 	}
 	tbytes = cli->args.data_nbytes;
 
 	buf_nbytes = tbytes;
 	buf = xnvme_buf_alloc(fh, buf_nbytes);
 	if (!buf) {
-		xnvme_cli_perr("xnvme_buf_alloc()", errno);
+		err = -errno;
+		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
 	xnvme_buf_fill(buf, buf_nbytes, "anum");
@@ -295,11 +303,10 @@ dump_async(struct xnvme_cli *cli)
 	for (size_t ofz = 0; (ofz < tbytes) && !cb_args.nerrors;) {
 		struct xnvme_cmd_ctx *ctx = xnvme_queue_get_cmd_ctx(queue);
 		size_t nbytes = XNVME_MIN_U64(iosize, tbytes - ofz);
-		ssize_t res;
 
 submit:
-		res = xnvme_file_pwrite(ctx, buf + ofz, nbytes, ofz);
-		switch (res) {
+		err = xnvme_file_pwrite(ctx, buf + ofz, nbytes, ofz);
+		switch (err) {
 		case 0:
 			cb_args.nsubmissions += 1;
 			goto next;
@@ -340,7 +347,7 @@ exit:
 
 	xnvme_buf_free(fh, buf);
 	xnvme_file_close(fh);
-	return 0;
+	return err;
 }
 
 int
@@ -369,8 +376,9 @@ dump_async_iovec(struct xnvme_cli *cli)
 
 	fh = xnvme_file_open(fpath, &opts);
 	if (!fh) {
-		xnvme_cli_perr("xnvme_file_open(fh)", errno);
-		return errno;
+		err = -errno;
+		xnvme_cli_perr("xnvme_file_open(fh)", err);
+		return err;
 	}
 	tbytes = cli->args.data_nbytes;
 	tbytes_left = tbytes;
@@ -378,7 +386,8 @@ dump_async_iovec(struct xnvme_cli *cli)
 	buf_nbytes = tbytes;
 	buf = xnvme_buf_alloc(fh, buf_nbytes);
 	if (!buf) {
-		xnvme_cli_perr("xnvme_buf_alloc()", errno);
+		err = -errno;
+		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
 	xnvme_buf_fill(buf, buf_nbytes, "anum");
@@ -402,7 +411,6 @@ dump_async_iovec(struct xnvme_cli *cli)
 		struct xnvme_cmd_ctx *ctx = xnvme_queue_get_cmd_ctx(queue);
 		struct iovec dvec[dvec_cnt];
 		int ndvec = XNVME_MIN_U64(dvec_cnt, (tbytes_left + iosize - 1) / iosize);
-		int res;
 		size_t nbytes = 0;
 
 		ctx->cmd.common.nsid = xnvme_dev_get_nsid(ctx->dev);
@@ -419,8 +427,8 @@ dump_async_iovec(struct xnvme_cli *cli)
 		}
 
 submit:
-		res = xnvme_cmd_pass_iov(ctx, dvec, ndvec, nbytes, NULL, 0);
-		switch (res) {
+		err = xnvme_cmd_pass_iov(ctx, dvec, ndvec, nbytes, NULL, 0);
+		switch (err) {
 		case 0:
 			cb_args.nsubmissions += 1;
 			continue;
@@ -445,7 +453,7 @@ submit:
 exit:
 	xnvme_buf_free(fh, buf);
 	xnvme_file_close(fh);
-	return 0;
+	return err;
 }
 
 int
@@ -456,21 +464,24 @@ load_sync(struct xnvme_cli *cli)
 	const char *fpath;
 	size_t buf_nbytes, tbytes, iosize;
 	char *buf;
+	int err;
 
 	fpath = cli->args.data_input;
 	iosize = cli->given[XNVME_CLI_OPT_IOSIZE] ? cli->args.iosize : IOSIZE_DEF;
 
 	fh = xnvme_file_open(fpath, &opts);
 	if (!fh) {
-		xnvme_cli_perr("xnvme_file_open(fh)", errno);
-		return errno;
+		err = -errno;
+		xnvme_cli_perr("xnvme_file_open(fh)", err);
+		return err;
 	}
 	tbytes = xnvme_dev_get_geo(fh)->tbytes;
 
 	buf_nbytes = tbytes;
 	buf = xnvme_buf_alloc(fh, buf_nbytes);
 	if (!buf) {
-		xnvme_cli_perr("xnvme_buf_alloc()", errno);
+		err = -errno;
+		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
 	xnvme_buf_fill(buf, buf_nbytes, "zero");
@@ -483,11 +494,11 @@ load_sync(struct xnvme_cli *cli)
 	for (size_t ofz = 0; ofz < tbytes; ofz += iosize) {
 		struct xnvme_cmd_ctx ctx = xnvme_file_get_cmd_ctx(fh);
 		size_t nbytes = XNVME_MIN_U64(iosize, tbytes - ofz);
-		ssize_t res;
 
-		res = xnvme_file_pread(&ctx, buf + ofz, nbytes, ofz);
-		if (res || xnvme_cmd_ctx_cpl_status(&ctx)) {
-			xnvme_cli_perr("xnvme_file_pread(fh)", res);
+		err = xnvme_file_pread(&ctx, buf + ofz, nbytes, ofz);
+		if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+			err = err ? err : -EIO;
+			xnvme_cli_perr("xnvme_file_pread(fh)", err);
 			xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
 			goto exit;
 		}
@@ -500,7 +511,7 @@ exit:
 	xnvme_buf_free(fh, buf);
 	xnvme_file_close(fh);
 
-	return 0;
+	return err;
 }
 
 int
@@ -523,15 +534,17 @@ load_async(struct xnvme_cli *cli)
 
 	fh = xnvme_file_open(fpath, &opts);
 	if (fh == NULL) {
-		xnvme_cli_perr("xnvme_file_open(fh)", errno);
-		return errno;
+		err = -errno;
+		xnvme_cli_perr("xnvme_file_open(fh)", err);
+		return err;
 	}
 	tbytes = xnvme_dev_get_geo(fh)->tbytes;
 
 	buf_nbytes = tbytes;
 	buf = xnvme_buf_alloc(fh, buf_nbytes);
 	if (!buf) {
-		xnvme_cli_perr("xnvme_buf_alloc()", errno);
+		err = -errno;
+		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
 	xnvme_buf_fill(buf, buf_nbytes, "zero");
@@ -552,11 +565,10 @@ load_async(struct xnvme_cli *cli)
 	for (size_t ofz = 0; (ofz < tbytes) && !cb_args.nerrors;) {
 		struct xnvme_cmd_ctx *ctx = xnvme_queue_get_cmd_ctx(queue);
 		size_t nbytes = XNVME_MIN_U64(iosize, tbytes - ofz);
-		ssize_t res;
 
 submit:
-		res = xnvme_file_pread(ctx, buf + ofz, nbytes, ofz);
-		switch (res) {
+		err = xnvme_file_pread(ctx, buf + ofz, nbytes, ofz);
+		switch (err) {
 		case 0:
 			cb_args.nsubmissions += 1;
 			goto next;
@@ -598,7 +610,7 @@ exit:
 	xnvme_buf_free(fh, buf);
 	xnvme_file_close(fh);
 
-	return 0;
+	return err;
 }
 
 int
@@ -610,6 +622,7 @@ copy_file_sync(struct xnvme_cli *cli)
 	const char *src_fpath, *dst_fpath;
 	size_t buf_nbytes, tbytes, iosize;
 	char *buf = NULL;
+	int err;
 
 	src_fpath = cli->args.data_input;
 	dst_fpath = cli->args.data_output;
@@ -617,12 +630,14 @@ copy_file_sync(struct xnvme_cli *cli)
 
 	src_fh = xnvme_file_open(src_fpath, &src_opts);
 	if (src_fh == NULL) {
-		xnvme_cli_perr("xnvme_file_open(src)", errno);
-		return errno;
+		err = -errno;
+		xnvme_cli_perr("xnvme_file_open(src)", err);
+		return err;
 	}
 	dst_fh = xnvme_file_open(dst_fpath, &dst_opts);
 	if (dst_fh == NULL) {
-		xnvme_cli_perr("xnvme_file_open(dst)", errno);
+		err = -errno;
+		xnvme_cli_perr("xnvme_file_open(dst)", err);
 		goto exit;
 	}
 	tbytes = xnvme_dev_get_geo(src_fh)->tbytes;
@@ -630,7 +645,8 @@ copy_file_sync(struct xnvme_cli *cli)
 	buf_nbytes = iosize;
 	buf = xnvme_buf_alloc(src_fh, buf_nbytes);
 	if (!buf) {
-		xnvme_cli_perr("xnvme_buf_alloc()", errno);
+		err = -errno;
+		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
 	xnvme_buf_fill(buf, buf_nbytes, "zero");
@@ -644,18 +660,19 @@ copy_file_sync(struct xnvme_cli *cli)
 		struct xnvme_cmd_ctx src_ctx = xnvme_file_get_cmd_ctx(src_fh);
 		struct xnvme_cmd_ctx dst_ctx = xnvme_file_get_cmd_ctx(dst_fh);
 		size_t nbytes = XNVME_MIN_U64(iosize, tbytes - ofz);
-		ssize_t res;
 
-		res = xnvme_file_pread(&src_ctx, buf, nbytes, ofz);
-		if (res || xnvme_cmd_ctx_cpl_status(&src_ctx)) {
-			xnvme_cli_perr("xnvme_file_pread(src)", res);
+		err = xnvme_file_pread(&src_ctx, buf, nbytes, ofz);
+		if (err || xnvme_cmd_ctx_cpl_status(&src_ctx)) {
+			err = err ? err : -EIO;
+			xnvme_cli_perr("xnvme_file_pread(src)", err);
 			xnvme_cmd_ctx_pr(&src_ctx, XNVME_PR_DEF);
 			goto exit;
 		}
 
-		res = xnvme_file_pwrite(&dst_ctx, buf, nbytes, ofz);
-		if (res || xnvme_cmd_ctx_cpl_status(&dst_ctx)) {
-			xnvme_cli_perr("xnvme_file_pwrite(dst)", res);
+		err = xnvme_file_pwrite(&dst_ctx, buf, nbytes, ofz);
+		if (err || xnvme_cmd_ctx_cpl_status(&dst_ctx)) {
+			err = err ? err : -EIO;
+			xnvme_cli_perr("xnvme_file_pwrite(dst)", err);
 			xnvme_cmd_ctx_pr(&dst_ctx, XNVME_PR_DEF);
 			goto exit;
 		}
@@ -668,7 +685,7 @@ exit:
 	xnvme_buf_free(src_fh, buf);
 	xnvme_file_close(src_fh);
 	xnvme_file_close(dst_fh);
-	return 0;
+	return err;
 }
 
 int
@@ -705,12 +722,14 @@ copy_file_async(struct xnvme_cli *cli)
 
 	src_fh = xnvme_file_open(src_fpath, &src_opts);
 	if (src_fh == NULL) {
-		xnvme_cli_perr("xnvme_file_open(src)", errno);
-		return errno;
+		err = -errno;
+		xnvme_cli_perr("xnvme_file_open(src)", err);
+		return err;
 	}
 	dst_fh = xnvme_file_open(dst_fpath, &dst_opts);
 	if (dst_fh == NULL) {
-		xnvme_cli_perr("xnvme_file_open(dst)", errno);
+		err = -errno;
+		xnvme_cli_perr("xnvme_file_open(dst)", err);
 		goto exit;
 	}
 	tbytes = xnvme_dev_get_geo(src_fh)->tbytes;
@@ -718,7 +737,8 @@ copy_file_async(struct xnvme_cli *cli)
 	buf_nbytes = iosize * qdepth;
 	buf = xnvme_buf_alloc(src_fh, buf_nbytes);
 	if (!buf) {
-		xnvme_cli_perr("xnvme_buf_alloc()", errno);
+		err = -errno;
+		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
 	xnvme_buf_fill(buf, buf_nbytes, "zero");
@@ -748,13 +768,12 @@ copy_file_async(struct xnvme_cli *cli)
 		struct cb_args_copy *work = &cb_args_copy[(ofz / iosize) % qdepth];
 		struct xnvme_cmd_ctx *src_ctx = xnvme_cmd_ctx_from_queue(queue);
 		size_t nbytes = XNVME_MIN_U64(iosize, tbytes - ofz);
-		ssize_t res;
 
 		src_ctx->async.cb_arg = work;
 
 submit:
-		res = xnvme_file_pread(src_ctx, work->buf, nbytes, ofz);
-		switch (res) {
+		err = xnvme_file_pread(src_ctx, work->buf, nbytes, ofz);
+		switch (err) {
 		case 0:
 			work->nsubmissions += 1;
 			goto next;
@@ -803,7 +822,7 @@ exit:
 	xnvme_buf_free(src_fh, buf);
 	xnvme_file_close(src_fh);
 	xnvme_file_close(dst_fh);
-	return 0;
+	return err;
 }
 
 static struct xnvme_cli_sub g_subs[] = {

--- a/tools/xnvme_file.c
+++ b/tools/xnvme_file.c
@@ -141,7 +141,12 @@ dump_sync(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_fill(buf, buf_nbytes, "anum");
+
+	err = xnvme_buf_fill(buf, buf_nbytes, "anum");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	xnvme_cli_pinf("dump-sync: {fpath: %s, tbytes: %zu, buf_nbytes: %zu iosize: %zu}", fpath,
 		       tbytes, buf_nbytes, iosize);
@@ -207,7 +212,12 @@ dump_sync_iovec(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_fill(buf, buf_nbytes, "anum");
+
+	err = xnvme_buf_fill(buf, buf_nbytes, "anum");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	xnvme_cli_pinf("dump-sync-iovec: {fpath: %s, tbytes: %zu, buf_nbytes: %zu iosize: %zu}",
 		       fpath, tbytes, buf_nbytes, iosize);
@@ -285,7 +295,12 @@ dump_async(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_fill(buf, buf_nbytes, "anum");
+
+	err = xnvme_buf_fill(buf, buf_nbytes, "anum");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	err = xnvme_queue_init(fh, qdepth, 0, &queue);
 	if (err) {
@@ -390,7 +405,12 @@ dump_async_iovec(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_fill(buf, buf_nbytes, "anum");
+
+	err = xnvme_buf_fill(buf, buf_nbytes, "anum");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	err = xnvme_queue_init(fh, qdepth, 0, &queue);
 	if (err) {
@@ -484,7 +504,11 @@ load_sync(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_fill(buf, buf_nbytes, "zero");
+
+	err = xnvme_buf_fill(buf, buf_nbytes, "zero");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+	}
 
 	xnvme_cli_pinf("load-sync: {fpath: %s, tbytes: %zu, buf_nbytes: %zu iosize: %zu}", fpath,
 		       tbytes, buf_nbytes, iosize);
@@ -547,7 +571,12 @@ load_async(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_fill(buf, buf_nbytes, "zero");
+
+	err = xnvme_buf_fill(buf, buf_nbytes, "zero");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	err = xnvme_queue_init(fh, qdepth, 0, &queue);
 	if (err) {
@@ -649,7 +678,12 @@ copy_file_sync(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_fill(buf, buf_nbytes, "zero");
+
+	err = xnvme_buf_fill(buf, buf_nbytes, "zero");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	xnvme_cli_pinf("copy-sync: {src: %s, dst: %s, tbytes: %zu, buf_nbytes: %zu, iosize: %zu",
 		       src_fpath, dst_fpath, tbytes, buf_nbytes, iosize);
@@ -741,7 +775,12 @@ copy_file_async(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_fill(buf, buf_nbytes, "zero");
+
+	err = xnvme_buf_fill(buf, buf_nbytes, "zero");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill()", err);
+		goto exit;
+	}
 
 	err = xnvme_queue_init(src_fh, qdepth, 0, &queue);
 	if (err) {

--- a/tools/xnvmeperf.c
+++ b/tools/xnvmeperf.c
@@ -747,7 +747,12 @@ xnvmeperf_verify(struct xnvmeperf_args *args)
 		for (int i = 0; i < nios; i++) {
 			uint64_t slba;
 
-			xnvme_buf_clear(read_buf, args->iosize);
+			err = xnvme_buf_clear(read_buf, args->iosize);
+			if (err) {
+				fprintf(stderr, "Failed: xnvme_buf_clear() at IO %d, err: %d\n", i,
+					err);
+				break;
+			}
 
 			struct xnvme_cmd_ctx *ctx = xnvme_queue_get_cmd_ctx(job.queue);
 			while (!ctx) {

--- a/tools/xnvmeperf.c
+++ b/tools/xnvmeperf.c
@@ -746,6 +746,7 @@ xnvmeperf_verify(struct xnvmeperf_args *args)
 
 		for (int i = 0; i < nios; i++) {
 			uint64_t slba;
+			size_t diff = 0;
 
 			err = xnvme_buf_clear(read_buf, args->iosize);
 			if (err) {
@@ -777,7 +778,13 @@ xnvmeperf_verify(struct xnvmeperf_args *args)
 			}
 
 			fill_pattern(expect_buf, args->iosize, slba, job.nlb);
-			if (xnvme_buf_diff(expect_buf, read_buf, args->iosize) != 0) {
+			err = xnvme_buf_diff(expect_buf, read_buf, args->iosize, &diff);
+			if (err) {
+				fprintf(stderr, "Failed: xnvme_buf_diff() at IO %d, err: %d\n", i,
+					err);
+				break;
+			}
+			if (diff) {
 				fprintf(stderr, "  MISMATCH at slba=%lu (IO %d)\n",
 					(unsigned long)slba, i);
 				mismatches++;

--- a/tools/xnvmeperf.c
+++ b/tools/xnvmeperf.c
@@ -327,7 +327,12 @@ thread_fn(void *arg)
 			xnvme_cli_perr("Failed: xnvme_buf_alloc()", err);
 			goto exit;
 		}
-		xnvme_buf_fill(job->buf, args->iosize, "anum");
+
+		err = xnvme_buf_fill(job->buf, args->iosize, "anum");
+		if (err) {
+			xnvme_cli_perr("Failed: xnvme_buf_fill()", err);
+			goto exit;
+		}
 	}
 
 	xnvme_timer_start(&timer);
@@ -629,18 +634,24 @@ failed_pthread_close:
  * @param slba    Starting LBA of the first sector in the buffer
  * @param nlb     Number of logical blocks in the buffer
  */
-static void
+static int
 fill_pattern(void *buf, size_t nbytes, uint64_t slba, uint16_t nlb)
 {
 	size_t lba_size = nbytes / nlb;
+	int err;
 
 	for (uint16_t i = 0; i < nlb; i++) {
 		uint8_t *p = (uint8_t *)buf + i * lba_size;
 		uint64_t lba = slba + i;
 
-		xnvme_buf_fill(p, lba_size, "anum");
+		err = xnvme_buf_fill(p, lba_size, "anum");
+		if (err) {
+			xnvme_cli_perr("xnvme_buf_fill()", err);
+			return err;
+		}
 		memcpy(p, &lba, sizeof(lba));
 	}
+	return 0;
 }
 
 /**
@@ -707,7 +718,12 @@ xnvmeperf_verify(struct xnvmeperf_args *args)
 		for (int i = 0; i < nios; i++) {
 			uint64_t slba = job.offset;
 
-			fill_pattern(write_buf, args->iosize, slba, job.nlb);
+			err = fill_pattern(write_buf, args->iosize, slba, job.nlb);
+			if (err) {
+				fprintf(stderr, "Failed: fill_pattern() at IO %d, err: %d\n", i,
+					err);
+				break;
+			}
 
 			struct xnvme_cmd_ctx *ctx = xnvme_queue_get_cmd_ctx(job.queue);
 			while (!ctx) {
@@ -777,7 +793,13 @@ xnvmeperf_verify(struct xnvmeperf_args *args)
 				xnvme_queue_poke(job.queue, 0);
 			}
 
-			fill_pattern(expect_buf, args->iosize, slba, job.nlb);
+			err = fill_pattern(expect_buf, args->iosize, slba, job.nlb);
+			if (err) {
+				fprintf(stderr, "Failed: fill_pattern() at IO %d, err: %d\n", i,
+					err);
+				break;
+			}
+
 			err = xnvme_buf_diff(expect_buf, read_buf, args->iosize, &diff);
 			if (err) {
 				fprintf(stderr, "Failed: xnvme_buf_diff() at IO %d, err: %d\n", i,

--- a/tools/zoned.c
+++ b/tools/zoned.c
@@ -411,6 +411,7 @@ cmd_write(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(dbuf, dbuf_nbytes,
 			     cli->args.data_input ? cli->args.data_input : "anum");
 	if (err) {
@@ -426,6 +427,7 @@ cmd_write(struct xnvme_cli *cli)
 			xnvme_cli_perr("xnvme_buf_alloc()", err);
 			goto exit;
 		}
+
 		err = xnvme_buf_fill(mbuf, mbuf_nbytes, "anum");
 		if (err) {
 			xnvme_cli_perr("xnvme_buf_fill()", err);
@@ -481,6 +483,7 @@ cmd_append(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
+
 	err = xnvme_buf_fill(dbuf, dbuf_nbytes, "anum");
 	if (err) {
 		xnvme_cli_perr("xnvme_buf_fill()", err);
@@ -534,6 +537,7 @@ _cmd_mgmt(struct xnvme_cli *cli, uint8_t zsa)
 			xnvme_cli_perr("xnvme_buf_alloc()", err);
 			goto exit;
 		}
+
 		err = xnvme_buf_fill(dbuf, dbuf_nbytes,
 				     cli->args.data_input ? cli->args.data_input : "anum");
 		if (err) {

--- a/tools/zoned.c
+++ b/tools/zoned.c
@@ -326,7 +326,12 @@ cmd_read(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	xnvme_buf_clear(dbuf, dbuf_nbytes);
+
+	err = xnvme_buf_clear(dbuf, dbuf_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_clear()", err);
+		goto exit;
+	}
 
 	if (mbuf_nbytes) {
 		xnvme_cli_pinf("Alloc/clear mbuf, mbuf_nbytes: %zu", mbuf_nbytes);
@@ -336,7 +341,12 @@ cmd_read(struct xnvme_cli *cli)
 			xnvme_cli_perr("xnvme_buf_alloc()", err);
 			goto exit;
 		}
-		xnvme_buf_clear(mbuf, mbuf_nbytes);
+
+		err = xnvme_buf_clear(mbuf, mbuf_nbytes);
+		if (err) {
+			xnvme_cli_perr("xnvme_buf_clear()", err);
+			goto exit;
+		}
 	}
 
 	xnvme_cli_pinf("Sending the command...");


### PR DESCRIPTION
This refactors the following functions to return an error code:
* ```C
  *OLD* void * xnvme_buf_clear(void *buf, size_t nbytes) 
  *NEW* int xnvme_buf_clear(void *buf, size_t nbytes)
* ```C
  *OLD* void * xnvme_buf_copy(void *dst, void *src, size_t nbytes)
  *NEW* int xnvme_buf_copy(void *dst, void *src, size_t nbytes)
* ```C
  *OLD* size_t xnvme_buf_diff(const void *expected, const void *actual, size_t nbytes)
  *NEW* int xnvme_buf_diff(const void *expected, const void *actual, size_t *diff, size_t nbytes)

Additionally, it adds error handling to every path using `xnvme_buf_fill()`.

Currently, none of these functions can fail. However, the intention is that they should handle different memory types in the future. As such, they need proper error handling.

NOTE: this commit `fix(platform): rename variables from ctrl to ctrlr` is unrelated - but I found it too frustrating to ignore