### PR TITLE
feat(libxnvme/buf): introduce xnvme_buf_copy()

### DIFF
--- a/include/libxnvme_buf.h
+++ b/include/libxnvme_buf.h
@@ -175,6 +175,18 @@ int
 xnvme_buf_clear(void *buf, size_t nbytes);
 
 /**
+ * Copy 'nbytes' from 'src' to 'dst'
+ *
+ * @param dst Pointer to the destination buffer
+ * @param src Pointer to the source buffer
+ * @param nbytes Amount of bytes to copy
+ *
+ * @return On success, 0 is returned. On error, negative `errno` is returned.
+ */
+int
+xnvme_buf_memcpy(void *dst, const void *src, size_t nbytes);
+
+/**
  * Compare two buffers and count the number of differing bytes.
  *
  * @param expected Pointer to buffer containing the expected data

--- a/lib/libxnvme.map
+++ b/lib/libxnvme.map
@@ -36,6 +36,7 @@
 		xnvme_buf_virt_free;
 		xnvme_buf_fill;
 		xnvme_buf_clear;
+		xnvme_buf_memcpy;
 		xnvme_buf_diff;
 		xnvme_buf_diff_pr;
 		xnvme_buf_to_file;

--- a/lib/xnvme_buf.c
+++ b/lib/xnvme_buf.c
@@ -94,6 +94,13 @@ xnvme_buf_clear(void *buf, size_t nbytes)
 	return 0;
 }
 
+int
+xnvme_buf_memcpy(void *dst, const void *src, size_t nbytes)
+{
+	memcpy(dst, src, nbytes);
+	return 0;
+}
+
 /**
  * Helper function writing/reading given buf to/from file. When mode has
  * O_WRONLY, the given buffer is written to file, otherwise, it is read.

--- a/lib/xnvme_dev.c
+++ b/lib/xnvme_dev.c
@@ -239,8 +239,18 @@ _dev_idfy_csi(struct xnvme_dev *dev, struct xnvme_spec_idfy *idfy_ns,
 		goto not_zns;
 	}
 
-	memcpy(&dev->idcss.ctrlr, idfy_ctrlr, sizeof(*idfy_ctrlr));
-	memcpy(&dev->idcss.ns, idfy_ns, sizeof(*idfy_ns));
+	err = xnvme_buf_memcpy(&dev->idcss.ctrlr, idfy_ctrlr, sizeof(*idfy_ctrlr));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_memcpy(idfy_ctrlr), err: %d", err);
+		return err;
+	}
+
+	err = xnvme_buf_memcpy(&dev->idcss.ns, idfy_ns, sizeof(*idfy_ns));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_memcpy(idfy_ns), err: %d", err);
+		return err;
+	}
+
 	dev->ident.csi = XNVME_SPEC_CSI_ZONED;
 
 	XNVME_DEBUG("INFO: looks like csi(ZNS)");
@@ -288,8 +298,17 @@ not_zns:
 		goto not_fs;
 	}
 
-	memcpy(&dev->idcss.ctrlr, idfy_ctrlr, sizeof(*idfy_ctrlr));
-	memcpy(&dev->idcss.ns, idfy_ns, sizeof(*idfy_ns));
+	err = xnvme_buf_memcpy(&dev->idcss.ctrlr, idfy_ctrlr, sizeof(*idfy_ctrlr));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_memcpy(idfy_ctrlr), err: %d", err);
+		return err;
+	}
+
+	err = xnvme_buf_memcpy(&dev->idcss.ns, idfy_ns, sizeof(*idfy_ns));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_memcpy(idfy_ns), err: %d", err);
+		return err;
+	}
 
 	XNVME_DEBUG("INFO: looks like csi(FS)");
 	dev->ident.csi = XNVME_SPEC_CSI_FS;
@@ -325,8 +344,18 @@ not_fs:
 		XNVME_DEBUG("INFO: !xnvme_adm_idfy_ns_csi(CSI_NVM)");
 		goto not_nvm;
 	}
-	memcpy(&dev->idcss.ctrlr, idfy_ctrlr, sizeof(*idfy_ctrlr));
-	memcpy(&dev->idcss.ns, idfy_ns, sizeof(*idfy_ns));
+
+	err = xnvme_buf_memcpy(&dev->idcss.ctrlr, idfy_ctrlr, sizeof(*idfy_ctrlr));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_memcpy(idfy_ctrlr), err: %d", err);
+		return err;
+	}
+
+	err = xnvme_buf_memcpy(&dev->idcss.ns, idfy_ns, sizeof(*idfy_ns));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_memcpy(idfy_ns), err: %d", err);
+		return err;
+	}
 
 	XNVME_DEBUG("INFO: looks like csi(NVM)");
 	dev->ident.csi = XNVME_SPEC_CSI_NVM;
@@ -378,10 +407,20 @@ _dev_idfy(struct xnvme_dev *dev)
 		XNVME_DEBUG("FAILED: xnvme_adm_idfy_ctrlr(), err: %d", err);
 		goto exit;
 	}
+
 	// Store idfy-ctrlr in device instance
-	memcpy(&dev->id.ctrlr, idfy_ctrlr, sizeof(*idfy_ctrlr));
+	err = xnvme_buf_memcpy(&dev->id.ctrlr, idfy_ctrlr, sizeof(*idfy_ctrlr));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_memcpy(idfy_ctrlr), err: %d", err);
+		goto exit;
+	}
+
 	// Store subnqn in device-identifier
-	memcpy(dev->ident.subnqn, idfy_ctrlr->ctrlr.subnqn, sizeof(dev->ident.subnqn));
+	err = xnvme_buf_memcpy(dev->ident.subnqn, dev->id.ctrlr.subnqn, sizeof(dev->ident.subnqn));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_memcpy(subnqn), err: %d", err);
+		goto exit;
+	}
 
 	if (dev->ident.dtype == XNVME_DEV_TYPE_NVME_CONTROLLER) {
 		goto exit;
@@ -401,8 +440,13 @@ _dev_idfy(struct xnvme_dev *dev)
 		XNVME_DEBUG("FAILED: xnvme_adm_idfy_ns(), err: %d", err);
 		goto exit;
 	}
+
 	// Store idfy-ns in device instance
-	memcpy(&dev->id.ns, idfy_ns, sizeof(*idfy_ns));
+	err = xnvme_buf_memcpy(&dev->id.ns, idfy_ns, sizeof(*idfy_ns));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_memcpy(idfy_ns), err: %d", err);
+		goto exit;
+	}
 
 	err = _dev_idfy_csi(dev, idfy_ns, idfy_ctrlr);
 	if (err) {

--- a/lib/xnvme_kvs.c
+++ b/lib/xnvme_kvs.c
@@ -8,31 +8,48 @@
 #include <xnvme_dev.h>
 #include <xnvme_spec.h>
 
-static inline void
+static inline int
 kvs_cmd_set_key(struct xnvme_spec_cmd *cmd, const void *key, uint8_t key_len)
 {
+	int err;
 	uint8_t *key_ptr = (uint8_t *)key;
 
 	cmd->kvs.cdw11.kl = key_len;
 
-	memcpy((void *)&cmd->kvs.key, key, XNVME_MIN(key_len, 8));
+	err = xnvme_buf_memcpy((void *)&cmd->kvs.key, key, XNVME_MIN(key_len, 8));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_memcpy(key), err: %d", err);
+		return err;
+	}
 
 	if (key_len > 8) {
-		memcpy((void *)&cmd->kvs.key_hi, key_ptr + 8, XNVME_MIN(key_len - 8, 8));
+		err = xnvme_buf_memcpy((void *)&cmd->kvs.key_hi, key_ptr + 8,
+				       XNVME_MIN(key_len - 8, 8));
+		if (err) {
+			XNVME_DEBUG("FAILED: xnvme_buf_memcpy(key_hi), err: %d", err);
+			return err;
+		}
 	}
+
+	return 0;
 }
 
 int
 xnvme_kvs_retrieve(struct xnvme_cmd_ctx *ctx, uint32_t nsid, const void *key, uint8_t key_len,
 		   const void *dbuf, uint32_t dbuf_nbytes, uint8_t opt)
 {
+	int err;
 	void *cdbuf = (void *)dbuf;
 
 	ctx->cmd.common.opcode = XNVME_SPEC_KV_OPC_RETRIEVE;
 	ctx->cmd.common.nsid = nsid;
 	ctx->cmd.kvs.cdw10 = dbuf_nbytes;
 
-	kvs_cmd_set_key(&ctx->cmd, key, key_len);
+	err = kvs_cmd_set_key(&ctx->cmd, key, key_len);
+	if (err) {
+		XNVME_DEBUG("FAILED: kvs_cmd_set_key(), err: %d", err);
+		return err;
+	}
 
 	if (opt & XNVME_KVS_RETRIEVE_OPT_RETRIEVE_RAW) {
 		ctx->cmd.kvs.cdw11.ro = opt;
@@ -45,6 +62,7 @@ int
 xnvme_kvs_store(struct xnvme_cmd_ctx *ctx, uint32_t nsid, const void *key, uint8_t key_len,
 		const void *dbuf, uint32_t dbuf_nbytes, uint8_t opt)
 {
+	int err;
 	void *cdbuf = (void *)dbuf;
 
 	ctx->cmd.common.opcode = XNVME_SPEC_KV_OPC_STORE;
@@ -65,7 +83,11 @@ xnvme_kvs_store(struct xnvme_cmd_ctx *ctx, uint32_t nsid, const void *key, uint8
 		ctx->cmd.kvs.cdw11.ro = ctx->cmd.kvs.cdw11.ro | XNVME_KVS_STORE_OPT_COMPRESS;
 	}
 
-	kvs_cmd_set_key(&ctx->cmd, key, key_len);
+	err = kvs_cmd_set_key(&ctx->cmd, key, key_len);
+	if (err) {
+		XNVME_DEBUG("FAILED: kvs_cmd_set_key(), err: %d", err);
+		return err;
+	}
 
 	return xnvme_cmd_pass(ctx, cdbuf, dbuf_nbytes, NULL, 0);
 }
@@ -73,10 +95,15 @@ xnvme_kvs_store(struct xnvme_cmd_ctx *ctx, uint32_t nsid, const void *key, uint8
 int
 xnvme_kvs_delete(struct xnvme_cmd_ctx *ctx, uint32_t nsid, const void *key, uint8_t key_len)
 {
+	int err;
 	ctx->cmd.common.opcode = XNVME_SPEC_KV_OPC_DELETE;
 	ctx->cmd.common.nsid = nsid;
 
-	kvs_cmd_set_key(&ctx->cmd, key, key_len);
+	err = kvs_cmd_set_key(&ctx->cmd, key, key_len);
+	if (err) {
+		XNVME_DEBUG("FAILED: kvs_cmd_set_key(), err: %d", err);
+		return err;
+	}
 
 	return xnvme_cmd_pass(ctx, NULL, 0, NULL, 0);
 }
@@ -84,10 +111,15 @@ xnvme_kvs_delete(struct xnvme_cmd_ctx *ctx, uint32_t nsid, const void *key, uint
 int
 xnvme_kvs_exist(struct xnvme_cmd_ctx *ctx, uint32_t nsid, const void *key, uint8_t key_len)
 {
+	int err;
 	ctx->cmd.common.opcode = XNVME_SPEC_KV_OPC_EXIST;
 	ctx->cmd.common.nsid = nsid;
 
-	kvs_cmd_set_key(&ctx->cmd, key, key_len);
+	err = kvs_cmd_set_key(&ctx->cmd, key, key_len);
+	if (err) {
+		XNVME_DEBUG("FAILED: kvs_cmd_set_key(), err: %d", err);
+		return err;
+	}
 
 	return xnvme_cmd_pass(ctx, NULL, 0, NULL, 0);
 }
@@ -96,13 +128,18 @@ int
 xnvme_kvs_list(struct xnvme_cmd_ctx *ctx, uint32_t nsid, const void *key, uint8_t key_len,
 	       const void *dbuf, uint32_t dbuf_nbytes)
 {
+	int err;
 	void *cdbuf = (void *)dbuf;
 
 	ctx->cmd.common.opcode = XNVME_SPEC_KV_OPC_LIST;
 	ctx->cmd.common.nsid = nsid;
 	ctx->cmd.kvs.cdw10 = dbuf_nbytes;
 
-	kvs_cmd_set_key(&ctx->cmd, key, key_len);
+	err = kvs_cmd_set_key(&ctx->cmd, key, key_len);
+	if (err) {
+		XNVME_DEBUG("FAILED: kvs_cmd_set_key(), err: %d", err);
+		return err;
+	}
 
 	return xnvme_cmd_pass(ctx, cdbuf, dbuf_nbytes, NULL, 0);
 }

--- a/lib/xnvme_znd.c
+++ b/lib/xnvme_znd.c
@@ -179,9 +179,14 @@ xnvme_znd_report_from_dev(struct xnvme_dev *dev, uint64_t slba, size_t limit, ui
 		}
 
 		// Skip the header and copy the remainder
-		memcpy(report->storage + ((zslba - slba) / geo->nsect) * report->zrent_nbytes,
-		       ((uint8_t *)dbuf) + sizeof(struct xnvme_spec_znd_report_hdr),
-		       report->zrent_nbytes * nentries);
+		err = xnvme_buf_memcpy(
+			report->storage + ((zslba - slba) / geo->nsect) * report->zrent_nbytes,
+			((uint8_t *)dbuf) + sizeof(struct xnvme_spec_znd_report_hdr),
+			report->zrent_nbytes * nentries);
+		if (err) {
+			XNVME_DEBUG("FAILED: xnvme_buf_memcpy(), err: %d", err);
+			break;
+		}
 
 		zslba += nentries * geo->nsect;
 	}
@@ -278,7 +283,11 @@ xnvme_znd_descr_from_dev(struct xnvme_dev *dev, uint64_t slba, struct xnvme_spec
 		err = -EIO;
 		goto exit;
 	}
-	memcpy(zdescr, dbuf + sizeof(*hdr), sizeof(*zdescr));
+	err = xnvme_buf_memcpy(zdescr, dbuf + sizeof(*hdr), sizeof(*zdescr));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_memcpy(zdescr), err: %d", err);
+		goto exit;
+	}
 
 exit:
 	xnvme_buf_free(dev, dbuf);
@@ -348,7 +357,11 @@ xnvme_znd_descr_from_dev_in_state(struct xnvme_dev *dev, enum xnvme_spec_znd_sta
 		err = -EIO;
 		goto exit;
 	}
-	memcpy(zdescr, dbuf + sizeof(*hdr), sizeof(*zdescr));
+	err = xnvme_buf_memcpy(zdescr, dbuf + sizeof(*hdr), sizeof(*zdescr));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_memcpy(zdescr), err: %d", err);
+		goto exit;
+	}
 
 exit:
 	xnvme_buf_free(dev, dbuf);

--- a/tests/kvs.c
+++ b/tests/kvs.c
@@ -48,7 +48,11 @@ kvs_io(struct xnvme_cli *cli)
 		goto exit;
 	}
 
-	memcpy(dbuf, kv_val, kv_val_nbytes);
+	err = xnvme_buf_memcpy(dbuf, kv_val, kv_val_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_memcpy()", err);
+		goto exit;
+	}
 
 	err = xnvme_kvs_store(&ctx, nsid, kv_key, kv_key_nbytes, dbuf, kv_val_nbytes, 0);
 	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {

--- a/tools/kvs.c
+++ b/tools/kvs.c
@@ -188,7 +188,11 @@ cmd_store(struct xnvme_cli *cli)
 		goto exit;
 	}
 
-	memcpy(dbuf, cli->args.kv_val, dbuf_nbytes);
+	err = xnvme_buf_memcpy(dbuf, cli->args.kv_val, dbuf_nbytes);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_memcpy()", err);
+		goto exit;
+	}
 
 	err = xnvme_kvs_store(&ctx, nsid, cli->args.kv_key, strlen(cli->args.kv_key), dbuf,
 			      dbuf_nbytes, opt);

--- a/tools/xnvme.c
+++ b/tools/xnvme.c
@@ -864,7 +864,11 @@ sub_set_fdp_events(struct xnvme_cli *cli)
 		goto exit;
 	}
 
-	memcpy(dbuf, SET_EVENT_TYPES, SET_EVENT_BUF_SIZE);
+	err = xnvme_buf_memcpy(dbuf, SET_EVENT_TYPES, SET_EVENT_BUF_SIZE);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_memcpy()", err);
+		goto exit;
+	}
 
 	xnvme_cli_pinf("cmd_sfeat: {nsid: 0%x, fid: 0x%x, save: 0x%x, feat: 0x%x, cdw12: 0x%x}",
 		       nsid, fid, save, feat, cdw12);
@@ -1019,7 +1023,12 @@ sub_ruhu(struct xnvme_cli *cli)
 		xnvme_cli_perr("xnvme_buf_alloc()", err);
 		goto exit;
 	}
-	memcpy(pid_list, &pi, npids * 2);
+
+	err = xnvme_buf_memcpy(pid_list, &pi, npids * 2);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_memcpy()", err);
+		goto exit;
+	}
 
 	xnvme_cli_pinf("Updating ruh ...");
 	err = xnvme_nvm_mgmt_send(&ctx, nsid, XNVME_SPEC_IO_MGMT_SEND_RUHU, npids - 1, pid_list,

--- a/tools/xnvmeperf.c
+++ b/tools/xnvmeperf.c
@@ -649,7 +649,12 @@ fill_pattern(void *buf, size_t nbytes, uint64_t slba, uint16_t nlb)
 			xnvme_cli_perr("xnvme_buf_fill()", err);
 			return err;
 		}
-		memcpy(p, &lba, sizeof(lba));
+
+		err = xnvme_buf_memcpy(p, &lba, sizeof(lba));
+		if (err) {
+			xnvme_cli_perr("xnvme_buf_memcpy()", err);
+			return err;
+		}
 	}
 	return 0;
 }


### PR DESCRIPTION
This expands the xNVMe BUF API to include a new `xnvme_buf_copy` function.
Currently, this wraps `memcpy()`. However, the goal is for this function
to handle both host and device memory.

This API returns an error code. Currently, it is always '0'. As
mentioned above, the goal is to handle different types of memory. Thus,
the error code is required in the future.