### PR TITLE
feat(be/upcie-cuda): implement mem_map and mem_unmap

### DIFF
--- a/lib/upcie/xnvme_be_upcie_cuda.h
+++ b/lib/upcie/xnvme_be_upcie_cuda.h
@@ -18,6 +18,7 @@ struct xnvme_be_upcie_cuda_rte {
 	struct cudamem_config cuda_config;
 	struct cudamem_heap cuda_heap;
 	int is_initialized;
+	struct cudamem_mapping *mappings;
 };
 
 extern struct xnvme_be_upcie_cuda_rte g_upcie_cuda_rte;

--- a/lib/upcie/xnvme_be_upcie_cuda_admin.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_admin.c
@@ -30,7 +30,8 @@ xnvme_be_upcie_cuda_sync_cmd_admin(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t
 	cmd->cid = req->cid;
 
 	if (dbuf) {
-		nvme_request_prep_command_prps_contig_cuda(req, &g_upcie_cuda_rte.cuda_heap, dbuf,
+		nvme_request_prep_command_prps_contig_cuda(req, &g_upcie_cuda_rte.cuda_heap,
+							   g_upcie_cuda_rte.mappings, dbuf,
 							   dbuf_nbytes, cmd);
 	}
 

--- a/lib/upcie/xnvme_be_upcie_cuda_async.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_async.c
@@ -46,7 +46,8 @@ xnvme_be_upcie_cuda_async_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t d
 	cmd->cid = req->cid;
 
 	if (dbuf) {
-		nvme_request_prep_command_prps_contig_cuda(req, &g_upcie_cuda_rte.cuda_heap, dbuf,
+		nvme_request_prep_command_prps_contig_cuda(req, &g_upcie_cuda_rte.cuda_heap,
+							   g_upcie_cuda_rte.mappings, dbuf,
 							   dbuf_nbytes, cmd);
 	}
 
@@ -103,7 +104,8 @@ xnvme_be_upcie_cuda_async_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec,
 	cmd->cid = req->cid;
 
 	if (dvec) {
-		nvme_request_prep_command_prps_iov_cuda(req, &g_upcie_cuda_rte.cuda_heap, dvec,
+		nvme_request_prep_command_prps_iov_cuda(req, &g_upcie_cuda_rte.cuda_heap,
+							g_upcie_cuda_rte.mappings, dvec,
 							dvec_cnt, cmd);
 	}
 

--- a/lib/upcie/xnvme_be_upcie_cuda_mem.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_mem.c
@@ -37,7 +37,120 @@ int
 xnvme_be_upcie_cuda_buf_vtophys(const struct xnvme_dev *XNVME_UNUSED(dev), void *buf,
 				uint64_t *phys)
 {
-	return cudamem_heap_block_virt_to_phys(&g_upcie_cuda_rte.cuda_heap, buf, phys);
+	int err;
+
+	err = cudamem_heap_block_virt_to_phys(&g_upcie_cuda_rte.cuda_heap, buf, phys);
+	if (!err) {
+		return 0;
+	}
+
+	uint64_t vaddr = (uint64_t)buf;
+
+	for (struct cudamem_mapping *m = g_upcie_cuda_rte.mappings; m; m = m->next) {
+		if (vaddr >= m->vaddr && vaddr < m->vaddr + m->size) {
+			size_t offset = vaddr - m->vaddr;
+			size_t page_idx = offset / m->config->device_pagesize;
+			size_t in_page_offset = offset % m->config->device_pagesize;
+
+			if (page_idx >= m->nphys) {
+				return -EINVAL;
+			}
+
+			*phys = m->phys_lut[page_idx] + in_page_offset;
+			return 0;
+		}
+	}
+
+	return -EINVAL;
+}
+
+int
+xnvme_be_upcie_cuda_mem_map(const struct xnvme_dev *XNVME_UNUSED(dev), void *vaddr,
+			    size_t nbytes, uint64_t *phys)
+{
+	struct cudamem_config *config = &g_upcie_cuda_rte.cuda_config;
+	struct cudamem_mapping *m;
+	int dmabuf_fd = -1;
+	CUresult cr;
+	int err;
+
+	if (!vaddr || !nbytes) {
+		return -EINVAL;
+	}
+	if ((uint64_t)vaddr % config->device_pagesize ||
+	    nbytes % config->device_pagesize) {
+		XNVME_DEBUG("FAILED: vaddr/nbytes not aligned to device_pagesize(%d)",
+			    config->device_pagesize);
+		return -EINVAL;
+	}
+
+	cr = cuMemGetHandleForAddressRange(&dmabuf_fd, (CUdeviceptr)vaddr, nbytes,
+					   CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
+	if (cr != CUDA_SUCCESS) {
+		XNVME_DEBUG("FAILED: cuMemGetHandleForAddressRange(), cr: %d", cr);
+		return -EIO;
+	}
+
+	m = calloc(1, sizeof(*m));
+	if (!m) {
+		close(dmabuf_fd);
+		return -ENOMEM;
+	}
+
+	err = dmabuf_attach(dmabuf_fd, &m->dmabuf);
+	if (err) {
+		XNVME_DEBUG("FAILED: dmabuf_attach(), err: %d", err);
+		free(m);
+		return err;
+	}
+
+	m->vaddr = (uint64_t)vaddr;
+	m->size = nbytes;
+	m->config = config;
+	m->nphys = nbytes / config->device_pagesize;
+	m->phys_lut = calloc(m->nphys, sizeof(*m->phys_lut));
+	if (!m->phys_lut) {
+		dmabuf_detach(&m->dmabuf);
+		free(m);
+		return -ENOMEM;
+	}
+
+	err = dmabuf_get_lut(&m->dmabuf, m->nphys, m->phys_lut, config->device_pagesize);
+	if (err) {
+		XNVME_DEBUG("FAILED: dmabuf_get_lut(), err: %d", err);
+		free(m->phys_lut);
+		dmabuf_detach(&m->dmabuf);
+		free(m);
+		return err;
+	}
+
+	m->next = g_upcie_cuda_rte.mappings;
+	g_upcie_cuda_rte.mappings = m;
+
+	if (phys) {
+		*phys = m->phys_lut[0];
+	}
+
+	return 0;
+}
+
+int
+xnvme_be_upcie_cuda_mem_unmap(const struct xnvme_dev *XNVME_UNUSED(dev), void *buf)
+{
+	uint64_t vaddr = (uint64_t)buf;
+	struct cudamem_mapping **prev = &g_upcie_cuda_rte.mappings;
+
+	for (struct cudamem_mapping *m = *prev; m; prev = &m->next, m = m->next) {
+		if (m->vaddr == vaddr) {
+			*prev = m->next;
+			dmabuf_detach(&m->dmabuf);
+			free(m->phys_lut);
+			free(m);
+			return 0;
+		}
+	}
+
+	return -EINVAL;
 }
 
 #endif
@@ -49,8 +162,8 @@ struct xnvme_be_mem g_xnvme_be_upcie_cuda_mem = {
 	.buf_realloc = xnvme_be_nosys_buf_realloc,
 	.buf_free = xnvme_be_upcie_cuda_buf_free,
 	.buf_vtophys = xnvme_be_upcie_cuda_buf_vtophys,
-	.mem_map = xnvme_be_nosys_mem_map,
-	.mem_unmap = xnvme_be_nosys_mem_unmap,
+	.mem_map = xnvme_be_upcie_cuda_mem_map,
+	.mem_unmap = xnvme_be_upcie_cuda_mem_unmap,
 #else
 	.buf_alloc = xnvme_be_nosys_buf_alloc,
 	.buf_realloc = xnvme_be_nosys_buf_realloc,

--- a/lib/upcie/xnvme_be_upcie_cuda_sync.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_sync.c
@@ -42,7 +42,8 @@ xnvme_be_upcie_cuda_sync_cmd_io(struct xnvme_cmd_ctx *ctx, void *dbuf, size_t db
 	cmd->cid = req->cid;
 
 	if (dbuf) {
-		nvme_request_prep_command_prps_contig_cuda(req, &g_upcie_cuda_rte.cuda_heap, dbuf,
+		nvme_request_prep_command_prps_contig_cuda(req, &g_upcie_cuda_rte.cuda_heap,
+							   g_upcie_cuda_rte.mappings, dbuf,
 							   dbuf_nbytes, cmd);
 	}
 
@@ -109,7 +110,8 @@ xnvme_be_upcie_cuda_sync_cmd_iov(struct xnvme_cmd_ctx *ctx, struct iovec *dvec, 
 	cmd->cid = req->cid;
 
 	if (dvec) {
-		nvme_request_prep_command_prps_iov_cuda(req, &g_upcie_cuda_rte.cuda_heap, dvec,
+		nvme_request_prep_command_prps_iov_cuda(req, &g_upcie_cuda_rte.cuda_heap,
+							g_upcie_cuda_rte.mappings, dvec,
 							dvec_cnt, cmd);
 	}
 

--- a/toolbox/third-party/linux/upcie/cudamem_heap.h
+++ b/toolbox/third-party/linux/upcie/cudamem_heap.h
@@ -436,3 +436,52 @@ cudamem_heap_block_vtp(struct cudamem_heap *heap, void *virt)
 
 	return heap->phys_lut[page_idx] + in_page_offset;
 }
+
+/**
+ * An externally mapped CUDA buffer registered via xnvme_mem_map()
+ *
+ * Unlike heap-allocated buffers, mapped buffers are allocated by the caller
+ * (e.g. via cudaMalloc) and their physical addresses are resolved on demand
+ * through the dma-buf interface.
+ */
+struct cudamem_mapping {
+	uint64_t vaddr;
+	size_t size;
+	struct dmabuf dmabuf;
+	size_t nphys;
+	uint64_t *phys_lut;
+	struct cudamem_config *config;
+	struct cudamem_mapping *next;
+};
+
+/**
+ * Resolve a GPU virtual address to its physical address
+ *
+ * Checks the heap first (fast path), then falls back to the linked list of
+ * externally mapped regions. Returns 0 on failure (caller should check).
+ */
+static inline uint64_t
+cudamem_vtp(struct cudamem_heap *heap, struct cudamem_mapping *mappings, void *virt)
+{
+	uint64_t vaddr = (uint64_t)virt;
+
+	// Fast path: check heap range
+	if (vaddr >= heap->vaddr && vaddr < heap->vaddr + heap->size) {
+		return cudamem_heap_block_vtp(heap, virt);
+	}
+
+	// Slow path: check mapped regions
+	for (struct cudamem_mapping *m = mappings; m; m = m->next) {
+		if (vaddr >= m->vaddr && vaddr < m->vaddr + m->size) {
+			size_t offset = vaddr - m->vaddr;
+			size_t page_idx = offset / m->config->device_pagesize;
+			size_t in_page_offset = offset % m->config->device_pagesize;
+
+			assert(page_idx < m->nphys);
+			return m->phys_lut[page_idx] + in_page_offset;
+		}
+	}
+
+	assert(0 && "cudamem_vtp: address not in heap or any mapping");
+	return 0;
+}

--- a/toolbox/third-party/linux/upcie/nvme/nvme_request_cuda.h
+++ b/toolbox/third-party/linux/upcie/nvme/nvme_request_cuda.h
@@ -17,20 +17,25 @@
  * It sets up the PRP1 and PRP2 fields in the command to describe the physical memory backing the
  * `data` buffer, allowing the NVMe controller to access the buffer during command execution.
  *
+ * The buffer may reside in the heap (allocated via xnvme_buf_alloc) or in an
+ * externally mapped region (registered via xnvme_mem_map). Physical addresses
+ * are resolved per page to support non-contiguous mappings.
+ *
  * Caveats
  * -------
  *
- * - Assumes that the memory backing `dbuf` in `heap` is physically contiguous.
  * - Does *not* support PRP list chaining; only a single list page is constructed.
  *
  * @param request Pointer to the NVMe request context used for tracking and metadata.
- * @param heap Pointer to the CUDA memory heap that dbuf is allocated within.
+ * @param heap Pointer to the CUDA memory heap.
+ * @param mappings Linked list of externally mapped CUDA regions (may be NULL).
  * @param dbuf Pointer to the contiguous data buffer to be described by PRPs.
  * @param dbuf_nbytes Size in bytes of the data buffer.
  * @param cmd Pointer to the NVMe command to be prepared with PRP entries.
  */
 static inline void
 nvme_request_prep_command_prps_contig_cuda(struct nvme_request *request, struct cudamem_heap *heap,
+                                           struct cudamem_mapping *mappings,
                                            void *dbuf, size_t dbuf_nbytes, struct nvme_command *cmd)
 {
 	const uint64_t npages = (dbuf_nbytes + heap->config->pagesize - 1) >> heap->config->pagesize_shift;
@@ -39,18 +44,19 @@ nvme_request_prep_command_prps_contig_cuda(struct nvme_request *request, struct 
 	/* Chaining is not supported, thus assert that the given dbuf fits. */
 	assert(npages <= 1 + 512);
 
-	cmd->prp1 = cudamem_heap_block_vtp(heap, dbuf);
+	cmd->prp1 = cudamem_vtp(heap, mappings, dbuf);
 
 	if (npages == 1) {
 		return;
 	} else if (npages == 2) {
-		cmd->prp2 = cmd->prp1 + pagesize;
+		cmd->prp2 = cudamem_vtp(heap, mappings, (uint8_t *)dbuf + pagesize);
 	} else {
 		uint64_t *prp_list = request->prp;
 
 		cmd->prp2 = request->prp_addr;
 		for (uint64_t i = 1; i < npages; ++i) {
-			prp_list[i - 1] = cmd->prp1 + (i << heap->config->pagesize_shift);
+			prp_list[i - 1] = cudamem_vtp(heap, mappings,
+						      (uint8_t *)dbuf + (i * pagesize));
 		}
 	}
 }
@@ -60,29 +66,31 @@ nvme_request_prep_command_prps_contig_cuda(struct nvme_request *request, struct 
  *
  * This function initializes the Physical Region Page (PRP) entries in the given NVMe command
  * (`cmd`) using the provided request and an array of iovec entries. Each iovec entry is assumed to
- * be page-aligned and allocated from the given `heap`.
+ * be page-aligned and allocated from the heap or an externally mapped region.
  *
  * Caveats
  * -------
  *
- * - Each iovec base must be page-aligned and allocated from `heap`.
+ * - Each iovec base must be page-aligned.
  * - Does *not* support PRP list chaining; only a single list page is constructed.
  *
  * @param request Pointer to the NVMe request context used for tracking and metadata.
- * @param heap Pointer to the CUDA heap that iovec buffers are allocated within.
+ * @param heap Pointer to the CUDA memory heap.
+ * @param mappings Linked list of externally mapped CUDA regions (may be NULL).
  * @param dvec Array of iovec structures describing the data segments.
  * @param dvec_cnt Number of elements in the dvec array.
  * @param cmd Pointer to the NVMe command to be prepared with PRP entries.
  */
 static inline void
 nvme_request_prep_command_prps_iov_cuda(struct nvme_request *request, struct cudamem_heap *heap,
+                                        struct cudamem_mapping *mappings,
 				   	struct iovec *dvec, size_t dvec_cnt, struct nvme_command *cmd)
 {
 	const uint64_t pagesize = heap->config->pagesize;
 	uint64_t *prp_list = request->prp;
 	size_t prp_idx = 0;
 
-	cmd->prp1 = cudamem_heap_block_vtp(heap, dvec[0].iov_base);
+	cmd->prp1 = cudamem_vtp(heap, mappings, dvec[0].iov_base);
 
 	for (size_t i = 0; i < dvec_cnt; ++i) {
 		uint8_t *base = dvec[i].iov_base;
@@ -96,7 +104,7 @@ nvme_request_prep_command_prps_iov_cuda(struct nvme_request *request, struct cud
 		}
 
 		while (remaining > 0) {
-			prp_list[prp_idx++] = cudamem_heap_block_vtp(heap, base + offset);
+			prp_list[prp_idx++] = cudamem_vtp(heap, mappings, base + offset);
 
 			offset += pagesize;
 			remaining = (remaining > pagesize) ? remaining - pagesize : 0;


### PR DESCRIPTION
Wire the upcie-cuda backend's .mem_map and .mem_unmap hooks, previously stubbed with nosys, so callers can register externally-allocated CUDA buffers (cuMemAlloc, cuMemCreate/cuMemMap, cudaMalloc) for NVMe DMA in addition to the pre-built heap used by xnvme_buf_alloc.

The new mem_map path calls cuMemGetHandleForAddressRange to obtain a dma-buf fd for the registered range, attaches it, and builds a physical address LUT at device_pagesize granularity stored in a new cudamem_mapping entry on a per-runtime linked list. mem_unmap detaches the dma-buf and removes the entry.

The PRP builders in nvme_request_cuda.h no longer assume the payload is physically contiguous: every page is resolved through the new cudamem_vtp helper, which checks the heap first and falls back to the mapping list. This is required for registered buffers, whose physical pages can be non-contiguous.

vaddr and nbytes passed to mem_map must be aligned to device_pagesize; unaligned inputs return -EINVAL. mem_unmap matches by the exact vaddr that was passed to mem_map.