### PR TITLE
docs(tooling): bump dependency versions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -260,7 +260,7 @@ jobs:
     steps:
     - name: Container-preparation, openSUSE does not have tar and gzip...
       if: contains(matrix.container.os, 'opensuse')
-      run: zypper --non-interactive install -y tar gzip
+      run: zypper --non-interactive --no-refresh install -y tar gzip
 
     - name: Retrieve and unpack the xNVMe source archive
       uses: xnvme/actions/.github/actions/setup-source@main

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -352,7 +352,7 @@ jobs:
     - name: Python-bindings (ctypes), install and test
       if: (!contains('focal', matrix.container.ver))
       run: |
-        python3 -m pipx inject cijoe "${{ steps.source.outputs.directory }}/xnvme-py-sdist.tar.gz" --force
+        python3 -m pipx inject xnvme-cijoe "${{ steps.source.outputs.directory }}/xnvme-py-sdist.tar.gz" --force
         pytest --pyargs xnvme.ctypes_bindings
 
     #
@@ -474,7 +474,7 @@ jobs:
 
     - name: Python-bindings (ctypes), install and test
       run: |
-        pipx inject cijoe "${{ steps.source.outputs.directory }}/xnvme-py-sdist.tar.gz" --force
+        pipx inject xnvme-cijoe "${{ steps.source.outputs.directory }}/xnvme-py-sdist.tar.gz" --force
         pytest --pyargs xnvme.ctypes_bindings
 
     #

--- a/Makefile
+++ b/Makefile
@@ -148,10 +148,7 @@ endef
 .PHONY: cijoe-install
 cijoe-install:
 	@echo "## xNVMe: cijoe-install"
-	pipx install cijoe==v0.9.58 --include-deps --force
-	pipx inject cijoe matplotlib --force
-	pipx inject cijoe numpy --force
-	pipx install rst2pdf
+	pipx install cijoe/ --include-deps --force
 	@echo "## xNVMe: cijoe-install [DONE]"
 
 define guest-env-help

--- a/cijoe/pyproject.toml
+++ b/cijoe/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "xnvme-cijoe"
+version = "0.7.5"
+description = "CIJOE environment for xNVMe"
+requires-python = ">=3.9"
+
+dependencies = [
+    "cijoe==0.9.58",
+    "matplotlib",
+    "numpy",
+    "rst2pdf",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = []

--- a/cijoe/scripts/latency_reporter.py
+++ b/cijoe/scripts/latency_reporter.py
@@ -16,7 +16,6 @@ from collections import defaultdict
 from pathlib import Path
 
 import jinja2
-from cijoe.core.resources import dict_from_yamlfile
 from reporter import (
     copy_graphs,
     create_stylesheet,
@@ -24,6 +23,8 @@ from reporter import (
     create_xnvme_cover,
     create_xnvme_info,
 )
+
+from cijoe.core.resources import dict_from_yamlfile
 
 PLOT_PATH_REGEX = r".*_GROUP=(?P<group>.+)_TYPE=(?P<type>.+)\.png"
 

--- a/cijoe/scripts/plotter.py
+++ b/cijoe/scripts/plotter.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Dict, List
 
 import matplotlib.pyplot as plt
+
 from cijoe.core.resources import dict_from_yamlfile
 
 OUTPUT_NORMALIZED_FILENAME = "benchmark-output-normalized.json"

--- a/cijoe/scripts/xnvme_bindings_py_install_tgz.py
+++ b/cijoe/scripts/xnvme_bindings_py_install_tgz.py
@@ -66,9 +66,9 @@ def main(args, cijoe):
 
     commands = [
         "pipx ensurepath",
-        "pipx install cijoe==v0.9.58 --include-deps --force",
-        "pipx inject cijoe numpy --force",
-        "pipx inject cijoe ./xnvme-py-sdist.tar.gz --force",
+        "pipx install cijoe==0.9.58 --include-deps --force",
+        "cd /tmp && pipx inject cijoe numpy --force",
+        f"cd /tmp && pipx inject cijoe {xnvme_source}/xnvme-py-sdist.tar.gz --force",
         "cijoe --version",
         "pytest --version",
     ]

--- a/cijoe/templates/perf_report/latency.jinja2.rst
+++ b/cijoe/templates/perf_report/latency.jinja2.rst
@@ -135,12 +135,10 @@ The engines used in this experiment are:
 Results
 =======
 
-.. raw:: pdf
-
 {% for group, group_plots in plots.items() %}
 
 .. raw:: pdf
-   
+
    FrameBreak 300
 
 {{group}}

--- a/docs/tooling/pyproject.toml
+++ b/docs/tooling/pyproject.toml
@@ -7,15 +7,15 @@ requires-python = ">=3.10"
 dependencies = [
     "myst-parser>=4.0",
     "sphinx>=8.0,<9.0",
-    "sphinx-autobuild>=2024.0",
-    "pydata-sphinx-theme>=0.15.2",
+    "sphinx-autobuild>=2025.0",
+    "pydata-sphinx-theme>=0.16.1",
     "sphinx-copybutton>=0.5.2",
-    "sphinx-tabs>=3.4.5",
+    "sphinx-tabs>=3.5.0",
     "sphinxcontrib-jquery>=4.1",
-    "breathe>=4.35.0",
-    "jinja2>=3.1.5",
+    "breathe>=4.36.0",
+    "jinja2>=3.1.6",
     "pyyaml>=6.0",
-    "watchdog>=4.0.0",
+    "watchdog>=6.0.0",
 ]
 
 [project.scripts]

--- a/python/bindings/Makefile
+++ b/python/bindings/Makefile
@@ -69,8 +69,7 @@ define deps-help
 endef
 .PHONY: deps
 deps:
-	@pipx install cijoe==v0.9.58 --include-deps --force
-	@pipx inject cijoe numpy --force
+	@pipx install ../../cijoe/ --include-deps --force
 
 define install-help
 # install for current user
@@ -78,7 +77,7 @@ endef
 .PHONY: install
 install: deps
 	@echo "## py: make install"
-	@pipx inject cijoe dist/xnvme-*.tar.gz --force
+	@cd /tmp && pipx inject xnvme-cijoe $(CURDIR)/dist/xnvme-*.tar.gz --force
 	@echo "## py: make install [DONE]"
 
 define uninstall-help


### PR DESCRIPTION
Prompted by https://github.com/xnvme/xnvme/pull/657 i took a look, realizing that xNVMe no longer uses the thing dependabot found an issue with. However, since I was there anyway, here is a soft bump of the documentation dependencies.