### PR TITLE
upcie: add vfio-pci path

### DIFF
--- a/docs/background/backends/upcie/cuda.md
+++ b/docs/background/backends/upcie/cuda.md
@@ -106,6 +106,8 @@ cd cijoe && cijoe workflows/test-gpu.yaml --config configs/<your-config>.toml
 
 ## Limitations
 
+- **No `vfio-pci` support.** The CUDA backend currently supports the
+  non-IOMMU user-space driver path only.
 - **GPU 0 only.** The CUDA context and heap are always created on CUDA device
   0. Multiple GPU support is not implemented.
 - **1 GiB heap.** The CUDA heap is fixed at 1 GiB. Allocations beyond this
@@ -118,4 +120,3 @@ cd cijoe && cijoe workflows/test-gpu.yaml --config configs/<your-config>.toml
 - **No memory mapping** (`mem_map` / `mem_unmap`). These return `ENOSYS`.
 - **No pseudo commands.** Show registers, controller reset, subsystem reset,
   and namespace rescan all return `ENOSYS`.
-

--- a/docs/background/backends/upcie/index.md
+++ b/docs/background/backends/upcie/index.md
@@ -21,10 +21,11 @@ allocated:
 ## Device Identifiers
 
 When using **user space** NVMe drivers, the operating-system kernel NVMe
-driver is detached and the device bound to `uio_pci_generic`. Thus, the device
-files in `/dev/`, such as `/dev/nvme0n1` are not available. Devices are
-instead identified by their PCI id (`0000:03:00.0`), and namespace identifier
-via the `--nsid` option.
+driver is detached and the device is bound either to `uio_pci_generic` for the
+legacy no-IOMMU path or to `vfio-pci` for the IOMMU-backed path. Thus, the
+device files in `/dev/`, such as `/dev/nvme0n1`, are not available. Devices
+are instead identified by their PCI id (`0000:03:00.0`), and namespace
+identifier via the `--nsid` option.
 
 (sec-backends-upcie-config)=
 
@@ -33,16 +34,15 @@ via the `--nsid` option.
 ### Driver Attachment
 
 Use the `xnvme-driver` script to unbind the kernel NVMe driver and bind
-devices to `uio_pci_generic`:
+devices to uio_pci_generic or vfio-pci:
 
 ```bash
 xnvme-driver
 ```
 
-**uPCIe** does **not** work with IOMMU enabled. When IOMMU is active,
-`xnvme-driver` will bind devices to `vfio-pci` by default, which is
-incompatible with uPCIe. Ensure devices are bound to `uio_pci_generic`
-instead.
+For the host-memory backend, bind devices to `uio_pci_generic` for the legacy
+path or `vfio-pci` for the IOMMU-backed path. The `upcie-cuda` backend still
+requires the non-VFIO path.
 
 ### Privileges
 
@@ -50,7 +50,8 @@ instead.
 
 1. Reading `/proc/self/pagemap` to translate virtual to physical addresses
    for DMA.
-2. Writing PCI config space via sysfs to enable Bus Master.
+2. Accessing VFIO device nodes and writing PCI config space via sysfs to
+   enable Bus Master when needed.
 
 
 ```{toctree}

--- a/lib/upcie/xnvme_be_upcie.h
+++ b/lib/upcie/xnvme_be_upcie.h
@@ -20,12 +20,19 @@ struct xnvme_queue_upcie {
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_queue_upcie) == XNVME_BE_QUEUE_STATE_NBYTES,
 		    "Incorrect size")
 
+enum nvme_backend {
+	NVME_BACKEND_SYSFS = 0,
+	NVME_BACKEND_VFIO,
+};
+
 /**
  * Shared controller state, one per physical controller, managed by cref.
  */
 struct xnvme_be_upcie_ctrlr {
 	struct nvme_controller *ctrl;
 	struct nvme_qpair sync; ///< Shared submission/completion queue for synchronous IOs
+	struct vfio_ctx vfio;
+	enum nvme_backend backend;
 };
 
 /**
@@ -55,6 +62,9 @@ extern struct xnvme_be_admin g_xnvme_be_upcie_admin;
 extern struct xnvme_be_sync g_xnvme_be_upcie_sync;
 extern struct xnvme_be_async g_xnvme_be_upcie_async;
 extern struct xnvme_be_dev g_xnvme_be_upcie_dev;
+
+int
+xnvme_be_upcie_get_driver_name(const char *bdf, char *driver_name, size_t driver_name_len);
 
 // Used by xnvme_be_upcie_cuda_dev.c
 void

--- a/lib/upcie/xnvme_be_upcie_cuda_dev.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_dev.c
@@ -107,7 +107,27 @@ void *
 xnvme_be_upcie_cuda_ctrlr_init(struct xnvme_dev *dev)
 {
 	struct xnvme_be_upcie_ctrlr *ctrlr;
+	char driver_name[sizeof(dev->ident.kernel_driver)] = {0};
 	int err;
+
+	err = xnvme_be_upcie_get_driver_name(dev->ident.uri, driver_name, sizeof(driver_name));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_be_upcie_get_driver_name(%s); err(%d)", dev->ident.uri,
+			    err);
+		errno = -err;
+		return NULL;
+	}
+	snprintf(dev->ident.kernel_driver, sizeof(dev->ident.kernel_driver), "%s", driver_name);
+
+	if (!strcmp(driver_name, "vfio-pci")) {
+		XNVME_DEBUG("FAILED: upcie-cuda does not support vfio-pci");
+		errno = ENOTSUP;
+		return NULL;
+	} else if (strcmp(driver_name, "uio_pci_generic")) {
+		XNVME_DEBUG("FAILED: unsupported driver '%s'", driver_name);
+		errno = ENOTSUP;
+		return NULL;
+	}
 
 	err = _cuda_rte_init();
 	if (err) {

--- a/lib/upcie/xnvme_be_upcie_dev.c
+++ b/lib/upcie/xnvme_be_upcie_dev.c
@@ -6,6 +6,7 @@
 #include <xnvme_be.h>
 #include <xnvme_be_nosys.h>
 #ifdef XNVME_BE_UPCIE_ENABLED
+#include <limits.h>
 #include <stdatomic.h>
 #include <xnvme_dev.h>
 #include <xnvme_be_upcie.h>
@@ -17,6 +18,31 @@ struct xnvme_be_upcie_enumerate_context {
 	xnvme_enumerate_cb cb_func;
 	void *cb_args;
 };
+
+int
+xnvme_be_upcie_get_driver_name(const char *bdf, char *driver_name, size_t driver_name_len)
+{
+	char path[PATH_MAX] = {0};
+	char link[PATH_MAX] = {0};
+	ssize_t nbytes;
+	char *base;
+
+	snprintf(path, sizeof(path), "/sys/bus/pci/devices/%s/driver", bdf);
+
+	nbytes = readlink(path, link, sizeof(link) - 1);
+	if (nbytes < 0) {
+		return -errno;
+	}
+
+	base = strrchr(link, '/');
+	if (!base || !base[1]) {
+		return -EINVAL;
+	}
+
+	snprintf(driver_name, driver_name_len, "%s", base + 1);
+
+	return 0;
+}
 
 /**
  * Terminate the uPCIe runtime-environment
@@ -130,6 +156,7 @@ void *
 xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev)
 {
 	struct xnvme_be_upcie_ctrlr *ctrlr;
+	char driver_name[sizeof(dev->ident.kernel_driver)] = {0};
 	int err;
 
 	err = _rte_init();
@@ -161,9 +188,33 @@ xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev)
 		return NULL;
 	}
 
-	err = nvme_controller_open(ctrlr->ctrl, dev->ident.uri, &g_upcie_rte.heap);
+	err = xnvme_be_upcie_get_driver_name(dev->ident.uri, driver_name, sizeof(driver_name));
 	if (err) {
-		XNVME_DEBUG("FAILED: nvme_controller_open(%s)", dev->ident.uri);
+		XNVME_DEBUG("FAILED: xnvme_be_upcie_get_driver_name(%s); err(%d)", dev->ident.uri,
+			    err);
+		errno = -err;
+		free(ctrlr->ctrl);
+		free(ctrlr);
+		return NULL;
+	}
+	snprintf(dev->ident.kernel_driver, sizeof(dev->ident.kernel_driver), "%s", driver_name);
+
+	if (!strcmp(driver_name, "vfio-pci")) {
+		ctrlr->backend = NVME_BACKEND_VFIO;
+		err = nvme_controller_open_vfio(ctrlr->ctrl, &ctrlr->vfio, dev->ident.uri,
+						&g_upcie_rte.heap);
+	} else if (!strcmp(driver_name, "uio_pci_generic")) {
+		ctrlr->backend = NVME_BACKEND_SYSFS;
+		err = nvme_controller_open(ctrlr->ctrl, dev->ident.uri, &g_upcie_rte.heap);
+	} else {
+		XNVME_DEBUG("FAILED: unsupported driver '%s'", driver_name);
+		err = -ENOTSUP;
+	}
+	if (err) {
+		XNVME_DEBUG("FAILED: %s(%s)",
+			    ctrlr->backend == NVME_BACKEND_VFIO ? "nvme_controller_open_vfio"
+								: "nvme_controller_open",
+			    dev->ident.uri);
 		errno = -err;
 		free(ctrlr->ctrl);
 		free(ctrlr);
@@ -174,7 +225,11 @@ xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev)
 	if (err) {
 		XNVME_DEBUG("FAILED: nvme_controller_create_io_qpair(%d)", err);
 		errno = -err;
-		nvme_controller_close(ctrlr->ctrl);
+		if (ctrlr->backend == NVME_BACKEND_VFIO) {
+			nvme_controller_close_vfio(ctrlr->ctrl, &ctrlr->vfio);
+		} else {
+			nvme_controller_close(ctrlr->ctrl);
+		}
 		free(ctrlr->ctrl);
 		free(ctrlr);
 		return NULL;
@@ -191,7 +246,11 @@ xnvme_be_upcie_ctrlr_term(void *handle)
 	struct xnvme_be_upcie_ctrlr *ctrlr = handle;
 
 	nvme_qpair_term(&ctrlr->sync);
-	nvme_controller_close(ctrlr->ctrl);
+	if (ctrlr->backend == NVME_BACKEND_VFIO) {
+		nvme_controller_close_vfio(ctrlr->ctrl, &ctrlr->vfio);
+	} else {
+		nvme_controller_close(ctrlr->ctrl);
+	}
 	free(ctrlr->ctrl);
 	free(ctrlr);
 

--- a/toolbox/third-party/linux/upcie/nvme/nvme_controller.h
+++ b/toolbox/third-party/linux/upcie/nvme/nvme_controller.h
@@ -83,6 +83,7 @@ nvme_controller_open(struct nvme_controller *ctrlr, const char *bdf, struct host
 	bar0 = ctrlr->func.bars[0].region;
 
 	cap = nvme_mmio_cap_read(bar0);
+	// CAP.TO is encoded in units of 500 ms.
 	ctrlr->timeout_ms = nvme_reg_cap_get_to(cap) * 500;
 
 	nvme_mmio_cc_disable(bar0);

--- a/toolbox/third-party/linux/upcie/nvme/nvme_controller_vfio.h
+++ b/toolbox/third-party/linux/upcie/nvme/nvme_controller_vfio.h
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Jaeyoon Choi <j_yoon.choi@samsung.com>
+
+/**
+ * VFIO state needed to access a single NVMe controller from user space.
+ */
+struct vfio_ctx {
+	struct vfio_container container;
+	struct vfio_group group;
+	int device_fd;
+	void *bar0;
+	size_t bar0_size;
+	int iommu_set;
+};
+
+static inline void
+nvme_vfio_ctx_init(struct vfio_ctx *vfio)
+{
+	memset(vfio, 0, sizeof(*vfio));
+	vfio->device_fd = -1;
+	vfio->group.fd = -1;
+	vfio->container.fd = -1;
+}
+
+/**
+ * Release VFIO resources and undo DMA mappings created for the heap.
+ */
+static inline int
+nvme_vfio_ctx_close(struct vfio_ctx *vfio, struct hostmem_heap *heap)
+{
+	int err = 0;
+
+	if (vfio->bar0 && vfio->bar0_size) {
+		munmap(vfio->bar0, vfio->bar0_size);
+	}
+
+	if (vfio->device_fd >= 0) {
+		close(vfio->device_fd);
+	}
+
+	if (heap && vfio->iommu_set) {
+		for (size_t i = 0; i < heap->nphys; ++i) {
+			struct vfio_iommu_type1_dma_unmap unmap = {0};
+
+			unmap.argsz = sizeof(unmap);
+			unmap.iova = heap->phys_lut[i];
+			unmap.size = heap->config->hugepgsz;
+
+			if (vfio_iommu_unmap_dma(&vfio->container, &unmap) < 0 && !err) {
+				err = -errno;
+			}
+		}
+	}
+
+	if (vfio->group.fd >= 0) {
+		vfio_group_close(&vfio->group);
+	}
+
+	if (vfio->container.fd >= 0) {
+		vfio_container_close(&vfio->container);
+	}
+
+	nvme_vfio_ctx_init(vfio);
+
+	return err;
+}
+
+static inline int
+nvme_controller_disable_vfio(const struct nvme_controller *ctrlr, const struct vfio_ctx *vfio)
+{
+	if (!vfio->bar0) {
+		return 0;
+	}
+
+	nvme_mmio_cc_disable(vfio->bar0);
+	if (!ctrlr->timeout_ms) {
+		return 0;
+	}
+
+	return nvme_mmio_csts_wait_until_not_ready(vfio->bar0, ctrlr->timeout_ms);
+}
+
+static inline int
+nvme_controller_close_vfio(struct nvme_controller *ctrlr, struct vfio_ctx *vfio)
+{
+	int close_err;
+	int err;
+
+	// Stop the controller before tearing down DMA mappings and BAR access.
+	err = nvme_controller_disable_vfio(ctrlr, vfio);
+
+	if (ctrlr->aq.rpool) {
+		nvme_qpair_term(&ctrlr->aq);
+		memset(&ctrlr->aq, 0, sizeof(ctrlr->aq));
+	}
+
+	if (ctrlr->buf) {
+		hostmem_dma_free(ctrlr->heap, ctrlr->buf);
+		ctrlr->buf = NULL;
+	}
+
+	close_err = nvme_vfio_ctx_close(vfio, ctrlr->heap);
+	if (close_err && !err) {
+		err = close_err;
+	}
+	memset(ctrlr, 0, sizeof(*ctrlr));
+
+	return err;
+}
+
+/**
+ * Resolve the IOMMU group ID of the PCI function identified by `bdf`.
+ */
+static inline int
+vfio_device_get_iommu_group_id(const char *bdf, int *group_id)
+{
+	char path[PATH_MAX] = {0};
+	char link[PATH_MAX] = {0};
+	ssize_t nbytes;
+	char *base;
+
+	snprintf(path, sizeof(path), "/sys/bus/pci/devices/%s/iommu_group", bdf);
+
+	nbytes = readlink(path, link, sizeof(link) - 1);
+	if (nbytes < 0) {
+		return -errno;
+	}
+
+	base = strrchr(link, '/');
+	if (!base || !base[1]) {
+		return -EINVAL;
+	}
+
+	*group_id = atoi(base + 1);
+
+	return 0;
+}
+
+/**
+ * Map the hugepage-backed heap into the VFIO IOMMU domain.
+ *
+ * The current implementation intentionally uses `iova == phys` for each hugepage.
+ * This keeps the existing NVMe code paths working because they already pass
+ * hostmem_dma_v2p() results to the controller for SQ/CQ/PRP DMA addresses.
+ *
+ * TODO: decouple IOVA from physical addresses by introducing a dedicated
+ *       hostmem_dma_v2iova() path for VFIO-backed DMA.
+ */
+static inline int
+vfio_map_heap(struct vfio_ctx *vfio, struct hostmem_heap *heap)
+{
+	for (size_t i = 0; i < heap->nphys; ++i) {
+		struct vfio_iommu_type1_dma_map map = {0};
+		void *vaddr = (uint8_t *)heap->memory.virt + (i * heap->config->hugepgsz);
+
+		map.argsz = sizeof(map);
+		map.flags = VFIO_DMA_MAP_FLAG_READ | VFIO_DMA_MAP_FLAG_WRITE;
+		map.vaddr = (uintptr_t)vaddr;
+		map.iova = heap->phys_lut[i];
+		map.size = heap->config->hugepgsz;
+
+		if (vfio_iommu_map_dma(&vfio->container, &map) < 0) {
+			UPCIE_DEBUG("FAILED: vfio_iommu_map_dma(); errno(%d)", errno);
+			return -errno;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * Open an NVMe controller through VFIO.
+ *
+ * This sets up the VFIO container/group, maps the DMA heap and BAR0, and then
+ * continues with the regular NVMe controller initialization flow.
+ */
+static inline int
+nvme_controller_open_vfio(struct nvme_controller *ctrlr, struct vfio_ctx *vfio, const char *bdf,
+			  struct hostmem_heap *heap)
+{
+	struct vfio_region_info region = {0};
+	int api_version = 0;
+	int group_id = -1;
+	uint64_t cap;
+	void *bar0;
+	int err;
+
+	memset(ctrlr, 0, sizeof(*ctrlr));
+	nvme_vfio_ctx_init(vfio);
+	ctrlr->heap = heap;
+
+	ctrlr->buf = hostmem_dma_malloc(ctrlr->heap, 4096);
+	if (!ctrlr->buf) {
+		UPCIE_DEBUG("FAILED: hostmem_dma_malloc(buf); errno(%d)", errno);
+		return -errno;
+	}
+	memset(ctrlr->buf, 0, 4096);
+
+	nvme_qid_bitmap_init(ctrlr->qids);
+
+	// Set up VFIO resources
+	err = vfio_device_get_iommu_group_id(bdf, &group_id);
+	if (err) {
+		UPCIE_DEBUG("FAILED: vfio_device_get_iommu_group_id(); err(%d)", err);
+		goto fail;
+	}
+
+	err = vfio_container_open(&vfio->container);
+	if (err) {
+		UPCIE_DEBUG("FAILED: vfio_container_open(); err(%d)", err);
+		goto fail;
+	}
+
+	err = vfio_get_api_version(&vfio->container, &api_version);
+	if (err) {
+		UPCIE_DEBUG("FAILED: vfio_get_api_version(); err(%d)", err);
+		goto fail;
+	}
+	if (api_version != VFIO_API_VERSION) {
+		err = -EINVAL;
+		UPCIE_DEBUG("FAILED: unexpected VFIO_API_VERSION(%d != %d)", api_version,
+			    VFIO_API_VERSION);
+		goto fail;
+	}
+
+	if (!vfio_check_extension(&vfio->container, VFIO_TYPE1_IOMMU)) {
+		err = -ENOTSUP;
+		UPCIE_DEBUG("FAILED: VFIO_TYPE1_IOMMU not supported");
+		goto fail;
+	}
+
+	err = vfio_group_open(group_id, &vfio->group);
+	if (err) {
+		UPCIE_DEBUG("FAILED: vfio_group_open(%d); err(%d)", group_id, err);
+		goto fail;
+	}
+
+	err = vfio_group_get_status(&vfio->group);
+	if (err < 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: vfio_group_get_status(); errno(%d)", errno);
+		goto fail;
+	}
+
+	if (!(vfio->group.status.flags & VFIO_GROUP_FLAGS_VIABLE)) {
+		err = -EBUSY;
+		UPCIE_DEBUG("FAILED: group not viable");
+		goto fail;
+	}
+
+	err = vfio_group_set_container(&vfio->group, &vfio->container);
+	if (err < 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: vfio_group_set_container(); errno(%d)", errno);
+		goto fail;
+	}
+
+	err = vfio_set_iommu(&vfio->container, VFIO_TYPE1_IOMMU);
+	if (err < 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: vfio_set_iommu(); errno(%d)", errno);
+		goto fail;
+	}
+	vfio->iommu_set = 1;
+
+	err = vfio_map_heap(vfio, heap);
+	if (err) {
+		UPCIE_DEBUG("FAILED: vfio_map_heap(); err(%d)", err);
+		goto fail;
+	}
+
+	vfio->device_fd = vfio_group_get_device_fd(&vfio->group, bdf);
+	if (vfio->device_fd < 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: vfio_group_get_device_fd(); errno(%d)", errno);
+		goto fail;
+	}
+
+	region.index = VFIO_PCI_BAR0_REGION_INDEX;
+	err = vfio_device_get_region_info(vfio->device_fd, &region);
+	if (err < 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: vfio_device_get_region_info(); errno(%d)", errno);
+		goto fail;
+	}
+
+	bar0 = vfio_map_region(vfio->device_fd, region.size, region.offset);
+	if (bar0 == MAP_FAILED) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: vfio_map_region(); errno(%d)", errno);
+		goto fail;
+	}
+
+	vfio->bar0 = bar0;
+	vfio->bar0_size = region.size;
+	ctrlr->func.bars[0].region = bar0;
+	ctrlr->func.bars[0].size = region.size;
+	ctrlr->func.bars[0].id = 0;
+	ctrlr->func.bars[0].fd = vfio->device_fd;
+
+	// Continue with the common NVMe controller initialization
+	cap = nvme_mmio_cap_read(bar0);
+	// CAP.TO is encoded in units of 500 ms.
+	ctrlr->timeout_ms = nvme_reg_cap_get_to(cap) * 500;
+
+	nvme_mmio_cc_disable(bar0);
+
+	err = nvme_mmio_csts_wait_until_not_ready(bar0, ctrlr->timeout_ms);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_mmio_csts_wait_until_not_ready(); err(%d)", err);
+		goto fail;
+	}
+
+	err = nvme_qpair_init(&ctrlr->aq, 0, 256, bar0, ctrlr->heap);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_qpair_init(aq); err(%d)", err);
+		goto fail;
+	}
+
+	nvme_mmio_aq_setup(bar0, hostmem_dma_v2p(heap, ctrlr->aq.sq),
+			   hostmem_dma_v2p(heap, ctrlr->aq.cq), ctrlr->aq.depth);
+
+	{
+		uint32_t css = (nvme_reg_cap_get_css(cap) & (1 << 6)) ? 0x6 : 0x0;
+		uint32_t cc = 0;
+
+		cc = nvme_reg_cc_set_css(cc, css);
+		cc = nvme_reg_cc_set_shn(cc, 0x0);
+		cc = nvme_reg_cc_set_mps(cc, 0x0);
+		cc = nvme_reg_cc_set_ams(cc, 0x0);
+		cc = nvme_reg_cc_set_iosqes(cc, 6);
+		cc = nvme_reg_cc_set_iocqes(cc, 4);
+		cc = nvme_reg_cc_set_en(cc, 0x1);
+
+		nvme_mmio_cc_write(bar0, cc);
+	}
+
+	err = nvme_mmio_csts_wait_until_ready(bar0, ctrlr->timeout_ms);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_mmio_csts_wait_until_ready(); err(%d)", err);
+		goto fail;
+	}
+
+	return 0;
+
+fail:
+	nvme_controller_close_vfio(ctrlr, vfio);
+
+	return err;
+}

--- a/toolbox/third-party/linux/upcie/upcie.h
+++ b/toolbox/third-party/linux/upcie/upcie.h
@@ -48,6 +48,7 @@ extern "C" {
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <linux/memfd.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -87,6 +88,7 @@ extern "C" {
 #include <upcie/nvme/nvme_qid.h>
 #include <upcie/nvme/nvme_qpair.h>
 #include <upcie/nvme/nvme_controller.h>
+#include <upcie/nvme/nvme_controller_vfio.h>
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
 ## Summary
 Add VFIO support to the upcie backend

 ## Changes
 - sync the bundled upcie headers to v0.4.2 with VFIO controller support
 - select the VFIO-backed open/close path when the device is bound to vfio-pci
 - reject vfio-pci for upcie-cuda, which still expects the non-VFIO path