### PR TITLE
feat(cijoe): add upcie-cuda GPU test workflow and fix CUDA memory compatibility

### DIFF
--- a/cijoe/tests/apps/test_fio.py
+++ b/cijoe/tests/apps/test_fio.py
@@ -15,6 +15,11 @@ def test_fio_engine(cijoe, device, be_opts, cli_args):
     """
     The construction of the fio-invocation is done in 'fio_fancy'
     """
+    if be_opts["mem"] == "upcie-cuda":
+        pytest.skip(
+            reason="[mem=upcie-cuda] fio xNVMe ioengine does not support CUDA memory"
+        )
+
     size = "64M"
     # size = "1G"
 
@@ -45,6 +50,10 @@ def test_fio_engine_iov(cijoe, device, be_opts, cli_args):
         pytest.skip(reason="[sync=nvme] on FreeBSD does not implement iovec")
     if be_opts["admin"] == "driverkit":
         pytest.skip(reason="[admin=driverkit] does not implement iovec")
+    if be_opts["mem"] == "upcie-cuda":
+        pytest.skip(
+            reason="[mem=upcie-cuda] fio xNVMe ioengine does not support CUDA memory"
+        )
 
     size = "64M"
     # size = "1G"

--- a/cijoe/tests/logic/test_xnvme_tests_async_intf.py
+++ b/cijoe/tests/logic/test_xnvme_tests_async_intf.py
@@ -1,8 +1,14 @@
+import pytest
+
 from ..conftest import xnvme_parametrize
 
 
 @xnvme_parametrize(["dev"], opts=["be", "admin", "async"])
 def test_init_term(cijoe, device, be_opts, cli_args):
+    if be_opts["be"] in ("upcie", "upcie-cuda"):
+        pytest.skip(
+            reason=f"[be={be_opts['be']}] This test requires memory beyond what is available"
+        )
     qdepth = 64
     for count in [1, 2, 4, 8, 16, 32, 64, 128]:
         err, _ = cijoe.run(

--- a/cijoe/tests/tools/test_lblk.py
+++ b/cijoe/tests/tools/test_lblk.py
@@ -21,6 +21,8 @@ def test_info(cijoe, device, be_opts, cli_args):
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
 def test_idfy(cijoe, device, be_opts, cli_args):
+    if be_opts["mem"] == "upcie-cuda":
+        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
     err, _ = cijoe.run(f"lblk idfy {cli_args}")
     assert not err
 
@@ -39,6 +41,8 @@ def test_write(cijoe, device, be_opts, cli_args):
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
 def test_compare(cijoe, device, be_opts, cli_args):
+    if be_opts["mem"] == "upcie-cuda":
+        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
     src = "/tmp/file.bin"
 
     prep = [

--- a/cijoe/tests/tools/test_xnvme.py
+++ b/cijoe/tests/tools/test_xnvme.py
@@ -121,6 +121,8 @@ def test_info(cijoe, device, be_opts, cli_args):
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
 def test_idfy(cijoe, device, be_opts, cli_args):
+    if be_opts["mem"] == "upcie-cuda":
+        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
     err, _ = cijoe.run(
         f"xnvme idfy {cli_args} --cns 0x0 --cntid 0x0 --setid 0x0 --uuid 0x0"
     )
@@ -129,12 +131,16 @@ def test_idfy(cijoe, device, be_opts, cli_args):
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
 def test_idfy_ns(cijoe, device, be_opts, cli_args):
+    if be_opts["mem"] == "upcie-cuda":
+        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
     err, _ = cijoe.run(f"xnvme idfy-ns {cli_args} --nsid {device['nsid']}")
     assert not err
 
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
 def test_idfy_ctrlr(cijoe, device, be_opts, cli_args):
+    if be_opts["mem"] == "upcie-cuda":
+        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
     err, _ = cijoe.run(f"xnvme idfy-ctrlr {cli_args}")
     assert not err
 
@@ -183,6 +189,8 @@ def test_sanitize(cijoe, device, be_opts, cli_args):
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
 def test_log_erri(cijoe, device, be_opts, cli_args):
+    if be_opts["mem"] == "upcie-cuda":
+        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
     if be_opts["admin"] == "block":
         pytest.skip(reason="[admin=block] does not implement error-log")
     if be_opts["admin"] == "ramdisk":
@@ -194,6 +202,8 @@ def test_log_erri(cijoe, device, be_opts, cli_args):
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
 def test_log_health_controller(cijoe, device, be_opts, cli_args):
+    if be_opts["mem"] == "upcie-cuda":
+        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
     if be_opts["admin"] == "block":
         pytest.skip(reason="[admin=block] does not implement health-log")
     if be_opts["admin"] == "ramdisk":
@@ -216,6 +226,8 @@ def test_log_health_namespace(cijoe, device, be_opts, cli_args):
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
 def test_log(cijoe, device, be_opts, cli_args):
+    if be_opts["mem"] == "upcie-cuda":
+        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
     if be_opts["admin"] == "block":
         pytest.skip(reason="[admin=block] does not implement get-log")
     if be_opts["admin"] == "ramdisk":
@@ -323,6 +335,8 @@ def test_pioc(cijoe, device, be_opts, cli_args):
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
 def test_dsm(cijoe, device, be_opts, cli_args):
+    if be_opts["mem"] == "upcie-cuda":
+        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
     err, _ = cijoe.run(
         f"xnvme dsm {cli_args} --nsid {device['nsid']} --ad --slba 0 --llb 1"
     )

--- a/cijoe/tests/tools/test_xnvme_library_info.py
+++ b/cijoe/tests/tools/test_xnvme_library_info.py
@@ -103,6 +103,7 @@ def test_library_info_has_all_combos(cijoe):
         "libaio_bdev": "XNVME_BE_LINUX_LIBAIO_ENABLED",
         "libaio_file": "XNVME_BE_LINUX_LIBAIO_ENABLED",
         "upcie": "XNVME_BE_UPCIE_ENABLED",
+        "upcie-cuda": "XNVME_BE_UPCIE_CUDA_ENABLED",
     }
 
     combos = get_backend_configurations()

--- a/cijoe/tests/xnvme_be_combinations.py
+++ b/cijoe/tests/xnvme_be_combinations.py
@@ -145,6 +145,14 @@ def get_backend_configurations():
             "admin": ["upcie"],
             "label": ["pcie"],
         },
+        {
+            "be": ["upcie-cuda"],
+            "mem": ["upcie-cuda"],
+            "async": ["upcie-cuda"],
+            "sync": ["upcie-cuda"],
+            "admin": ["upcie-cuda"],
+            "label": ["cuda"],
+        },
         # Ramdisk
         {
             "be": ["ramdisk_emu"],

--- a/cijoe/workflows/test-gpu.yaml
+++ b/cijoe/workflows/test-gpu.yaml
@@ -1,0 +1,20 @@
+---
+doc: |
+  Test xNVMe uPCIe CUDA P2P backend on Linux
+
+steps:
+- name: sysinfo
+  uses: linux.sysinfo
+
+- name: nvidia-memory
+  run: |
+    nvidia-smi -q -d memory || true
+
+- name: hugepages
+  uses: linux_setup_hugepages
+
+- name: test_upcie_cuda
+  uses: core.testrunner
+  with:
+    args: '-k "cuda and not fabrics" tests'
+    random_order: false

--- a/docs/background/backends/upcie/cuda.md
+++ b/docs/background/backends/upcie/cuda.md
@@ -67,6 +67,28 @@ the host hugepage runtime (256 MiB) used to hold NVMe control structures. Follow
 the hugepage setup steps in {ref}`sec-backends-upcie-host` before opening an
 **upcie-cuda** device.
 
+(sec-backends-upcie-cuda-validation)=
+
+## Validation
+
+The cijoe workflow ``test-gpu.yaml`` exercises the **upcie-cuda** backend
+against a PCIe NVMe device. Devices must be tagged with the ``cuda`` label in
+your cijoe configuration:
+
+```toml
+[[devices]]
+uri = "0000:xx:00.0"
+nsid = 1
+labels = ["dev", "pcie", "nvm", "cuda"]
+driver_attachment = "userspace"
+```
+
+Run the workflow with:
+
+```bash
+cd cijoe && cijoe workflows/test-gpu.yaml --config configs/<your-config>.toml
+```
+
 (sec-backends-upcie-cuda-limitations)=
 
 ## Limitations

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -11,6 +11,8 @@
 #include <xnvme_dev.h>
 #include <xnvme_platform.h>
 
+#define XNVME_MAX_NS_LIST_SIZE 1024
+
 struct xnvme_platform *g_xnvme_platform =
 #if defined(XNVME_PLATFORM_LINUX_ENABLED)
 	&g_xnvme_platform_linux;
@@ -274,7 +276,8 @@ enumerate_controller(const char *uri, struct xnvme_opts *opts, xnvme_enumerate_c
 	struct xnvme_dev *ctrlr_dev;
 	struct xnvme_spec_idfy *idfy_buf;
 	struct xnvme_cmd_ctx ctx;
-	uint32_t *nslist;
+	uint32_t nslist[XNVME_MAX_NS_LIST_SIZE];
+	size_t buf_size;
 	int err;
 
 	ctrlr_opts.nsid = 0;
@@ -284,14 +287,15 @@ enumerate_controller(const char *uri, struct xnvme_opts *opts, xnvme_enumerate_c
 		return -errno;
 	}
 
-	idfy_buf = xnvme_buf_alloc(ctrlr_dev, sizeof(*idfy_buf));
+	buf_size = sizeof(*idfy_buf);
+	idfy_buf = xnvme_buf_alloc(ctrlr_dev, buf_size);
 	if (!idfy_buf) {
 		XNVME_DEBUG("FAILED: xnvme_buf_alloc()");
 		xnvme_dev_close(ctrlr_dev);
 		return -ENOMEM;
 	}
 
-	err = xnvme_buf_clear(idfy_buf, sizeof(*idfy_buf));
+	err = xnvme_buf_clear(idfy_buf, buf_size);
 	if (err) {
 		XNVME_DEBUG("FAILED: xnvme_buf_clear(), err: %d", err);
 		xnvme_buf_free(ctrlr_dev, idfy_buf);
@@ -307,8 +311,13 @@ enumerate_controller(const char *uri, struct xnvme_opts *opts, xnvme_enumerate_c
 		return err ? err : -EIO;
 	}
 
-	nslist = (uint32_t *)idfy_buf;
-	for (int i = 0; i < 1024 && nslist[i]; ++i) {
+	// Copy data out of IO buffer, since this can be CUDA memory
+	err = xnvme_buf_memcpy(nslist, idfy_buf, buf_size);
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_buf_memcpy(), err: %d", err);
+		goto exit;
+	}
+	for (int i = 0; i < XNVME_MAX_NS_LIST_SIZE && nslist[i]; ++i) {
 		struct xnvme_opts ns_opts = *opts;
 		struct xnvme_dev *ns_dev;
 
@@ -325,6 +334,7 @@ enumerate_controller(const char *uri, struct xnvme_opts *opts, xnvme_enumerate_c
 		}
 	}
 
+exit:
 	xnvme_buf_free(ctrlr_dev, idfy_buf);
 	xnvme_dev_close(ctrlr_dev);
 	return 0;

--- a/tests/ioworker.c
+++ b/tests/ioworker.c
@@ -261,7 +261,7 @@ iowork_teardown(struct iowork *work)
 	int err;
 
 	for (uint32_t i = 0; i < work->nworkers; ++i) {
-		xnvme_buf_free(work->dev, work->workers[i].vec);
+		free(work->workers[i].vec);
 	}
 
 	xnvme_buf_free(work->dev, work->rbuf);
@@ -355,10 +355,10 @@ iowork_from_cli(struct xnvme_cli *cli, struct iowork *work)
 		worker->range = work->range;
 
 		worker->vec_cnt = work->vec_cnt;
-		worker->vec = xnvme_buf_alloc(work->dev, sizeof(*worker->vec) * worker->vec_cnt);
+		worker->vec = malloc(sizeof(*worker->vec) * worker->vec_cnt);
 		if (!worker->vec) {
 			err = -errno;
-			XNVME_DEBUG("FAILED: xnvme_buf_alloc(vec), err: %d", errno);
+			XNVME_DEBUG("FAILED: malloc(vec), err: %d", errno);
 			goto failed;
 		}
 


### PR DESCRIPTION
Adds cijoe test infrastructure for the uPCIe CUDA P2P backend and fixes two
  bugs where CPU code inadvertently accessed GPU device memory.

  The new `test-gpu.yaml` workflow and `upcie-cuda` backend combination entry
  run the test suite against GPU-equipped machines using the `cuda` device label.

  Two segfaults are fixed: `test_ioworker` was allocating the `struct iovec[]`
  array via `xnvme_buf_alloc()` (which returns GPU memory under upcie-cuda), and
  `enumerate_controller()` was walking the Identify NS List response on the CPU
  without first copying it out of the DMA buffer. Both are fixed by using host
  memory for CPU-side access.

  Tests structurally incompatible with CUDA device memory are skipped: admin
  command tools (`xnvme idfy`, `xnvme log-*`, `xnvme dsm`, `lblk idfy`,
  `lblk compare`), fio (ioengine does not support CUDA buffers), and
  `test_init_term` (queue depth sweep exceeds hugepage heap capacity).