### PR TITLE
More developer tooling

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -342,7 +342,7 @@ jobs:
     - name: CIJOE, setup pipx environment
       if: (!contains('focal', matrix.container.ver))
       run: |
-        make cijoe
+        make cijoe-install
 
     - name: CIJOE, check that it is available
       if: (!contains('focal', matrix.container.ver))
@@ -466,7 +466,7 @@ jobs:
     # Setup Python virtual-environment for cijoe and Python xNVMe bindings to run ramdisk testing
     - name: CIJOE, setup pipx environment
       run: |
-        make cijoe
+        make cijoe-install
 
     - name: CIJOE, check that it is available
       run: |
@@ -627,7 +627,7 @@ jobs:
     # Setup Python virtual-environment for cijoe and Python xNVMe bindings to run ramdisk testing
     - name: CIJOE, setup pipx environment
       run: |
-        make cijoe
+        make cijoe-install
 
     - name: CIJOE, check that it is available
       run: |
@@ -722,7 +722,7 @@ jobs:
 
     - name: CIJOE, setup pipx environment
       run: |
-        make cijoe
+        make guest-env <<< "${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
 
     - name: CIJOE, check that it is available
       run: |
@@ -731,7 +731,6 @@ jobs:
     - name: CIJOE, provision and test guest
       run: |
         make verify-guest \
-          GUEST="${{ matrix.guest.os }}-${{ matrix.guest.ver }}" \
           CIJOE_OUTPUT="${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
 
     - name: CIJOE, result-log-dump on error
@@ -804,12 +803,12 @@ jobs:
       run: |
         apt-get -qy update
         apt-get -qy upgrade
-        apt-get -qy install python3 python3-dev python3-venv pipx git make gcc fontconfig sshpass
+        apt-get -qy install python3 python3-dev python3-venv pipx git make gcc fontconfig
         pipx ensurepath
 
     - name: CIJOE, setup pipx environment
       run: |
-        make cijoe
+        make cijoe-install
         cijoe --version
 
     # cd'ing into 'cijoe' to auto-collect the non-packaged github-specific configs and
@@ -902,7 +901,7 @@ jobs:
 
     - name: CIJOE, setup pipx environment
       run: |
-        make cijoe
+        make cijoe-install
         cijoe --version
 
     - name: CIJOE, run provisioning
@@ -983,7 +982,7 @@ jobs:
 
     - name: CIJOE, setup pipx environment
       run: |
-        make cijoe
+        make cijoe-install
 
     - name: CIJOE, provision xnvme from tgz
       run: |
@@ -1076,7 +1075,7 @@ jobs:
 
     - name: CIJOE, setup pipx environment
       run: |
-        make cijoe
+        make cijoe-install
         cijoe --version
 
     - name: CIJOE, provision xnvme from tgz
@@ -1191,7 +1190,7 @@ jobs:
 
     - name: CIJOE, setup pipx environment
       run: |
-        make cijoe
+        make guest-env <<< "${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
 
     - name: CIJOE, check that it is available
       run: |
@@ -1202,7 +1201,6 @@ jobs:
     - name: CIJOE, provision and generate documentation
       run: |
         make docgen-guest \
-          GUEST="${{ matrix.guest.os }}-${{ matrix.guest.ver }}" \
           CIJOE_OUTPUT="${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
 
     - name: CIJOE, upload report-docgen

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-cijoe-output
+cijoe-output*
 cijoe-archive
 kdebs
 hello
@@ -52,5 +52,6 @@ subprojects/*
 dist
 selftest_results
 *.egg-info
+cijoe/current.guest
 # macos
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -331,15 +331,6 @@ cijoe-do-bootimage-freebsd-amd64:
 		-l
 	@echo "## xNVME: cijoe-do-bootimage-freebsd-amd64 [DONE]"
 
-define cijoe-report-help
-# Produce a report for the latest cijoe state (cijoe/cijoe-output)
-endef
-.PHONY: cijoe-report
-cijoe-report:
-	@echo "## xNVMe: cijoe-report"
-	cd cijoe && cijoe -p
-	@echo "## xNVME: cijoe-report [DONE]"
-
 define git-setup-help
 # Do git config for: 'core.hooksPath' and 'blame.ignoreRevsFile'
 endef

--- a/Makefile
+++ b/Makefile
@@ -301,15 +301,6 @@ cijoe-sync-tgz:
 		xnvme_source_sync
 	@echo "## xNVME: cijoe-sync-tgz [DONE]"
 
-define cijoe-do-selftest-help
-# Run the cijoe selftest, this is useful after setting up cijoe
-endef
-.PHONY: cijoe-do-selftest
-cijoe-do-selftest:
-	@echo "## xNVMe: cijoe-do-selftest"
-	cd cijoe && pytest tests/selftest --config configs/default-config.toml --config configs/xnvme.toml
-	@echo "## xNVME: cijoe-do-selftest [DONE]"
-
 define cijoe-do-bootimage-debian-trixie-amd64-help
 # Create a Debian Trixie - amd64 - bootable system image for a qemu-guest
 endef

--- a/Makefile
+++ b/Makefile
@@ -340,20 +340,6 @@ cijoe-do-bootimage-freebsd-amd64:
 		-l
 	@echo "## xNVME: cijoe-do-bootimage-freebsd-amd64 [DONE]"
 
-define cijoe-do-linux-kdebs-help
-# Build a custom Linux kernel as installable packages (.deb)
-endef
-.PHONY: cijoe-do-linux-kdebs
-cijoe-do-linux-kdebs:
-	@echo "## xNVMe: cijoe-do-linux-kdebs"
-	cd cijoe && cijoe workflows/build-kdebs.yaml \
-		--monitor \
-		--config "configs/debian-trixie.toml" \
-		--config "configs/fio.toml" \
-		--config "configs/xnvme.toml" \
-		-l
-	@echo "## xNVME: cijoe-do-linux-kdebs [DONE]"
-
 define cijoe-report-help
 # Produce a report for the latest cijoe state (cijoe/cijoe-output)
 endef

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ export MACOSX_DEPLOYMENT_TARGET=11.0
 
 BUILD_DIR?=builddir
 TOOLBOX_DIR?=toolbox
+CIJOE_GUEST_FILE := cijoe/current.guest
 PROJECT_VER = $$( python3 $(TOOLBOX_DIR)/xnvme_ver.py --path meson.build )
 
 ALLOW_DIRTY ?= 0
@@ -141,126 +142,106 @@ docker:
 	docker run -it --privileged -w /tmp/xnvme --mount type=bind,source="$(shell pwd)",target=/tmp/xnvme --mount type=bind,source=/tmp/artifacts,target=/tmp/artifacts ghcr.io/xnvme/xnvme-qemu:latest bash
 	@echo "## xNVME: docker [DONE]"
 
-define cijoe-help
-# Setup a CIJOE environment for Linux development, documentation, and testing
+define cijoe-install-help
+# Install CIJOE and dependencies via pipx (used by CI and guest-env)
 endef
-.PHONY: cijoe
-cijoe:
-	@echo "## xNVMe: cijoe"
+.PHONY: cijoe-install
+cijoe-install:
+	@echo "## xNVMe: cijoe-install"
 	pipx install cijoe==v0.9.58 --include-deps --force
 	pipx inject cijoe matplotlib --force
 	pipx inject cijoe numpy --force
 	pipx install rst2pdf
-	mkdir -p ~/.config/cijoe
-	@[ -e ~/.config/cijoe/cijoe-config.toml ] || cp cijoe/configs/debian-trixie.toml ~/.config/cijoe/cijoe-config.toml
-	@echo ""
-	@echo ""
-	@echo "                     !!!! READ THIS !!!!"
-	@echo ""
-	@echo ""
-	@echo " --={[ Edit the config at ~/.config/cijoe/cijoe-config.toml ]}=-- "
-	@echo ""
-	@echo ""
-	@echo "                     !!!! READ THIS !!!!"
-	@echo ""
-	@echo ""
-	@echo "## xNVME: cijoe [DONE]"
+	@echo "## xNVMe: cijoe-install [DONE]"
 
-define cijoe-guest-setup-xnvme-using-git-help
-# Create and start a qemu-guest, then setup xNVMe within the guest using git
+define guest-env-help
+# Setup guest environment: install CIJOE, check QEMU, select guest
 endef
-.PHONY: cijoe-guest-setup-xnvme-using-git
-cijoe-guest-setup-xnvme-using-git:
-	@echo "## xNVMe: cijoe-guest-setup-xnvme-using-git"
-	cd cijoe && cijoe "workflows/provision-using-git.yaml" \
-		--monitor \
-		--config "configs/debian-trixie.toml" \
-		--config "configs/fio.toml" \
-		--config "configs/xnvme.toml" \
-		--config "configs/system_imaging.toml"
-	@echo "## xNVME: cijoe-guest-setup-xnvme-using-git [DONE]"
+.PHONY: guest-env
+guest-env: cijoe-install
+	@echo "## xNVMe: guest-env"
+	@python3 $(TOOLBOX_DIR)/dev_setup_check.py
+	@python3 $(TOOLBOX_DIR)/guest_select.py cijoe/
+	@echo "## xNVMe: guest-env [DONE]"
 
-define cijoe-guest-setup-blank-help
-# Create and start a qemu-guest
+define guest-select-help
+# Interactive menu to select the active QEMU guest (or pipe: echo debian-trixie | make guest-select)
 endef
-.PHONY: cijoe-guest-setup-blank
-cijoe-guest-setup-blank:
-	@echo "## xNVMe: cijoe-guest-setup-blank"
-	cd cijoe && cijoe "workflows/provision-using-git.yaml" \
+.PHONY: guest-select
+guest-select:
+	@python3 $(TOOLBOX_DIR)/guest_select.py cijoe/
+
+define guest-start-help
+# Kill, initialize, and start the QEMU guest (reads from cijoe/current.guest)
+endef
+.PHONY: guest-start
+guest-start:
+	@if [ ! -f "$(CIJOE_GUEST_FILE)" ]; then \
+		echo ""; \
+		echo "+=============================================+"; \
+		echo "                                               "; \
+		echo " ERR: No guest selected                        "; \
+		echo "                                               "; \
+		echo " Run: make guest-select                        "; \
+		echo "                                               "; \
+		echo "+=============================================+"; \
+		echo ""; \
+		false; \
+	fi
+	$(eval GUEST := $(shell cat $(CIJOE_GUEST_FILE)))
+	@echo "## xNVMe: guest-start ($(GUEST))"
+	cd cijoe && cijoe "workflows/provision-using-tgz.yaml" \
 		--monitor \
-		--config "configs/debian-trixie.toml" \
+		--config "configs/$(GUEST).toml" \
 		--config "configs/fio.toml" \
 		--config "configs/xnvme.toml" \
 		--config "configs/system_imaging.toml" \
+		--output "$(if $(CIJOE_OUTPUT),$(CIJOE_OUTPUT)-guest-start,cijoe-output-guest-start)" \
 		guest_kill \
 		guest_initialize \
 		guest_start \
 		guest_check
-	@echo "## xNVME: cijoe-guest-setup-blank [DONE]"
+	@echo "## xNVMe: guest-start [DONE]"
 
-define cijoe-guest-start-help
-# Start the qemu-guest -- assumes a qemu-guest has been setup
+define guest-provision-help
+# Sync source, build, and install xNVMe inside the guest (reads from cijoe/current.guest)
+#
+# Requires: /tmp/artifacts/xnvme-src.tar.gz (run: make gen-artifacts ALLOW_DIRTY=1)
 endef
-.PHONY: cijoe-guest-start
-cijoe-guest-start:
-	@echo "## xNVMe: cijoe-guest-start"
-	cd cijoe && cijoe "workflows/provision-using-git.yaml" \
+.PHONY: guest-provision
+guest-provision:
+	@if [ ! -f "$(CIJOE_GUEST_FILE)" ]; then \
+		echo ""; \
+		echo "+=============================================+"; \
+		echo "                                               "; \
+		echo " ERR: No guest selected                        "; \
+		echo "                                               "; \
+		echo " Run: make guest-select                        "; \
+		echo "                                               "; \
+		echo "+=============================================+"; \
+		echo ""; \
+		false; \
+	fi
+	$(eval GUEST := $(shell cat $(CIJOE_GUEST_FILE)))
+	@if [ ! -f /tmp/artifacts/xnvme-src.tar.gz ]; then \
+		echo ""; \
+		echo "+=============================================+"; \
+		echo "                                               "; \
+		echo " ERR: /tmp/artifacts/xnvme-src.tar.gz missing  "; \
+		echo "                                               "; \
+		echo " Run: make gen-artifacts ALLOW_DIRTY=1         "; \
+		echo "                                               "; \
+		echo "+=============================================+"; \
+		echo ""; \
+		false; \
+	fi
+	@echo "## xNVMe: guest-provision ($(GUEST))"
+	cd cijoe && cijoe "workflows/provision-using-tgz.yaml" \
 		--monitor \
-		--config "configs/debian-trixie.toml" \
+		--config "configs/$(GUEST).toml" \
 		--config "configs/fio.toml" \
 		--config "configs/xnvme.toml" \
-		--config "configs/system_imaging.toml" \
-		guest_start \
-		guest_check
-	@echo "## xNVMe: cijoe-guest-start [DONE]"
-
-define cijoe-guest-stop-help
-# Stop the qemu-guest -- assumes a qemu-guest has been setup
-endef
-.PHONY: cijoe-guest-stop
-cijoe-guest-stop:
-	@echo "## xNVMe: cijoe-guest-stop"
-	cd cijoe && cijoe "workflows/provision-using-git.yaml" \
-		--monitor \
-		--config "configs/debian-trixie.toml" \
-		--config "configs/fio.toml" \
-		--config "configs/xnvme.toml" \
-		--config "configs/system_imaging.toml" \
-		guest_kill
-	@echo "## xNVMe: cijoe-guest-stop [DONE]"
-
-define cijoe-setup-xnvme-using-git-help
-# Synchronize xNVMe source using git, then setup xNVMe
-endef
-.PHONY: cijoe-setup-xnvme-using-git
-cijoe-setup-xnvme-using-git:
-	@echo "## xNVMe: cijoe-setup-xnvme-using-git"
-	cd cijoe && cijoe workflows/provision-using-git.yaml \
-		--monitor \
-		--config "configs/debian-trixie.toml" \
-		--config "configs/fio.toml" \
-		--config "configs/xnvme.toml" \
-		-l \
-		xnvme_source_sync \
-		xnvme_build_prep \
-		xnvme_build \
-		xnvme_install \
-		ldconfig \
-		xnvme_bindings_py_build \
-		fio_prep
-	@echo "## xNVME: cijoe-setup-xnvme-using-git [DONE]"
-
-define cijoe-setup-xnvme-using-tgz-help
-# Synchronize xNVMe source using tgz, then setup xNVMe
-endef
-.PHONY: cijoe-setup-xnvme-using-tgz
-cijoe-setup-xnvme-using-tgz:
-	@echo "## xNVMe: cijoe-setup-xnvme-using-tgz"
-	cd cijoe && cijoe workflows/provision-using-tgz.yaml \
-		--monitor \
-		--config "configs/debian-trixie.toml" \
-		--config "configs/fio.toml" \
-		--config "configs/xnvme.toml" \
+		--output "$(if $(CIJOE_OUTPUT),$(CIJOE_OUTPUT)-guest-provision,cijoe-output-guest-provision)" \
 		-l \
 		xnvme_source_sync \
 		xnvme_build_prep \
@@ -269,37 +250,65 @@ cijoe-setup-xnvme-using-tgz:
 		ldconfig \
 		xnvme_bindings_py_install_tgz \
 		fio_prep
-	@echo "## xNVME: cijoe-setup-xnvme-using-tgz [DONE]"
+	@echo "## xNVMe: guest-provision [DONE]"
 
-define cijoe-sync-git-help
-# Synchronize xNVMe source using git
+define guest-test-help
+# Run the CIJOE test workflow for the selected guest (reads from cijoe/current.guest)
+#
+# Optional: CIJOE_OUTPUT=<prefix> for CI artifact naming
 endef
-.PHONY: cijoe-sync-git
-cijoe-sync-git:
-	@echo "## xNVMe: cijoe-sync-git"
-	cd cijoe && cijoe workflows/provision-using-git.yaml \
+.PHONY: guest-test
+guest-test:
+	@if [ ! -f "$(CIJOE_GUEST_FILE)" ]; then \
+		echo ""; \
+		echo "+=============================================+"; \
+		echo "                                               "; \
+		echo " ERR: No guest selected                        "; \
+		echo "                                               "; \
+		echo " Run: make guest-select                        "; \
+		echo "                                               "; \
+		echo "+=============================================+"; \
+		echo ""; \
+		false; \
+	fi
+	$(eval GUEST := $(shell cat $(CIJOE_GUEST_FILE)))
+	@echo "## xNVMe: guest-test ($(GUEST))"
+	cd cijoe && cijoe "workflows/test-$(GUEST).yaml" \
 		--monitor \
-		--config "configs/debian-trixie.toml" \
+		--config "configs/$(GUEST).toml" \
 		--config "configs/fio.toml" \
 		--config "configs/xnvme.toml" \
-		-l \
-		xnvme_source_sync
-	@echo "## xNVME: cijoe-sync-git [DONE]"
+		--output "$(if $(CIJOE_OUTPUT),$(CIJOE_OUTPUT)-test-results,cijoe-output-guest-test)"
+	@echo "## xNVMe: guest-test [DONE]"
 
-define cijoe-sync-tgz-help
-# Synchronize xNVMe source using tgz
+define guest-stop-help
+# Stop (kill) the QEMU guest (reads from cijoe/current.guest)
 endef
-.PHONY: cijoe-sync-tgz
-cijoe-sync-tgz:
-	@echo "## xNVMe: cijoe-sync-tgz"
-	cd cijoe && cijoe workflows/provision-using-tgz.yaml \
+.PHONY: guest-stop
+guest-stop:
+	@if [ ! -f "$(CIJOE_GUEST_FILE)" ]; then \
+		echo ""; \
+		echo "+=============================================+"; \
+		echo "                                               "; \
+		echo " ERR: No guest selected                        "; \
+		echo "                                               "; \
+		echo " Run: make guest-select                        "; \
+		echo "                                               "; \
+		echo "+=============================================+"; \
+		echo ""; \
+		false; \
+	fi
+	$(eval GUEST := $(shell cat $(CIJOE_GUEST_FILE)))
+	@echo "## xNVMe: guest-stop ($(GUEST))"
+	cd cijoe && cijoe "workflows/provision-using-tgz.yaml" \
 		--monitor \
-		--config "configs/debian-trixie.toml" \
+		--config "configs/$(GUEST).toml" \
 		--config "configs/fio.toml" \
 		--config "configs/xnvme.toml" \
-		-l \
-		xnvme_source_sync
-	@echo "## xNVME: cijoe-sync-tgz [DONE]"
+		--config "configs/system_imaging.toml" \
+		--output "$(if $(CIJOE_OUTPUT),$(CIJOE_OUTPUT)-guest-stop,cijoe-output-guest-stop)" \
+		guest_kill
+	@echo "## xNVMe: guest-stop [DONE]"
 
 define cijoe-do-bootimage-debian-trixie-amd64-help
 # Create a Debian Trixie - amd64 - bootable system image for a qemu-guest
@@ -428,27 +437,15 @@ verify-ramdisk:
 	@echo "## xNVMe: make verify-ramdisk [DONE]"
 
 define verify-guest-help
-# Provision a QEMU guest and run the CIJOE test suite for it
+# Chain: guest-start + guest-provision + guest-test (reads from cijoe/current.guest)
 #
 # Requires: A custom QEMU environment (run: make docker)
-# Requires: GUEST=<os>-<ver> (e.g. GUEST=debian-trixie)
+# Requires: Guest selected via 'make guest-select'
+# Requires: /tmp/artifacts/xnvme-src.tar.gz (run: make gen-artifacts ALLOW_DIRTY=1)
 # Optional: CIJOE_OUTPUT=<prefix> for CI artifact naming
 endef
 .PHONY: verify-guest
 verify-guest:
-	@if [ -z "$(GUEST)" ]; then \
-		echo ""; \
-		echo "+=============================================+"; \
-		echo "                                               "; \
-		echo " ERR: GUEST is not set                         "; \
-		echo "                                               "; \
-		echo " Usage: make verify-guest GUEST=debian-trixie  "; \
-		echo "                                               "; \
-		echo "+=============================================+"; \
-		echo ""; \
-		false; \
-	fi
-	@echo "## xNVMe: make verify-guest GUEST=$(GUEST)"
 	@if [ ! -f /tmp/artifacts/xnvme-src.tar.gz ]; then \
 		echo ""; \
 		echo "+=============================================+"; \
@@ -461,69 +458,27 @@ verify-guest:
 		echo ""; \
 		false; \
 	fi
-	cd cijoe && cijoe "workflows/provision-using-tgz.yaml" \
-		--monitor \
-		--config "configs/$(GUEST).toml" \
-		--config "configs/fio.toml" \
-		--config "configs/xnvme.toml" \
-		--config "configs/system_imaging.toml" \
-		$(if $(CIJOE_OUTPUT),--output "$(CIJOE_OUTPUT)-provision")
-	cd cijoe && cijoe "workflows/test-$(GUEST).yaml" \
-		--monitor \
-		--config "configs/$(GUEST).toml" \
-		--config "configs/fio.toml" \
-		--config "configs/xnvme.toml" \
-		$(if $(CIJOE_OUTPUT),--output "$(CIJOE_OUTPUT)-test-results")
-	@echo "## xNVMe: make verify-guest [DONE]"
+	$(MAKE) guest-start guest-provision guest-test
 
 define docgen-guest-help
-# Provision a QEMU guest and generate documentation
+# Provision a QEMU guest and generate documentation (reads from cijoe/current.guest)
 #
 # Requires: A custom QEMU environment (run: make docker)
-# Requires: GUEST=<os>-<ver> (e.g. GUEST=debian-trixie)
+# Requires: Guest selected via 'make guest-select'
+# Requires: /tmp/artifacts/xnvme-src.tar.gz (run: make gen-artifacts ALLOW_DIRTY=1)
 # Optional: CIJOE_OUTPUT=<prefix> for CI artifact naming
 endef
 .PHONY: docgen-guest
-docgen-guest:
-	@if [ -z "$(GUEST)" ]; then \
-		echo ""; \
-		echo "+=============================================+"; \
-		echo "                                               "; \
-		echo " ERR: GUEST is not set                         "; \
-		echo "                                               "; \
-		echo " Usage: make docgen-guest GUEST=debian-trixie  "; \
-		echo "                                               "; \
-		echo "+=============================================+"; \
-		echo ""; \
-		false; \
-	fi
-	@echo "## xNVMe: make docgen-guest GUEST=$(GUEST)"
-	@if [ ! -f /tmp/artifacts/xnvme-src.tar.gz ]; then \
-		echo ""; \
-		echo "+=============================================+"; \
-		echo "                                               "; \
-		echo " ERR: /tmp/artifacts/xnvme-src.tar.gz missing  "; \
-		echo "                                               "; \
-		echo " Run: make gen-artifacts ALLOW_DIRTY=1         "; \
-		echo "                                               "; \
-		echo "+=============================================+"; \
-		echo ""; \
-		false; \
-	fi
-	cd cijoe && cijoe "workflows/provision-using-tgz.yaml" \
-		--monitor \
-		--config "configs/$(GUEST).toml" \
-		--config "configs/fio.toml" \
-		--config "configs/xnvme.toml" \
-		--config "configs/system_imaging.toml" \
-		$(if $(CIJOE_OUTPUT),--output "$(CIJOE_OUTPUT)-provision")
+docgen-guest: guest-start guest-provision
+	$(eval GUEST := $(shell cat $(CIJOE_GUEST_FILE)))
+	@echo "## xNVMe: docgen-guest ($(GUEST))"
 	cd cijoe && cijoe "workflows/docgen.yaml" \
 		--monitor \
 		--config "configs/$(GUEST).toml" \
 		--config "configs/fio.toml" \
 		--config "configs/xnvme.toml" \
-		$(if $(CIJOE_OUTPUT),--output "$(CIJOE_OUTPUT)-docs")
-	@echo "## xNVMe: make docgen-guest [DONE]"
+		--output "$(if $(CIJOE_OUTPUT),$(CIJOE_OUTPUT)-docs,cijoe-output-docgen)"
+	@echo "## xNVMe: docgen-guest [DONE]"
 
 define install-help
 # Install xNVMe with Meson
@@ -683,22 +638,23 @@ endef
 gen-src-archive-with-subprojects:
 	@echo "## xNVMe: make gen-src-archive-with-subprojects"
 	$(MESON) setup $(BUILD_DIR) -Dbuild_subprojects=false -Dwith-liburing=disabled -Dwith-libvfn=disabled
-	$(MESON) dist -C $(BUILD_DIR) --no-tests --formats gztar --include-subprojects
+	if [ $(ALLOW_DIRTY) -eq 1 ]; then \
+		$(MESON) dist -C $(BUILD_DIR) --no-tests --formats gztar --include-subprojects --allow-dirty; \
+	else \
+		$(MESON) dist -C $(BUILD_DIR) --no-tests --formats gztar --include-subprojects; \
+	fi
 	@echo "## xNVMe: make gen-src-archive-with-subprojects [DONE]"
 
 define gen-artifacts-help
-# Generate artifacts in "/tmp/artifacts" for local guest provisoning
+# Generate artifacts in "/tmp/artifacts" for local guest provisioning
 #
-# This is a helper to produce the set of files used by toolbox/workflows/provision.workflow
-# The set of files would usually be downloaded from the CI build-artifacts, however, this helper
-# provides the means to perform local provisioning without downloading files.
+# Optional: ALLOW_DIRTY=1 to allow uncommitted changes
 endef
 .PHONY: gen-artifacts
 gen-artifacts: gen-src-archive-with-subprojects
 	@echo "## xNVMe: make gen-artifacts"
 	cd python/bindings && make clean build
 	mkdir -p /tmp/artifacts
-	ls -l /tmp/artifacts
 	cp builddir/meson-dist/xnvme-$(PROJECT_VER).tar.gz /tmp/artifacts/xnvme-src.tar.gz
 	cp python/bindings/dist/xnvme-$(PROJECT_VER).tar.gz /tmp/artifacts/xnvme-py-sdist.tar.gz
 	ls -l /tmp/artifacts

--- a/cijoe/scripts/git_sync.py
+++ b/cijoe/scripts/git_sync.py
@@ -34,14 +34,15 @@ def add_args(parser: ArgumentParser):
 
 
 def git_remote_from_config(cijoe, remote_path):
-    """Returns git-remote URI using configuration cijoe.transport.ssh"""
+    """Returns git-remote URI and SSH config using configuration cijoe.transport.ssh"""
 
     hostname = cijoe.getconf("cijoe.transport.ssh.hostname", None)
     if not hostname:
-        return None
+        return None, {}
 
     username = cijoe.getconf("cijoe.transport.ssh.username", None)
     port = cijoe.getconf("cijoe.transport.ssh.port", None)
+    password = cijoe.getconf("cijoe.transport.ssh.password", None)
 
     remote = "ssh://"
     if username:
@@ -51,7 +52,9 @@ def git_remote_from_config(cijoe, remote_path):
         remote += f":{port}"
     remote += f"{remote_path}"
 
-    return remote
+    ssh_conf = {"password": password, "port": port}
+
+    return remote, ssh_conf
 
 
 def main(args, cijoe):
@@ -70,9 +73,20 @@ def main(args, cijoe):
 
     remote_path = args.remote_path
     remote_alias = args.remote_alias
-    remote_url = git_remote_from_config(cijoe, remote_path)
+    remote_url, ssh_conf = git_remote_from_config(cijoe, remote_path)
     if not remote_url:
         return 1
+
+    # Build GIT_SSH_COMMAND so git push uses the config credentials
+    ssh_cmd_parts = ["ssh", "-o", "StrictHostKeyChecking=no"]
+    if ssh_conf.get("port"):
+        ssh_cmd_parts += ["-p", str(ssh_conf["port"])]
+    ssh_cmd = " ".join(ssh_cmd_parts)
+    if ssh_conf.get("password"):
+        password = ssh_conf["password"]
+        push_prefix = f'SSHPASS="{password}" GIT_SSH_COMMAND="sshpass -e {ssh_cmd}"'
+    else:
+        push_prefix = f'GIT_SSH_COMMAND="{ssh_cmd}"'
 
     # Remotely: clone repository from upstream
     err, _ = cijoe.run(f'[ -d "{remote_path}/.git" ]')
@@ -110,6 +124,13 @@ def main(args, cijoe):
             if "nothing to commit" in state.output():
                 continue
             return err
+
+    # Locally: push to remote using config credentials
+    err, state = cijoe.run_local(
+        f"{push_prefix} git push {remote_alias} HEAD:{branch} -f", cwd=local_path
+    )
+    if err:
+        return err
 
     err, _ = cijoe.run(f"git checkout {branch}", cwd=remote_path)
     if err:

--- a/cijoe/scripts/xnvme_bindings_py_build.py
+++ b/cijoe/scripts/xnvme_bindings_py_build.py
@@ -8,6 +8,7 @@ Retargetable: True
 """
 import errno
 from argparse import ArgumentParser
+from pathlib import Path
 
 
 def add_args(parser: ArgumentParser):
@@ -42,7 +43,7 @@ def main(args, cijoe):
         "make test",
     ]
     for cmd in commands:
-        err, _ = cijoe.run(cmd, cwd=xnvme_source / "python" / "bindings")
+        err, _ = cijoe.run(cmd, cwd=str(Path(xnvme_source) / "python" / "bindings"))
         if err:
             return err
 

--- a/cijoe/scripts/xnvme_bindings_py_test.py
+++ b/cijoe/scripts/xnvme_bindings_py_test.py
@@ -8,6 +8,7 @@ Retargetable: True
 """
 import errno
 from argparse import ArgumentParser
+from pathlib import Path
 
 
 def add_args(parser: ArgumentParser):
@@ -26,7 +27,9 @@ def main(args, cijoe):
     if not xnvme_source:
         return errno.EINVAL
 
-    err, _ = cijoe.run("pytest test_buf.py", cwd=xnvme_source / "python" / "tests")
+    err, _ = cijoe.run(
+        "pytest test_buf.py", cwd=str(Path(xnvme_source) / "python" / "tests")
+    )
     if err:
         return err
 

--- a/docs/tutorial/devs/index.rst
+++ b/docs/tutorial/devs/index.rst
@@ -263,68 +263,20 @@ Setup by running the following in the root of the **xNVMe** repository:
 .. code-block:: bash
 
   cd ~/git/xnvme
-  make cijoe
+  make guest-env
 
-This will install **cijoe** along with a couple of **cijoe-packages** for
-Linux, qemu, and fio. After installation, then a configuation file is added at
-``~/.config/cijoe/cijoe-config.toml``. You need to adjust this to match your
-system, look specifically for these entries:
+This will:
 
-.. code-block:: bash
+1. Install **cijoe** along with dependencies for Linux, qemu, and fio
+2. Check that QEMU and KVM are available
+3. Present an interactive menu to select a guest (e.g. ``debian-trixie``,
+   ``freebsd-14``)
 
-  [qemu]
-  img_bin = "qemu-img"
-  default_guest = "bookworm_arm64"
-
-  [qemu.systems.aarch64]
-  # bin = "{{ local.env.HOME }}/opt/qemu/bin/qemu-system-aarch64"
-  bin = "/opt/qemu/bin/qemu-system-aarch64"
-
-  [xnvme.repository]
-  upstream = "https://github.com/OpenMPDK/xNVMe.git"
-  path = "{{ local.env.HOME }}/git/xnvme"
-
-  # This is utilized by repository syncing during development.
-  [xnvme.repository.sync]
-  branch = "wip"
-  remote = "guest"
-  remote_path = "/root/git/xnvme"
-
-In general, ensure paths to repositories, binaries, etc. match your local system
-and the remote system you are using.
+The selected guest is stored in ``cijoe/current.guest`` and used by all
+subsequent ``make guest-*`` targets.
 
 Then logout and back in to reload the environment, the addition of ``pipx`` and
 the ``cijoe`` into ``$PATH``.
-
-Do a trial-run:
-
-.. code-block:: bash
-
-  # Create a workdir
-  mkdir -p ~/workdirs/cijoe
-  cd ~/workdirs/cijoe
-
-  # Create a default configuration and workflow
-  cijoe --example core
-
-In case everything is fine, then it will execute silently.
-
-You can increase the information-level with ``-l``
-argument, the more times you provide the higher the level.
-Try running it with two, that is debug-level:
-
-.. code-block:: bash
-
-  cijoe -ll
-
-In the ``cwd`` then a ``cijoe-output`` is produced, this
-directory holds all information about what was executed.
-Have a look at the generated report at
-``cijoe-output/report.html``.
-
-.. note::
-   In case you see failures, then inspect the ``RUNLOG`` in the report, this
-   usually tells you exactly what went wrong.
 
 .. note::
    Make sure that ``pytest`` is not installed system-wide by running ``which
@@ -446,7 +398,7 @@ Checkout qemu:
 .. code-block:: bash
 
   cd ~/git
-  git clone https://github.com/OpenMPDK/qemu --recursive
+  git clone https://github.com/SamsungDS/qemu.git --recursive
   cd qemu
   git checkout for-xnvme
   git submodule update --init --recursive
@@ -491,41 +443,33 @@ helper-targets to do this. That is, spinning up the guest, synchronizing your
 **xNVMe** git repository changes into the qemu-guest, building, installing, and
 running tests.
 
-Test Linux
-~~~~~~~~~~
+The ``make guest-env`` target will present an interactive menu to select the
+guest OS (e.g. ``debian-trixie``, ``freebsd-14``). The same workflow applies
+regardless of which guest you choose:
 
 .. code-block:: bash
 
-  # Create a cijoe-config for a qemu-guest with Debian Trixie
-  cp cijoe/configs/debian-trixie.toml ~/.config/cijoe/cijoe-config.toml
+  # One-time setup: install CIJOE and select a guest
+  make guest-env
 
-  # Provision the machine
-  make cijoe-guest-setup-xnvme-using-git
+  # Build source artifacts and run the full test cycle
+  make gen-artifacts ALLOW_DIRTY=1 && make verify-guest
 
-  # Run the test
-  make cijoe-do-test-linux
+  # Or run stages individually:
+  make guest-start          # start the guest
+  make guest-provision   # sync source, build, install
+  make guest-test        # run the test suite
 
-Generate documentation in Linux
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To switch to a different guest, run ``make guest-select``.
 
-You can reuse the qemu-guest created in the previous section to generate the
-documentation. See the :ref:`sec-tutorials-devs-linux-reproduce-ci` section for
-using ``make docgen-guest`` inside the Docker container.
+Generate documentation
+~~~~~~~~~~~~~~~~~~~~~~
 
-Test FreeBSD
-~~~~~~~~~~~~
+You can reuse the qemu-guest to generate the documentation. See the
+:ref:`sec-tutorials-devs-linux-reproduce-ci` section for using
+``make docgen-guest`` inside the Docker container.
 
-.. code-block:: bash
 
-  # Create a cijoe-config for a qemu-guest with FreeBSD
-  cp cijoe/configs/debian-trixie.toml ~/.config/cijoe/cijoe-config.toml
-
-  # Provision the machine
-  make cijoe-guest-setup-xnvme-using-git
-
-  # Run the test
-  make cijoe-do-test-freebsd
-  
 
 .. _sec-tutorials-devs-linux-reproduce-ci:
 
@@ -551,18 +495,18 @@ build that includes NVMe device emulation.
 The container bind-mounts the repository at ``/tmp/xnvme`` and
 ``/tmp/artifacts``, so the artifacts from step 1 are available inside.
 
-3. Inside the container, set up CIJOE and run the desired target:
+3. Inside the container, set up CIJOE, select a guest, and run tests:
 
 .. code-block:: bash
 
-  # Install CIJOE
-  make cijoe
+  # Install CIJOE and select guest
+  echo debian-trixie | make guest-env
 
-  # Test on Debian Trixie
-  make verify-guest GUEST=debian-trixie
+  # Test
+  make verify-guest
 
   # Or generate documentation
-  make docgen-guest GUEST=debian-trixie
+  make docgen-guest
 
 In case you are setting up the test-target using other tools, or just want to
 run pytest directly, then the following two sections describe how to do that.
@@ -642,10 +586,10 @@ paths to binaries etc. Once you have done that, then go ahead and run:
 
 .. code-block:: bash
 
-  # Synchronize your local git with the repos on the remote physical machine
-  make cijoe-sync-git
+  # Sync source, build, and install xNVMe on the remote end
+  make guest-provision
 
-  # Build and install **xNVMe** on the remote end
-  make cijoe-setup-xnvme-using-git
+  # Run the test suite
+  make guest-test
 
-You can do any of the **cijoe** things like the above.
+You can do any of the ``make guest-*`` things like the above.

--- a/toolbox/dev_setup_check.py
+++ b/toolbox/dev_setup_check.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Check QEMU development environment readiness for xNVMe guest workflows.
+
+Checks:
+- qemu-system-x86_64 binary available
+- /dev/kvm accessible
+"""
+import os
+import shutil
+import subprocess
+import sys
+
+
+def is_custom_qemu(qemu_bin):
+    """Check if the QEMU binary is the custom xNVMe fork (supports KVS, mdts=0)."""
+
+    try:
+        result = subprocess.run(
+            [qemu_bin, "-device", "nvme-ns,help"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return "kv=" in (result.stdout + result.stderr)
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+
+
+def main():
+    errors = []
+
+    print("Checking environment...")
+
+    # Check qemu-system-x86_64
+    qemu = shutil.which("qemu-system-x86_64")
+    if qemu:
+        if is_custom_qemu(qemu):
+            print(f"  qemu-system-x86_64: OK (xNVMe fork at {qemu})")
+        else:
+            print(f"  qemu-system-x86_64: WRONG BUILD ({qemu})")
+            errors.append(
+                "  Found qemu-system-x86_64 but it is upstream QEMU, not the xNVMe fork.\n"
+                "  The xNVMe fork is required for KVS emulation and mdts=0 support.\n"
+                "  Either:\n"
+                "    a) Run inside the xNVMe Docker environment: make docker\n"
+                "    b) Build the xNVMe QEMU fork: https://github.com/SamsungDS/qemu.git (branch: for-xnvme)"
+            )
+    else:
+        print("  qemu-system-x86_64: MISSING")
+        errors.append(
+            "  qemu-system-x86_64 not found.\n"
+            "  Either:\n"
+            "    a) Run inside the xNVMe Docker environment: make docker\n"
+            "    b) Build the xNVMe QEMU fork: https://github.com/SamsungDS/qemu.git (branch: for-xnvme)"
+        )
+
+    # Check KVM — not fatal, QEMU works without it (just slower)
+    if os.path.exists("/dev/kvm"):
+        if os.access("/dev/kvm", os.R_OK | os.W_OK):
+            print("  /dev/kvm: OK")
+        else:
+            print("  /dev/kvm: NO ACCESS (guests will run without KVM acceleration)")
+            print("    Fix: sudo usermod -aG kvm $USER")
+    else:
+        print("  /dev/kvm: MISSING (guests will run without KVM acceleration)")
+        print(
+            "    Fix: enable KVM in your kernel / hypervisor (e.g. nested virtualization)"
+        )
+
+    if errors:
+        print()
+        for err in errors:
+            print(err)
+            print()
+        sys.exit(1)
+
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/toolbox/guest_select.py
+++ b/toolbox/guest_select.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Interactive guest selection for xNVMe CIJOE workflows.
+
+Discovers available guests by scanning cijoe/workflows/test-*.yaml and
+verifying a matching cijoe/configs/{guest}.toml exists. Presents an
+interactive numbered menu on TTY, reads from stdin when piped.
+
+Writes the selected guest name to cijoe/current.guest.
+"""
+import glob
+import os
+import sys
+
+
+def discover_guests(cijoe_dir):
+    """Find guests that have both a test workflow and a config file."""
+
+    workflow_pattern = os.path.join(cijoe_dir, "workflows", "test-*.yaml")
+    configs_dir = os.path.join(cijoe_dir, "configs")
+
+    guests = []
+    for wf in sorted(glob.glob(workflow_pattern)):
+        basename = os.path.basename(wf)
+        # test-debian-trixie.yaml -> debian-trixie
+        guest = basename.removeprefix("test-").removesuffix(".yaml")
+
+        # Skip ramdisk entries — they aren't qemu guests
+        if "ramdisk" in guest:
+            continue
+
+        config_path = os.path.join(configs_dir, f"{guest}.toml")
+        if os.path.isfile(config_path):
+            guests.append(guest)
+
+    return guests
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <cijoe-dir>", file=sys.stderr)
+        sys.exit(1)
+
+    cijoe_dir = sys.argv[1]
+    guests = discover_guests(cijoe_dir)
+
+    if not guests:
+        print(
+            "ERROR: No guests found. Check cijoe/workflows/test-*.yaml and configs/.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    guest_file = os.path.join(cijoe_dir, "current.guest")
+
+    if sys.stdin.isatty():
+        # Interactive mode
+        print("Available guests:")
+        for i, guest in enumerate(guests, 1):
+            print(f"  {i}) {guest}")
+        print()
+
+        while True:
+            try:
+                choice = input("Select guest: ")
+            except (EOFError, KeyboardInterrupt):
+                print()
+                sys.exit(1)
+
+            try:
+                idx = int(choice)
+                if 1 <= idx <= len(guests):
+                    selected = guests[idx - 1]
+                    break
+                print(f"Please enter a number between 1 and {len(guests)}")
+            except ValueError:
+                # Allow typing the guest name directly
+                if choice.strip() in guests:
+                    selected = choice.strip()
+                    break
+                print(f"Invalid choice: {choice}")
+    else:
+        # Piped / non-interactive mode
+        selected = sys.stdin.readline().strip()
+        if selected not in guests:
+            print(f"ERROR: Unknown guest '{selected}'", file=sys.stderr)
+            print(f"Available: {', '.join(guests)}", file=sys.stderr)
+            sys.exit(1)
+
+    with open(guest_file, "w") as f:
+        f.write(selected + "\n")
+
+    print(f"Selected: {selected}")
+
+
+if __name__ == "__main__":
+    main()

--- a/toolbox/meson_dist_archive_fixer.py
+++ b/toolbox/meson_dist_archive_fixer.py
@@ -5,10 +5,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 """
-    Removes '.git' from subprojects
+    Removes '.git' and SPDK build artifacts from subprojects
 
     This script is intended to be added with 'meson.add_dist_script()', to cleanup the
-    subprojects, that is, remove the '.git'.
+    subprojects, that is, remove the '.git' directories and SPDK build artifacts
+    (build/ directory and mk/config.mk) that contain host-specific absolute paths.
 """
 import argparse
 import os
@@ -45,11 +46,26 @@ def main(args):
         print("ERR: path: '{path}' looks bad".format(path=args.path))
         return 1
 
-    for root, dnames, _ in os.walk(args.path):
-        for dname in dnames:
+    for root, dnames, fnames in os.walk(args.path, topdown=True):
+        for dname in dnames[:]:
             path = os.path.join(root, dname)
-            if dname == ".git" and "builddir" in path and "subprojects" in path:
+            if "builddir" not in path or "subprojects" not in path:
+                continue
+            if dname == ".git":
                 shutil.rmtree(path)
+                dnames.remove(dname)
+            elif dname == "build" and os.path.join(os.sep, "spdk", "build") in path:
+                shutil.rmtree(path)
+                dnames.remove(dname)
+        for fname in fnames:
+            path = os.path.join(root, fname)
+            if "builddir" not in path or "subprojects" not in path:
+                continue
+            if (
+                fname == "config.mk"
+                and os.path.join(os.sep, "spdk", "mk", "config.mk") in path
+            ):
+                os.remove(path)
 
     return 0
 


### PR DESCRIPTION
Replaces the scattered `cijoe-*` Makefile targets with a composable `guest-*` workflow. A sticky guest selection (`make guest-select`) persists across targets, so `guest-up`, `guest-provision`, `guest-test`, and `guest-stop` all operate on the same QEMU guest without repeating configuration. `make verify-guest` chains these into a single end-to-end run and fails fast when the source tarball is missing.

The meson dist-archive fixer is extended to purge SPDK build artifacts that embed host-specific paths, preventing stale configuration from breaking builds on the target system.

## Test plan

- [x] `make gen-artifacts ALLOW_DIRTY=1 && make verify-guest` completes successfully
- [x] CI workflow passes with updated target names