### PR TITLE
feat(tools/xnvmeperf): add GPU benchmark subcommands (gpu-run, gpu-verify)

### DIFF
--- a/docs/tools/xnvmeperf/index.rst
+++ b/docs/tools/xnvmeperf/index.rst
@@ -5,8 +5,13 @@ xnvmeperf
 
 **xnvmeperf** is a multi-threaded async I/O benchmark for NVMe devices. It
 runs a time-bounded async I/O loop and reports per-device and aggregate IOPS
-and throughput. A ``verify`` subcommand is also provided to check data integrity
-by writing a known per-LBA pattern and reading it back.
+and throughput. A ``verify`` subcommand checks data integrity by writing a known
+per-LBA pattern and reading it back.
+
+When built with CUDA support (``XNVME_BE_UPCIE_CUDA_ENABLED``), two additional
+subcommands are available: ``cuda-run`` and ``cuda-verify``. These run NVMe I/O
+directly from CUDA kernels via the :ref:`sec-backends-upcie-cuda` backend, bypassing
+the host I/O path entirely.
 
 .. literalinclude:: xnvmeperf_usage.out
    :language: bash
@@ -48,3 +53,51 @@ mismatches and I/O errors per device.
 Example::
 
    xnvmeperf verify --iosize 4096 --count 256 /dev/nvme0n1
+
+``cuda-run`` — GPU benchmark
+============================
+
+.. seealso::
+
+   :ref:`sec-backends-upcie-cuda`
+      Backend setup, system configuration, and memory architecture.
+
+   :ref:`sec-api-c-gpu`
+      The ``libxnvme_cuda`` API used to create queues and dispatch commands
+      from CUDA kernels.
+
+Requires the ``upcie-cuda`` backend. All queues across all devices are driven
+by a single CUDA kernel: each CUDA block owns one NVMe queue and each thread
+within the block owns one queue slot, so ``--qdepth`` threads submit and reap
+commands in lock-step. The grid has ``ndevs × --queues`` blocks in total.
+
+Both ``--qdepth`` and ``--iosize`` must be powers of 2. Supported patterns are
+``read``, ``write``, ``randread``, and ``randwrite``.
+
+.. literalinclude:: xnvmeperf_cuda_run_usage.out
+   :language: bash
+
+Example — sequential read, four queues of depth 32 on two devices::
+
+   xnvmeperf cuda-run --iopattern read --queues 4 --qdepth 32 --iosize 4096 \
+       --runtime 10 --be upcie-cuda 0000:01:00.0 0000:02:00.0
+
+Example — random write, single queue::
+
+   xnvmeperf cuda-run --iopattern randwrite --qdepth 64 --iosize 4096 \
+       --runtime 10 --be upcie-cuda 0000:01:00.0
+
+``cuda-verify`` — GPU data integrity check
+==========================================
+
+Uses the same queue topology as ``cuda-run``. For each queue slot the kernel
+writes a unique LBA-stamped pattern, then reads it back on the host and
+compares against the expected data. This is intended to confirm that
+``cuda-run`` results reflect correct I/O rather than silent data corruption.
+
+.. literalinclude:: xnvmeperf_cuda_verify_usage.out
+   :language: bash
+
+Example::
+
+   xnvmeperf cuda-verify --iosize 4096 --qdepth 32 --be upcie-cuda 0000:01:00.0

--- a/docs/tools/xnvmeperf/xnvmeperf_cuda_run_usage.cmd
+++ b/docs/tools/xnvmeperf/xnvmeperf_cuda_run_usage.cmd
@@ -1,0 +1,1 @@
+xnvmeperf cuda-run --help

--- a/docs/tools/xnvmeperf/xnvmeperf_cuda_run_usage.out
+++ b/docs/tools/xnvmeperf/xnvmeperf_cuda_run_usage.out
@@ -1,0 +1,26 @@
+Usage: xnvmeperf cuda-run [<uri>...] [<args>]
+
+Run a time-bounded GPU NVMe I/O benchmark against one or more devices.
+All devices run in parallel: one CUDA block per queue, all queues launched
+in a single kernel. All devices must use the same LBA size.
+
+Positional arguments:
+
+  [uri ...]                     ; Device URI e.g. '/dev/nvme0n1', '0000:01:00.1', '10.9.8.1.8888', '\\.\PhysicalDrive1'
+
+Where <args> include:
+
+  --iopattern STRING            ; IO pattern (read, write, randread, randwrite)
+  [ --nqueues NUM ]             ; Number of queues per device
+  --qdepth NUM                  ; Use given 'NUM' as queue max capacity
+  --iosize NUM                  ; Use given 'NUM' as bs/iosize
+  --runtime NUM                 ; Run for 'NUM' seconds
+
+With <args> for backend:
+
+  [ --be STRING ]               ; xNVMe backend, e.g. 'linux', 'spdk', 'fbsd', 'macos', 'posix', 'windows'
+  [ --help ]                    ; Show usage / help
+
+See 'xnvmeperf --help' for other commands
+
+xnvmeperf - NVMe async IO benchmark -- ver: {major: 0, minor: 7, patch: 5}

--- a/docs/tools/xnvmeperf/xnvmeperf_cuda_verify_usage.cmd
+++ b/docs/tools/xnvmeperf/xnvmeperf_cuda_verify_usage.cmd
@@ -1,0 +1,1 @@
+xnvmeperf cuda-verify --help

--- a/docs/tools/xnvmeperf/xnvmeperf_cuda_verify_usage.out
+++ b/docs/tools/xnvmeperf/xnvmeperf_cuda_verify_usage.out
@@ -1,0 +1,24 @@
+Usage: xnvmeperf cuda-verify [<uri>...] [<args>]
+
+Write an LBA-stamped pattern to each device through GPU queues and read
+it back, verifying that the data matches. Uses the same queue topology
+as cuda-run so results are directly comparable.
+
+Positional arguments:
+
+  [uri ...]                     ; Device URI e.g. '/dev/nvme0n1', '0000:01:00.1', '10.9.8.1.8888', '\\.\PhysicalDrive1'
+
+Where <args> include:
+
+  --iosize NUM                  ; Use given 'NUM' as bs/iosize
+  [ --nqueues NUM ]             ; Number of queues per device
+  --qdepth NUM                  ; Use given 'NUM' as queue max capacity
+
+With <args> for backend:
+
+  [ --be STRING ]               ; xNVMe backend, e.g. 'linux', 'spdk', 'fbsd', 'macos', 'posix', 'windows'
+  [ --help ]                    ; Show usage / help
+
+See 'xnvmeperf --help' for other commands
+
+xnvmeperf - NVMe async IO benchmark -- ver: {major: 0, minor: 7, patch: 5}

--- a/include/libxnvme_cli.h
+++ b/include/libxnvme_cli.h
@@ -170,6 +170,7 @@ struct xnvme_cli_args {
 	uint32_t runtime;
 	const char *iopattern;
 	const char *cpumask;
+	uint32_t nqueues;
 
 	const char **posn; //< Remaining positional args (points into argv)
 	int posn_count;    ///< Number of remaining positional args
@@ -345,8 +346,9 @@ enum xnvme_cli_opt {
 	XNVME_CLI_OPT_RUNTIME   = 125, ///< XNVME_CLI_OPT_RUNTIME
 	XNVME_CLI_OPT_IOPATTERN = 126, ///< XNVME_CLI_OPT_IOPATTERN
 	XNVME_CLI_OPT_CPUMASK   = 127, ///< XNVME_CLI_OPT_CPUMASK
+	XNVME_CLI_OPT_NQUEUES   = 128, ///< XNVME_CLI_OPT_NQUEUES
 
-	XNVME_CLI_OPT_END = 128, ///< XNVME_CLI_OPT_END
+	XNVME_CLI_OPT_END = 129, ///< XNVME_CLI_OPT_END
 };
 
 /**

--- a/lib/xnvme_cli.c
+++ b/lib/xnvme_cli.c
@@ -883,6 +883,12 @@ static struct xnvme_cli_opt_attr xnvme_cli_opts[] = {
 		.descr = "Hex CPU bitmask for thread pinning (e.g. 0x3)",
 	},
 	{
+		.opt = XNVME_CLI_OPT_NQUEUES,
+		.vtype = XNVME_CLI_OPT_VTYPE_NUM,
+		.name = "nqueues",
+		.descr = "Number of queues per device",
+	},
+	{
 		.opt = XNVME_CLI_OPT_END,
 		.vtype = XNVME_CLI_OPT_VTYPE_NUM,
 		.name = "",
@@ -1563,6 +1569,9 @@ xnvme_cli_assign_arg(struct xnvme_cli *cli, struct xnvme_cli_opt_attr *opt_attr,
 		break;
 	case XNVME_CLI_OPT_CPUMASK:
 		args->cpumask = arg ? arg : "INVALID_INPUT";
+		break;
+	case XNVME_CLI_OPT_NQUEUES:
+		args->nqueues = num;
 		break;
 	case XNVME_CLI_OPT_POSA_TITLE:
 	case XNVME_CLI_OPT_NON_POSA_TITLE:

--- a/meson.build
+++ b/meson.build
@@ -215,6 +215,9 @@ configure_file(
 
 # Provide configuration via header-file 'xnvme_config.h'
 add_project_arguments(['-include', 'xnvme_config.h'], language: 'c')
+if cuda_dep.found()
+  add_project_arguments(['-include', 'xnvme_config.h'], language: 'cuda')
+endif
 
 # bash-completions: run the Makefile target 'make gen-bash-completions' to update the completions
 bash_completion_dep = dependency(

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -59,17 +59,4 @@ foreach source, tests : tools
   endforeach
 endforeach
 
-if thread_dep.found()
-  executable(
-    'xnvmeperf',
-    'xnvmeperf.c',
-    include_directories: [conf_inc, xnvme_inc],
-    link_args: link_args_hardening,
-    link_with: xnvmelib,
-    install_rpath: xnvmelib_rpath,
-    dependencies: [thread_dep],
-    install: true,
-  )
-else
-  warning('No support for threads, skipping xnvmeperf')
-endif
+subdir('xnvmeperf')

--- a/tools/xnvmeperf.c
+++ b/tools/xnvmeperf.c
@@ -473,10 +473,98 @@ dev_close_fn(void *arg)
 }
 
 static void
+print_run_args(struct xnvmeperf_args *args, const char *pattern)
+{
+	printf("Running xnvmeperf with arguments:\n");
+	printf("- Devices: [");
+	for (int i = 0; i < args->ndevs; i++) {
+		if (i) {
+			printf(", ");
+		}
+		printf("%s", args->dev_uris[i]);
+	}
+	printf("] (total: %d)\n", args->ndevs);
+	printf("- io pattern: %s\n", pattern);
+	printf("- queues per device: %u\n", args->nqueues);
+	printf("- queue depth: %u\n", args->qdepth);
+	printf("- io size: %u\n", args->iosize);
+	printf("- runtime: %u\n", args->time);
+
+	if (args->ncpus) {
+		printf("- CPUs: [");
+		for (int i = 0; i < args->ncpus; i++) {
+			if (i) {
+				printf(", ");
+			}
+			printf("%d", args->cpus[i]);
+		}
+		printf("] (total: %d)\n", args->ncpus);
+	}
+}
+
+/**
+ * Print a performance results table.
+ *
+ * @param title    Header string (e.g. "xnvmeperf" or "xnvmeperf gpu-run")
+ * @param elapsed  Elapsed time in seconds
+ * @param uris     Device URI strings
+ * @param ndevs    Number of devices
+ * @param iops     Per-device IOPS
+ * @param mibps    Per-device throughput in MiB/s
+ * @param failed   Per-device failed I/O count
+ * @param cpus     Per-device CPU strings, or NULL to omit the CPUs column
+ */
+static void
+print_perf_results(const char *title, double elapsed, const char **uris, int ndevs,
+		   const double *iops, const double *mibps, const uint64_t *failed,
+		   const char **cpus)
+{
+	double total_iops = 0, total_mibps = 0;
+	uint64_t total_failed = 0;
+
+	printf("\n");
+	printf("====================================================================\n");
+	printf(" %s (elapsed: %.2fs)\n", title, elapsed);
+	printf("====================================================================\n");
+	if (cpus) {
+		printf(" %-20s  %6s  %12s %10s %8s\n", "Device", "CPUs", "IOPS", "MiB/s",
+		       "Failed");
+	} else {
+		printf(" %-20s  %12s %10s %8s\n", "Device", "IOPS", "MiB/s", "Failed");
+	}
+
+	for (int d = 0; d < ndevs; d++) {
+		if (cpus) {
+			printf(" %-20s  %6s  %12.2f %10.2f %8lu\n", uris[d], cpus[d], iops[d],
+			       mibps[d], (unsigned long)failed[d]);
+		} else {
+			printf(" %-20s  %12.2f %10.2f %8lu\n", uris[d], iops[d], mibps[d],
+			       (unsigned long)failed[d]);
+		}
+
+		total_iops += iops[d];
+		total_mibps += mibps[d];
+		total_failed += failed[d];
+	}
+
+	printf("--------------------------------------------------------------------\n");
+	if (cpus) {
+		printf(" %-29s %12.2f %10.2f %8lu\n", "Total:", total_iops, total_mibps,
+		       (unsigned long)total_failed);
+	} else {
+		printf(" %-21s %12.2f %10.2f %8lu\n", "Total:", total_iops, total_mibps,
+		       (unsigned long)total_failed);
+	}
+	printf("====================================================================\n");
+}
+
+static void
 print_results(struct xnvmeperf_thread *threads, struct xnvmeperf_args *args)
 {
-	uint64_t total_completed = 0, total_failed = 0;
-	double elapsed = 0;
+	double *iops, *mibps, elapsed = 0;
+	uint64_t *failed;
+	char **cpus_bufs;
+	const char **cpus;
 
 	for (int t = 0; t < args->ncpus; t++) {
 		if (threads[t].elapsed > elapsed) {
@@ -484,16 +572,23 @@ print_results(struct xnvmeperf_thread *threads, struct xnvmeperf_args *args)
 		}
 	}
 
-	printf("\n");
-	printf("====================================================================\n");
-	printf(" xnvmeperf (elapsed: %.2fs)\n", elapsed);
-	printf("====================================================================\n");
-	printf(" %-20s  %6s  %12s %10s %8s\n", "Device", "CPUs", "IOPS", "MiB/s", "Failed");
+	iops = calloc(args->ndevs, sizeof(*iops));
+	mibps = calloc(args->ndevs, sizeof(*mibps));
+	failed = calloc(args->ndevs, sizeof(*failed));
+	cpus_bufs = calloc(args->ndevs, sizeof(*cpus_bufs));
+	cpus = calloc(args->ndevs, sizeof(*cpus));
+	if (!iops || !mibps || !failed || !cpus_bufs || !cpus) {
+		goto done;
+	}
 
 	for (int d = 0; d < args->ndevs; d++) {
-		uint64_t completed = 0, failed = 0;
-		char cpus[256] = {0};
+		uint64_t completed = 0;
 		int cpus_len = 0;
+
+		cpus_bufs[d] = calloc(256, 1);
+		if (!cpus_bufs[d]) {
+			goto done;
+		}
 
 		for (int t = 0; t < args->ncpus; t++) {
 			struct xnvmeperf_thread *thread = &threads[t];
@@ -506,33 +601,37 @@ print_results(struct xnvmeperf_thread *threads, struct xnvmeperf_args *args)
 				}
 
 				completed += thread->jobs[j].io_completed;
-				failed += thread->jobs[j].io_failed;
+				failed[d] += thread->jobs[j].io_failed;
 
 				if (cpus_len > 0) {
-					cpus_len += snprintf(cpus + cpus_len,
-							     sizeof(cpus) - cpus_len, ",");
+					cpus_len += snprintf(cpus_bufs[d] + cpus_len,
+							     256 - cpus_len, ",");
 				}
-				cpus_len += snprintf(cpus + cpus_len, sizeof(cpus) - cpus_len,
-						     "%d", thread->cpu);
+				cpus_len += snprintf(cpus_bufs[d] + cpus_len, 256 - cpus_len, "%d",
+						     thread->cpu);
 			}
 		}
 
-		double iops = (double)completed / elapsed;
-		double mibps =
+		iops[d] = (double)completed / elapsed;
+		mibps[d] =
 			((double)completed * (double)args->iosize) / (elapsed * 1024.0 * 1024.0);
-
-		printf(" %-20s  %6s  %12.2f %10.2f %8lu\n", args->dev_uris[d], cpus, iops, mibps,
-		       (unsigned long)failed);
-
-		total_completed += completed;
-		total_failed += failed;
+		cpus[d] = cpus_bufs[d];
 	}
 
-	printf("--------------------------------------------------------------------\n");
-	printf(" %-29s %12.2f %10.2f %8lu\n", "Total:", (double)total_completed / elapsed,
-	       ((double)total_completed * (double)args->iosize) / (elapsed * 1024.0 * 1024.0),
-	       (unsigned long)total_failed);
-	printf("====================================================================\n");
+	print_perf_results("xnvmeperf", elapsed, args->dev_uris, args->ndevs, iops, mibps, failed,
+			   cpus);
+
+done:
+	if (cpus_bufs) {
+		for (int i = 0; i < args->ndevs; i++) {
+			free(cpus_bufs[i]);
+		}
+	}
+	free(cpus_bufs);
+	free(cpus);
+	free(failed);
+	free(mibps);
+	free(iops);
 }
 
 /**
@@ -1045,31 +1144,7 @@ sub_run(struct xnvme_cli *cli)
 		return err;
 	}
 
-	printf("Running xnvmeperf with arguments:\n");
-
-	printf("- Devices: [");
-	for (int i = 0; i < args.ndevs; i++) {
-		if (i) {
-			printf(", ");
-		}
-		printf("%s", args.dev_uris[i]);
-	}
-	printf("] (total: %d)\n", args.ndevs);
-
-	printf("- CPUs: [");
-	for (int i = 0; i < args.ncpus; i++) {
-		if (i) {
-			printf(", ");
-		}
-		printf("%d", args.cpus[i]);
-	}
-	printf("] (total: %d)\n", args.ncpus);
-
-	printf("- io pattern: %d (%s)\n", args.pattern, cli->args.iopattern);
-	printf("- queues per device: %u\n", args.nqueues);
-	printf("- queue depth: %d\n", args.qdepth);
-	printf("- io size: %d\n", args.iosize);
-	printf("- runtime: %d\n", args.time);
+	print_run_args(&args, cli->args.iopattern);
 
 	err = xnvmeperf_run(&args);
 	free(args.cpus);

--- a/tools/xnvmeperf.c
+++ b/tools/xnvmeperf.c
@@ -25,6 +25,7 @@ struct xnvmeperf_args {
 	uint32_t iosize;
 	uint32_t time;
 	uint32_t count;
+	uint32_t nqueues;
 	enum iopattern pattern;
 	struct xnvme_opts opts;
 };
@@ -49,11 +50,11 @@ struct xnvmeperf_job {
 struct xnvmeperf_thread {
 	int cpu;
 	int njobs;
+	int job_start;
 	struct xnvmeperf_job *jobs;
 	struct xnvmeperf_args *args;
 	double elapsed;
 	struct xnvme_dev **devs;
-	const char **dev_uris;
 	int ndevs;
 };
 
@@ -355,8 +356,8 @@ thread_init(struct xnvmeperf_thread *thread, struct xnvmeperf_args *args)
 	for (int i = 0; i < thread->ndevs; i++) {
 		struct xnvmeperf_job *job = &thread->jobs[i];
 
-		err = setup_job(job, thread->devs[i], args,
-				(unsigned int)(thread->cpu * 1000 + i));
+		err = setup_job(job, thread->devs[(thread->job_start + i) / (int)args->nqueues],
+				args, (unsigned int)(thread->cpu * 1000 + i));
 		if (err) {
 			xnvme_cli_perr("Failed: setup_job()", err);
 			return err;
@@ -498,7 +499,9 @@ print_results(struct xnvmeperf_thread *threads, struct xnvmeperf_args *args)
 			struct xnvmeperf_thread *thread = &threads[t];
 
 			for (int j = 0; j < thread->njobs; j++) {
-				if (strcmp(thread->dev_uris[j], args->dev_uris[d]) != 0) {
+				if (strcmp(args->dev_uris[(thread->job_start + j) /
+							  (int)args->nqueues],
+					   args->dev_uris[d]) != 0) {
 					continue;
 				}
 
@@ -589,9 +592,8 @@ xnvmeperf_run(struct xnvmeperf_args *args)
 {
 	struct xnvmeperf_thread *threads;
 	struct xnvme_dev **devs;
-	pthread_t *tids;
-	pthread_t *close_tids;
-	int err = 0;
+	pthread_t *tids, *close_tids;
+	int total_jobs, err;
 
 	// Pre-open all devices, as they can only be opened once.
 	devs = calloc(args->ndevs, sizeof(*devs));
@@ -607,6 +609,20 @@ xnvmeperf_run(struct xnvmeperf_args *args)
 		return err;
 	}
 
+	total_jobs = args->ndevs * (int)args->nqueues;
+
+	// Underprovisioning: more threads than queues means threads would share a
+	// queue, which is not safe. Require at least one queue per thread.
+	if (args->ncpus > total_jobs) {
+		fprintf(stderr,
+			"Error: --cpumask specifies %d threads but only %d queue(s) "
+			"(%d device(s) x %d queue(s) each); "
+			"increase --nqueues so every thread has its own queue\n",
+			args->ncpus, total_jobs, args->ndevs, args->nqueues);
+		err = -EINVAL;
+		goto close_devs;
+	}
+
 	threads = calloc(args->ncpus, sizeof(*threads));
 	tids = calloc(args->ncpus, sizeof(*tids));
 	if (!threads || !tids) {
@@ -615,25 +631,19 @@ xnvmeperf_run(struct xnvmeperf_args *args)
 		goto close_devs;
 	}
 
+	// Distribute job slots evenly across threads; overflow goes to the first
+	// few threads one slot at a time.
 	for (int i = 0; i < args->ncpus; i++) {
-		int start, count;
-
-		if (args->ndevs >= args->ncpus) {
-			int base = args->ndevs / args->ncpus;
-			int extra = args->ndevs % args->ncpus;
-
-			start = i * base + (i < extra ? i : extra);
-			count = base + (i < extra ? 1 : 0);
-		} else {
-			start = i % args->ndevs;
-			count = 1;
-		}
+		int base = total_jobs / args->ncpus;
+		int extra = total_jobs % args->ncpus;
+		int start = i * base + (i < extra ? i : extra);
+		int count = base + (i < extra ? 1 : 0);
 
 		threads[i].cpu = args->cpus[i];
 		threads[i].args = args;
 		threads[i].ndevs = count;
-		threads[i].devs = &devs[start];
-		threads[i].dev_uris = &args->dev_uris[start];
+		threads[i].job_start = start;
+		threads[i].devs = devs;
 
 		err = thread_init(&threads[i], args);
 		if (err) {
@@ -1013,6 +1023,8 @@ parse_run_args(struct xnvme_cli *cli, struct xnvmeperf_args *args)
 		return err;
 	}
 
+	args->nqueues = cli->args.nqueues ? cli->args.nqueues : 1;
+
 	return err;
 }
 
@@ -1054,6 +1066,7 @@ sub_run(struct xnvme_cli *cli)
 	printf("] (total: %d)\n", args.ncpus);
 
 	printf("- io pattern: %d (%s)\n", args.pattern, cli->args.iopattern);
+	printf("- queues per device: %u\n", args.nqueues);
 	printf("- queue depth: %d\n", args.qdepth);
 	printf("- io size: %d\n", args.iosize);
 	printf("- runtime: %d\n", args.time);
@@ -1099,6 +1112,7 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_URI, XNVME_CLI_POSN},
 			{XNVME_CLI_OPT_NON_POSA_TITLE, XNVME_CLI_SKIP},
 			{XNVME_CLI_OPT_IOPATTERN, XNVME_CLI_LREQ},
+			{XNVME_CLI_OPT_NQUEUES, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_QDEPTH, XNVME_CLI_LREQ},
 			{XNVME_CLI_OPT_IOSIZE, XNVME_CLI_LREQ},
 			{XNVME_CLI_OPT_RUNTIME, XNVME_CLI_LREQ},

--- a/tools/xnvmeperf.c
+++ b/tools/xnvmeperf.c
@@ -533,6 +533,48 @@ print_results(struct xnvmeperf_thread *threads, struct xnvmeperf_args *args)
 }
 
 /**
+ * Open all devices in args and derive their geometry.
+ *
+ * devs must be a calloc'd array of args->ndevs null-initialised pointers.
+ * On failure all successfully opened devices are closed and their entries
+ * are set to NULL.
+ *
+ * @param args  Benchmark arguments with dev_uris, ndevs, and opts
+ * @param devs  Caller-allocated array of ndevs device pointers (zero-initialised)
+ * @return 0 on success, negative errno on error
+ */
+static int
+xnvmeperf_open_devs(struct xnvmeperf_args *args, struct xnvme_dev **devs)
+{
+	int err;
+
+	for (int i = 0; i < args->ndevs; i++) {
+		devs[i] = xnvme_dev_open(args->dev_uris[i], &args->opts);
+		if (!devs[i]) {
+			err = -errno;
+			fprintf(stderr, "Failed: xnvme_dev_open(%s): err(%d)\n", args->dev_uris[i],
+				err);
+			goto close;
+		}
+		err = xnvme_dev_derive_geo(devs[i]);
+		if (err) {
+			xnvme_cli_perr("Failed: xnvme_dev_derive_geo()", err);
+			goto close;
+		}
+	}
+	return 0;
+
+close:
+	for (int i = 0; i < args->ndevs; i++) {
+		if (devs[i]) {
+			xnvme_dev_close(devs[i]);
+			devs[i] = NULL;
+		}
+	}
+	return err;
+}
+
+/**
  * Runs a multi-threaded benchmark against all configured devices.
  *
  * Opens all devices, distributes them across CPU threads, and runs a
@@ -559,27 +601,10 @@ xnvmeperf_run(struct xnvmeperf_args *args)
 		return err;
 	}
 
-	for (int i = 0; i < args->ndevs; i++) {
-		devs[i] = xnvme_dev_open(args->dev_uris[i], &args->opts);
-		if (!devs[i]) {
-			err = -errno;
-			fprintf(stderr, "Failed: xnvme_dev_open(%s): err(%d)\n", args->dev_uris[i],
-				err);
-			for (int j = 0; j < i; j++) {
-				xnvme_dev_close(devs[j]);
-			}
-			free(devs);
-			return err;
-		}
-		err = xnvme_dev_derive_geo(devs[i]);
-		if (err) {
-			xnvme_cli_perr("Failed: xnvme_dev_derive_geo()", err);
-			for (int j = 0; j <= i; j++) {
-				xnvme_dev_close(devs[j]);
-			}
-			free(devs);
-			return err;
-		}
+	err = xnvmeperf_open_devs(args, devs);
+	if (err) {
+		free(devs);
+		return err;
 	}
 
 	threads = calloc(args->ncpus, sizeof(*threads));
@@ -722,31 +747,30 @@ fill_pattern(void *buf, size_t nbytes, uint64_t slba, uint16_t nlb)
 static int
 xnvmeperf_verify(struct xnvmeperf_args *args)
 {
+	struct xnvme_dev **devs;
 	int nios = (int)args->count;
-	int err = 0;
+	int err;
 
 	printf("\nxnvmeperf verify: iosize=%u, nios=%d\n", args->iosize, nios);
 	printf("====================================================================\n");
 
+	devs = calloc(args->ndevs, sizeof(*devs));
+	if (!devs) {
+		return -ENOMEM;
+	}
+
+	err = xnvmeperf_open_devs(args, devs);
+	if (err) {
+		free(devs);
+		return err;
+	}
+
+	err = 0;
 	for (int d = 0; d < args->ndevs; d++) {
-		struct xnvme_dev *dev;
+		struct xnvme_dev *dev = devs[d];
 		struct xnvmeperf_job job = {0};
 		void *write_buf = NULL, *read_buf = NULL, *expect_buf = NULL;
 		uint64_t mismatches = 0;
-
-		dev = xnvme_dev_open(args->dev_uris[d], &args->opts);
-		if (!dev) {
-			err = -errno;
-			fprintf(stderr, "Failed: xnvme_dev_open(%s): err(%d)\n", args->dev_uris[d],
-				err);
-			continue;
-		}
-
-		err = xnvme_dev_derive_geo(dev);
-		if (err) {
-			xnvme_cli_perr("Failed: xnvme_dev_derive_geo()", err);
-			goto next_dev;
-		}
 
 		err = setup_job(&job, dev, args, 1);
 		if (err) {
@@ -883,10 +907,14 @@ next_dev:
 		if (job.queue) {
 			xnvme_queue_term(job.queue);
 		}
-		xnvme_dev_close(dev);
 	}
 
 	printf("====================================================================\n");
+
+	for (int i = 0; i < args->ndevs; i++) {
+		xnvme_dev_close(devs[i]);
+	}
+	free(devs);
 	return err;
 }
 

--- a/tools/xnvmeperf.c
+++ b/tools/xnvmeperf.c
@@ -939,55 +939,99 @@ str_to_iopattern(const char *name)
 	return 0;
 }
 
+/**
+ * Parse the subset of CLI arguments common to all sub-commands: devices, iosize, and opts.
+ *
+ * @return 0 on success, negative errno on validation failure
+ */
+static int
+parse_common_args(struct xnvme_cli *cli, struct xnvmeperf_args *args)
+{
+	int err = 0;
+
+	args->ndevs = cli->args.posn_count;
+	if (args->ndevs <= 0) {
+		err = -EINVAL;
+		xnvme_cli_perr("Error: at least one device URI is required", err);
+		return err;
+	}
+	args->dev_uris = cli->args.posn;
+
+	args->iosize = cli->args.iosize;
+	if (!args->iosize || !xnvme_is_pow2(args->iosize)) {
+		err = -EINVAL;
+		xnvme_cli_perr("Error: --iosize must be a power of 2", err);
+		return err;
+	}
+
+	args->opts = xnvme_opts_default();
+	xnvme_cli_to_opts(cli, &args->opts);
+	return err;
+}
+
+/**
+ * Parse the full set of run sub-command arguments into @p args.
+ * Calls parse_common_args() then adds iopattern, qdepth, and runtime.
+ * Does not parse cpumask or nqueues; those are the caller's responsibility.
+ *
+ * @return 0 on success, negative errno on validation failure
+ */
+static int
+parse_run_args(struct xnvme_cli *cli, struct xnvmeperf_args *args)
+{
+	int err = 0;
+
+	err = parse_common_args(cli, args);
+	if (err) {
+		return err;
+	}
+
+	if (!cli->args.iopattern) {
+		err = -EINVAL;
+		xnvme_cli_perr("Error: --iopattern is required", err);
+		return err;
+	}
+	args->pattern = str_to_iopattern(cli->args.iopattern);
+	if (!args->pattern) {
+		err = -EINVAL;
+		fprintf(stderr, "Error: unknown iopattern '%s': err(%d)\n", cli->args.iopattern,
+			err);
+		return err;
+	}
+
+	args->qdepth = cli->args.qdepth;
+	if (!args->qdepth || !xnvme_is_pow2(args->qdepth)) {
+		err = -EINVAL;
+		xnvme_cli_perr("Error: --qdepth must be a power of 2", err);
+		return err;
+	}
+
+	args->time = cli->args.runtime;
+	if (!args->time) {
+		err = -EINVAL;
+		xnvme_cli_perr("Error: --time must be a positive integer", err);
+		return err;
+	}
+
+	return err;
+}
+
 static int
 sub_run(struct xnvme_cli *cli)
 {
 	struct xnvmeperf_args args = {0};
-	int err = 0;
+	int err;
 
-	args.ndevs = cli->args.posn_count;
-	if (args.ndevs <= 0) {
-		fprintf(stderr, "Error: at least one device URI is required\n");
-		return -EINVAL;
+	err = parse_run_args(cli, &args);
+	if (err) {
+		return err;
 	}
-	args.dev_uris = cli->args.posn;
 
 	err = parse_cpumask(cli->args.cpumask, &args.cpus, &args.ncpus);
 	if (err) {
 		xnvme_cli_perr("Failed: parse_cpumask()", err);
 		return err;
 	}
-
-	args.pattern = str_to_iopattern(cli->args.iopattern);
-	if (!args.pattern) {
-		fprintf(stderr, "Error: unknown iopattern '%s'\n", cli->args.iopattern);
-		err = -EINVAL;
-		goto free_cpus;
-	}
-
-	args.qdepth = cli->args.qdepth;
-	if (!args.qdepth || !xnvme_is_pow2(args.qdepth)) {
-		fprintf(stderr, "Error: --qdepth must be a power of 2\n");
-		err = -EINVAL;
-		goto free_cpus;
-	}
-
-	args.iosize = cli->args.iosize;
-	if (!args.iosize || !xnvme_is_pow2(args.iosize)) {
-		fprintf(stderr, "Error: --iosize must be a power of 2\n");
-		err = -EINVAL;
-		goto free_cpus;
-	}
-
-	args.time = cli->args.runtime;
-	if (!args.time) {
-		fprintf(stderr, "Error: --time must be a positive integer\n");
-		err = -EINVAL;
-		goto free_cpus;
-	}
-
-	args.opts = xnvme_opts_default();
-	xnvme_cli_to_opts(cli, &args.opts);
 
 	printf("Running xnvmeperf with arguments:\n");
 
@@ -1015,8 +1059,6 @@ sub_run(struct xnvme_cli *cli)
 	printf("- runtime: %d\n", args.time);
 
 	err = xnvmeperf_run(&args);
-
-free_cpus:
 	free(args.cpus);
 	return err;
 }
@@ -1027,18 +1069,8 @@ sub_verify(struct xnvme_cli *cli)
 	struct xnvmeperf_args args = {0};
 	int err;
 
-	args.ndevs = cli->args.posn_count;
-	if (args.ndevs <= 0) {
-		err = -EINVAL;
-		xnvme_cli_perr("Error: at least one device URI is required", err);
-		return err;
-	}
-	args.dev_uris = cli->args.posn;
-
-	args.iosize = cli->args.iosize;
-	if (!args.iosize || !xnvme_is_pow2(args.iosize)) {
-		err = -EINVAL;
-		xnvme_cli_perr("Error: --iosize must be a power of 2", err);
+	err = parse_common_args(cli, &args);
+	if (err) {
 		return err;
 	}
 
@@ -1051,8 +1083,6 @@ sub_verify(struct xnvme_cli *cli)
 
 	args.qdepth = 1;
 	args.pattern = IOPATTERN_VERIFY;
-	args.opts = xnvme_opts_default();
-	xnvme_cli_to_opts(cli, &args.opts);
 
 	return xnvmeperf_verify(&args);
 }

--- a/tools/xnvmeperf/meson.build
+++ b/tools/xnvmeperf/meson.build
@@ -3,14 +3,25 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 if thread_dep.found()
+  xnvmeperf_sources = files('xnvmeperf.c')
+  xnvmeperf_deps = [thread_dep]
+
+  xnvmeperf_cuda_args = []
+  if conf_data.get('XNVME_BE_UPCIE_CUDA_ENABLED')
+    xnvmeperf_sources += files('xnvmeperf_cuda.cu')
+    xnvmeperf_deps += [cuda_dep]
+    xnvmeperf_cuda_args = ['-arch=native']
+  endif
+
   executable(
     'xnvmeperf',
-    files('xnvmeperf.c'),
+    xnvmeperf_sources,
     include_directories: [conf_inc, xnvme_inc],
     link_args: link_args_hardening,
     link_with: xnvmelib,
     install_rpath: xnvmelib_rpath,
-    dependencies: [thread_dep],
+    dependencies: xnvmeperf_deps,
+    cuda_args: xnvmeperf_cuda_args,
     install: true,
   )
 else

--- a/tools/xnvmeperf/meson.build
+++ b/tools/xnvmeperf/meson.build
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+if thread_dep.found()
+  executable(
+    'xnvmeperf',
+    files('xnvmeperf.c'),
+    include_directories: [conf_inc, xnvme_inc],
+    link_args: link_args_hardening,
+    link_with: xnvmelib,
+    install_rpath: xnvmelib_rpath,
+    dependencies: [thread_dep],
+    install: true,
+  )
+else
+  warning('No support for threads, skipping xnvmeperf')
+endif

--- a/tools/xnvmeperf/xnvmeperf.c
+++ b/tools/xnvmeperf/xnvmeperf.c
@@ -8,27 +8,7 @@
 
 #include <libxnvme.h>
 
-enum iopattern {
-	IOPATTERN_READ = 1,
-	IOPATTERN_WRITE = 2,
-	IOPATTERN_RANDREAD = 3,
-	IOPATTERN_RANDWRITE = 4,
-	IOPATTERN_VERIFY = 5, ///< Used for verify subcommand
-};
-
-struct xnvmeperf_args {
-	int ndevs;
-	const char **dev_uris;
-	int ncpus;
-	int *cpus;
-	uint32_t qdepth;
-	uint32_t iosize;
-	uint32_t time;
-	uint32_t count;
-	uint32_t nqueues;
-	enum iopattern pattern;
-	struct xnvme_opts opts;
-};
+#include "xnvmeperf.h"
 
 struct xnvmeperf_job {
 	struct xnvme_dev *dev;
@@ -818,7 +798,7 @@ failed_pthread_close:
  * @param slba    Starting LBA of the first sector in the buffer
  * @param nlb     Number of logical blocks in the buffer
  */
-static int
+int
 fill_pattern(void *buf, size_t nbytes, uint64_t slba, uint16_t nlb)
 {
 	size_t lba_size = nbytes / nlb;

--- a/tools/xnvmeperf/xnvmeperf.c
+++ b/tools/xnvmeperf/xnvmeperf.c
@@ -485,7 +485,7 @@ print_run_args(struct xnvmeperf_args *args, const char *pattern)
 /**
  * Print a performance results table.
  *
- * @param title    Header string (e.g. "xnvmeperf" or "xnvmeperf gpu-run")
+ * @param title    Header string (e.g. "xnvmeperf" or "xnvmeperf cuda-run")
  * @param elapsed  Elapsed time in seconds
  * @param uris     Device URI strings
  * @param ndevs    Number of devices
@@ -1007,6 +1007,71 @@ next_dev:
 	return err;
 }
 
+static int
+xnvmeperf_cuda_run(struct xnvmeperf_args *args)
+{
+	struct xnvme_dev **devs;
+	uint64_t *rounds_per_dev, *failed_per_dev;
+	double elapsed_s;
+	float elapsed_ms = 0;
+	int err;
+
+	devs = calloc(args->ndevs, sizeof(*devs));
+	if (!devs) {
+		err = -errno;
+		xnvme_cli_perr("Failed: calloc() for devs", err);
+		return err;
+	}
+
+	err = xnvmeperf_open_devs(args, devs);
+	if (err) {
+		free(devs);
+		return err;
+	}
+
+	rounds_per_dev = calloc(args->ndevs, sizeof(*rounds_per_dev));
+	failed_per_dev = calloc(args->ndevs, sizeof(*failed_per_dev));
+
+	if (!rounds_per_dev || !failed_per_dev) {
+		err = -ENOMEM;
+		xnvme_cli_perr("Failed: calloc()", err);
+		free(rounds_per_dev);
+		free(failed_per_dev);
+		goto close_devs;
+	}
+
+	err = xnvmeperf_cuda_run_io(devs, args, rounds_per_dev, failed_per_dev, &elapsed_ms);
+	if (err) {
+		xnvme_cli_perr("Failed: xnvmeperf_cuda_run_io()", err);
+		free(rounds_per_dev);
+		free(failed_per_dev);
+		goto close_devs;
+	}
+
+	elapsed_s = elapsed_ms / 1000.0;
+	{
+		double iops[args->ndevs], mibps[args->ndevs];
+
+		for (int i = 0; i < args->ndevs; i++) {
+			double total_ios = (double)rounds_per_dev[i] * args->qdepth;
+			iops[i] = total_ios / elapsed_s;
+			mibps[i] = (total_ios * args->iosize) / (elapsed_s * 1024.0 * 1024.0);
+		}
+		print_perf_results("xnvmeperf cuda-run", elapsed_s, args->dev_uris, args->ndevs,
+				   iops, mibps, failed_per_dev, NULL);
+	}
+
+	free(rounds_per_dev);
+	free(failed_per_dev);
+
+close_devs:
+	for (int i = 0; i < args->ndevs; i++) {
+		xnvme_dev_close(devs[i]);
+	}
+	free(devs);
+	return err;
+}
+
 static enum iopattern
 str_to_iopattern(const char *name)
 {
@@ -1155,6 +1220,31 @@ sub_verify(struct xnvme_cli *cli)
 	return xnvmeperf_verify(&args);
 }
 
+static int
+sub_cuda_run(struct xnvme_cli *cli)
+{
+	struct xnvmeperf_args args = {0};
+	int err;
+
+	err = parse_run_args(cli, &args);
+	if (err) {
+		return err;
+	}
+
+	if (!args.opts.be) {
+		args.opts.be = "upcie-cuda";
+	} else if (strcmp(args.opts.be, "upcie-cuda") != 0) {
+		err = -EINVAL;
+		fprintf(stderr, "Error: cuda-run requires --be upcie-cuda, got '%s': err(%d)\n",
+			args.opts.be, err);
+		return err;
+	}
+
+	print_run_args(&args, cli->args.iopattern);
+
+	return xnvmeperf_cuda_run(&args);
+}
+
 static struct xnvme_cli_sub g_subs[] = {
 	{
 		"run",
@@ -1196,6 +1286,26 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_DIRECT, XNVME_CLI_LFLG},
 			{XNVME_CLI_OPT_POLL_IO, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_POLL_SQ, XNVME_CLI_LOPT},
+		},
+	},
+	{
+		"cuda-run",
+		"Run a GPU benchmark against the given devices (requires upcie-cuda backend)",
+		"Run a time-bounded GPU NVMe I/O benchmark against one or more devices.\n"
+		"All devices run in parallel: one CUDA block per queue, all queues launched\n"
+		"in a single kernel. All devices must use the same LBA size.",
+		sub_cuda_run,
+		{
+			{XNVME_CLI_OPT_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_URI, XNVME_CLI_POSN},
+			{XNVME_CLI_OPT_NON_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_IOPATTERN, XNVME_CLI_LREQ},
+			{XNVME_CLI_OPT_NQUEUES, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_QDEPTH, XNVME_CLI_LREQ},
+			{XNVME_CLI_OPT_IOSIZE, XNVME_CLI_LREQ},
+			{XNVME_CLI_OPT_RUNTIME, XNVME_CLI_LREQ},
+			{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_BE, XNVME_CLI_LOPT},
 		},
 	},
 };

--- a/tools/xnvmeperf/xnvmeperf.c
+++ b/tools/xnvmeperf/xnvmeperf.c
@@ -1072,6 +1072,43 @@ close_devs:
 	return err;
 }
 
+static int
+xnvmeperf_cuda_verify(struct xnvmeperf_args *args)
+{
+	struct xnvme_dev **devs;
+	int err;
+
+	devs = calloc(args->ndevs, sizeof(*devs));
+	if (!devs) {
+		err = -errno;
+		xnvme_cli_perr("Failed: calloc() for devs", err);
+		return err;
+	}
+
+	err = xnvmeperf_open_devs(args, devs);
+	if (err) {
+		free(devs);
+		return err;
+	}
+
+	printf("\nxnvmeperf cuda-verify: iosize: %u, qdepth: %u, nqueues: %u\n", args->iosize,
+	       args->qdepth, args->nqueues);
+	printf("====================================================================\n");
+
+	err = xnvmeperf_cuda_verify_io(devs, args);
+	if (err) {
+		xnvme_cli_perr("Failed: xnvmeperf_cuda_verify_io()", err);
+	}
+
+	printf("====================================================================\n");
+
+	for (int i = 0; i < args->ndevs; i++) {
+		xnvme_dev_close(devs[i]);
+	}
+	free(devs);
+	return err;
+}
+
 static enum iopattern
 str_to_iopattern(const char *name)
 {
@@ -1245,6 +1282,38 @@ sub_cuda_run(struct xnvme_cli *cli)
 	return xnvmeperf_cuda_run(&args);
 }
 
+static int
+sub_cuda_verify(struct xnvme_cli *cli)
+{
+	struct xnvmeperf_args args = {0};
+	int err;
+
+	err = parse_common_args(cli, &args);
+	if (err) {
+		return err;
+	}
+
+	if (!args.opts.be) {
+		args.opts.be = "upcie-cuda";
+	} else if (strcmp(args.opts.be, "upcie-cuda") != 0) {
+		err = -EINVAL;
+		fprintf(stderr, "Error: cuda-verify requires --be upcie-cuda, got '%s': err(%d)\n",
+			args.opts.be, err);
+		return err;
+	}
+
+	args.qdepth = cli->args.qdepth;
+	if (!args.qdepth || !xnvme_is_pow2(args.qdepth)) {
+		err = -EINVAL;
+		xnvme_cli_perr("Error: --qdepth must be a power of 2", err);
+		return err;
+	}
+
+	args.nqueues = cli->args.nqueues ? cli->args.nqueues : 1;
+
+	return xnvmeperf_cuda_verify(&args);
+}
+
 static struct xnvme_cli_sub g_subs[] = {
 	{
 		"run",
@@ -1304,6 +1373,24 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_QDEPTH, XNVME_CLI_LREQ},
 			{XNVME_CLI_OPT_IOSIZE, XNVME_CLI_LREQ},
 			{XNVME_CLI_OPT_RUNTIME, XNVME_CLI_LREQ},
+			{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_BE, XNVME_CLI_LOPT},
+		},
+	},
+	{
+		"cuda-verify",
+		"Verify GPU NVMe I/O data integrity (requires upcie-cuda backend)",
+		"Write an LBA-stamped pattern to each device through GPU queues and read\n"
+		"it back, verifying that the data matches. Uses the same queue topology\n"
+		"as cuda-run so results are directly comparable.",
+		sub_cuda_verify,
+		{
+			{XNVME_CLI_OPT_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_URI, XNVME_CLI_POSN},
+			{XNVME_CLI_OPT_NON_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_IOSIZE, XNVME_CLI_LREQ},
+			{XNVME_CLI_OPT_NQUEUES, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_QDEPTH, XNVME_CLI_LREQ},
 			{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP},
 			{XNVME_CLI_OPT_BE, XNVME_CLI_LOPT},
 		},

--- a/tools/xnvmeperf/xnvmeperf.h
+++ b/tools/xnvmeperf/xnvmeperf.h
@@ -7,6 +7,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <errno.h>
 
 #include <libxnvme.h>
 
@@ -34,5 +35,20 @@ struct xnvmeperf_args {
 
 int
 fill_pattern(void *buf, size_t nbytes, uint64_t slba, uint16_t nlb);
+
+#ifdef XNVME_BE_UPCIE_CUDA_ENABLED
+int
+xnvmeperf_cuda_run_io(struct xnvme_dev **devs, const struct xnvmeperf_args *args,
+		      uint64_t *rounds_per_dev, uint64_t *failed_per_dev, float *elapsed_ms);
+#else
+static inline int
+xnvmeperf_cuda_run_io(struct xnvme_dev **XNVME_UNUSED(devs),
+		      const struct xnvmeperf_args *XNVME_UNUSED(args),
+		      uint64_t *XNVME_UNUSED(rounds_per_dev),
+		      uint64_t *XNVME_UNUSED(failed_per_dev), float *XNVME_UNUSED(elapsed_ms))
+{
+	return -ENOSYS;
+}
+#endif
 
 #endif /* __XNVMEPERF_H */

--- a/tools/xnvmeperf/xnvmeperf.h
+++ b/tools/xnvmeperf/xnvmeperf.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef __XNVMEPERF_H
+#define __XNVMEPERF_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <libxnvme.h>
+
+enum iopattern {
+	IOPATTERN_READ      = 1,
+	IOPATTERN_WRITE     = 2,
+	IOPATTERN_RANDREAD  = 3,
+	IOPATTERN_RANDWRITE = 4,
+	IOPATTERN_VERIFY    = 5, ///< Used for verify subcommand
+};
+
+struct xnvmeperf_args {
+	int ndevs;
+	const char **dev_uris;
+	int ncpus;
+	int *cpus;
+	uint32_t qdepth;
+	uint32_t iosize;
+	uint32_t time;
+	uint32_t count;
+	uint32_t nqueues;
+	enum iopattern pattern;
+	struct xnvme_opts opts;
+};
+
+int
+fill_pattern(void *buf, size_t nbytes, uint64_t slba, uint16_t nlb);
+
+#endif /* __XNVMEPERF_H */

--- a/tools/xnvmeperf/xnvmeperf.h
+++ b/tools/xnvmeperf/xnvmeperf.h
@@ -40,12 +40,21 @@ fill_pattern(void *buf, size_t nbytes, uint64_t slba, uint16_t nlb);
 int
 xnvmeperf_cuda_run_io(struct xnvme_dev **devs, const struct xnvmeperf_args *args,
 		      uint64_t *rounds_per_dev, uint64_t *failed_per_dev, float *elapsed_ms);
+int
+xnvmeperf_cuda_verify_io(struct xnvme_dev **devs, const struct xnvmeperf_args *args);
 #else
 static inline int
 xnvmeperf_cuda_run_io(struct xnvme_dev **XNVME_UNUSED(devs),
 		      const struct xnvmeperf_args *XNVME_UNUSED(args),
 		      uint64_t *XNVME_UNUSED(rounds_per_dev),
 		      uint64_t *XNVME_UNUSED(failed_per_dev), float *XNVME_UNUSED(elapsed_ms))
+{
+	return -ENOSYS;
+}
+
+static inline int
+xnvmeperf_cuda_verify_io(struct xnvme_dev **XNVME_UNUSED(devs),
+			 const struct xnvmeperf_args *XNVME_UNUSED(args))
 {
 	return -ENOSYS;
 }

--- a/tools/xnvmeperf/xnvmeperf_cuda.cu
+++ b/tools/xnvmeperf/xnvmeperf_cuda.cu
@@ -1,0 +1,698 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <libxnvme.h>
+
+extern "C" {
+#include "xnvmeperf.h"
+}
+
+/**
+ * One CUDA block per queue; each thread owns one queue slot and advances
+ * sequentially by qdepth * nlbas per round, wrapping at the device boundary.
+ */
+__global__ static void
+xnvmeperf_cuda_kernel_seq(struct xnvme_cuda_queue **qps, struct xnvme_spec_cmd *cmds,
+			  uint64_t *nblocks, uint16_t nlbas, volatile int *stop,
+			  uint64_t *out_rounds, uint64_t *out_failed)
+{
+	struct xnvme_spec_cmd cmd;
+	uint64_t cap, offset, rounds = 0, failed = 0;
+	__shared__ int s_stop;
+	int err;
+
+	const size_t bid = blockIdx.x;
+	const size_t tid = threadIdx.x;
+	const size_t qdepth = blockDim.x;
+
+	cap = nblocks[bid];
+	cmd = cmds[bid * qdepth + tid];
+	offset = (uint64_t)tid * nlbas;
+
+	while (true) {
+		/* Thread 0 samples the stop flag and broadcasts via shared memory so
+		 * all threads in the block make the same exit decision.  Without this,
+		 * warps that observe *stop == 1 would skip xnvme_cuda_cmd_io while
+		 * others still enter it, causing the __syncthreads() inside
+		 * nvme_qpair_cuda_io to deadlock. */
+		if (tid == 0) {
+			s_stop = *stop;
+		}
+
+		__syncthreads();
+		if (s_stop) {
+			break;
+		}
+
+		cmd.nvm.slba = offset;
+
+		offset += (uint64_t)qdepth * nlbas;
+		if (offset >= cap * (uint64_t)nlbas) {
+			offset = (uint64_t)tid * nlbas;
+		}
+
+		err = xnvme_cuda_cmd_io(qps[bid], &cmd, tid, qdepth);
+
+		if (tid == 0) {
+			rounds++;
+		}
+		if (err) {
+			failed++;
+		}
+	}
+
+	if (tid == 0) {
+		out_rounds[bid] = rounds;
+	}
+	atomicAdd((unsigned long long *)&out_failed[bid], (unsigned long long)failed);
+}
+
+/**
+ * One CUDA block per queue; each thread owns one queue slot and picks a random
+ * LBA each round using an independent per-thread LCG seeded from seeds.
+ */
+__global__ static void
+xnvmeperf_cuda_kernel_rand(struct xnvme_cuda_queue **qps, struct xnvme_spec_cmd *cmds,
+			   uint64_t *nblocks, uint16_t nlbas, uint64_t *seeds, volatile int *stop,
+			   uint64_t *out_rounds, uint64_t *out_failed)
+{
+	struct xnvme_spec_cmd cmd;
+	uint64_t cap, slba, seed, rounds = 0, failed = 0;
+	__shared__ int s_stop;
+	int err;
+
+	const size_t bid = blockIdx.x;
+	const size_t tid = threadIdx.x;
+	const size_t qdepth = blockDim.x;
+
+	cap = nblocks[bid];
+	cmd = cmds[bid * qdepth + tid];
+	seed = seeds[bid * qdepth + tid];
+
+	while (true) {
+		if (tid == 0) {
+			s_stop = *stop;
+		}
+
+		__syncthreads();
+		if (s_stop) {
+			break;
+		}
+
+		seed = seed * 6364136223846793005ULL + 1442695040888963407ULL;
+		slba = ((seed >> 33) % cap) * (uint64_t)nlbas;
+
+		cmd.nvm.slba = slba;
+
+		err = xnvme_cuda_cmd_io(qps[bid], &cmd, tid, qdepth);
+
+		if (tid == 0) {
+			rounds++;
+		}
+		if (err) {
+			failed++;
+		}
+	}
+
+	if (tid == 0) {
+		out_rounds[bid] = rounds;
+	}
+	atomicAdd((unsigned long long *)&out_failed[bid], (unsigned long long)failed);
+}
+
+static cudaError_t
+cuda_sync_check(void)
+{
+	cudaError_t cerr = cudaGetLastError();
+	if (cerr) {
+		fprintf(stderr, "Failed: cudaGetLastError(): %s\n", cudaGetErrorString(cerr));
+		return cerr;
+	}
+	cerr = cudaDeviceSynchronize();
+	if (cerr) {
+		fprintf(stderr, "Failed: cudaDeviceSynchronize(): %s\n", cudaGetErrorString(cerr));
+	}
+	return cerr;
+}
+
+static cudaError_t
+cuda_upload(void **d_ptr, const void *h_ptr, size_t nbytes)
+{
+	cudaError_t cerr;
+
+	cerr = cudaMalloc(d_ptr, nbytes);
+	if (cerr) {
+		fprintf(stderr, "Failed: cudaMalloc(): %s\n", cudaGetErrorString(cerr));
+		return cerr;
+	}
+
+	cerr = cudaMemcpy(*d_ptr, h_ptr, nbytes, cudaMemcpyHostToDevice);
+	if (cerr) {
+		fprintf(stderr, "Failed: cudaMemcpy(): %s\n", cudaGetErrorString(cerr));
+	}
+	return cerr;
+}
+
+/**
+ * Allocates qdepth DMA buffers for one queue; for iosize spanning more than two
+ * pages an additional PRP-list page is allocated per slot.
+ */
+static int
+xnvmeperf_cuda_alloc_bufs(struct xnvme_dev *dev, uint32_t iosize, uint32_t qdepth,
+			  void ***out_bufs, void ***out_prp_bufs)
+{
+	void **bufs, **prp_bufs = NULL;
+	uint64_t npages;
+	uint32_t pagesize;
+	int err = 0;
+
+	pagesize = (uint32_t)getpagesize();
+	npages = ((uint64_t)iosize + pagesize - 1) / pagesize;
+
+	bufs = (void **)calloc(qdepth, sizeof(*bufs));
+	if (!bufs) {
+		xnvme_cli_perr("Failed: calloc()", -ENOMEM);
+		return -ENOMEM;
+	}
+
+	if (npages > 2) {
+		prp_bufs = (void **)calloc(qdepth, sizeof(*prp_bufs));
+		if (!prp_bufs) {
+			xnvme_cli_perr("Failed: calloc()", -ENOMEM);
+			free(bufs);
+			return -ENOMEM;
+		}
+	}
+
+	for (uint32_t i = 0; i < qdepth; i++) {
+		bufs[i] = xnvme_buf_alloc(dev, iosize);
+		if (!bufs[i]) {
+			err = -ENOMEM;
+			xnvme_cli_perr("Failed: xnvme_buf_alloc()", err);
+			goto err_free_allocs;
+		}
+		if (npages > 2) {
+			prp_bufs[i] = xnvme_buf_alloc(dev, pagesize);
+			if (!prp_bufs[i]) {
+				err = -ENOMEM;
+				xnvme_cli_perr("Failed: xnvme_buf_alloc()", err);
+				goto err_free_allocs;
+			}
+		}
+	}
+
+	*out_bufs = bufs;
+	*out_prp_bufs = prp_bufs;
+	return 0;
+
+err_free_allocs:
+	for (uint32_t i = 0; i < qdepth; i++) {
+		if (bufs[i]) {
+			xnvme_buf_free(dev, bufs[i]);
+		}
+		if (prp_bufs && prp_bufs[i]) {
+			xnvme_buf_free(dev, prp_bufs[i]);
+		}
+	}
+	free(prp_bufs);
+	free(bufs);
+	return err;
+}
+
+/**
+ * Resolves physical buffer addresses and sets PRP1/PRP2 (1-page and 2-page
+ * cases) or builds a PRP list in prp_bufs and points PRP2 at it (>2 pages).
+ */
+static int
+xnvmeperf_cuda_fill_cmds(struct xnvme_dev *dev, uint32_t iosize, uint32_t qdepth, uint8_t opcode,
+			 uint32_t nsid, uint16_t nlb, void **bufs, void **prp_bufs,
+			 struct xnvme_spec_cmd *h_cmds)
+{
+	uint64_t prp1, prp2, prp_list_phys, page_phys, npages, *prp_list = NULL;
+	uint32_t pagesize;
+	cudaError_t cerr;
+	int err = 0;
+
+	pagesize = (uint32_t)getpagesize();
+	npages = ((uint64_t)iosize + pagesize - 1) / pagesize;
+
+	if (npages > 2) {
+		/* PRP-list buffer is one page; reject iosize whose list overflows it. */
+		if ((npages - 1) * sizeof(uint64_t) > pagesize) {
+			fprintf(stderr,
+				"Error: iosize %u requires a PRP list larger than one page\n",
+				iosize);
+			return -EINVAL;
+		}
+		prp_list = (uint64_t *)malloc((npages - 1) * sizeof(*prp_list));
+		if (!prp_list) {
+			xnvme_cli_perr("Failed: malloc()", -ENOMEM);
+			return -ENOMEM;
+		}
+	}
+
+	for (uint32_t i = 0; i < qdepth; i++) {
+		err = xnvme_buf_vtophys(dev, bufs[i], &prp1);
+		if (err) {
+			xnvme_cli_perr("Failed: xnvme_buf_vtophys()", err);
+			goto done;
+		}
+
+		h_cmds[i].common.opcode = opcode;
+		h_cmds[i].common.nsid = nsid;
+		h_cmds[i].nvm.nlb = nlb;
+		h_cmds[i].common.dptr.prp.prp1 = prp1;
+
+		if (npages == 2) {
+			err = xnvme_buf_vtophys(dev, (char *)bufs[i] + pagesize, &prp2);
+			if (err) {
+				xnvme_cli_perr("Failed: xnvme_buf_vtophys()", err);
+				goto done;
+			}
+			h_cmds[i].common.dptr.prp.prp2 = prp2;
+		} else if (npages > 2) {
+			for (uint64_t p = 1; p < npages; p++) {
+				err = xnvme_buf_vtophys(dev, (char *)bufs[i] + p * pagesize,
+							&page_phys);
+				if (err) {
+					xnvme_cli_perr("Failed: xnvme_buf_vtophys()", err);
+					goto done;
+				}
+				prp_list[p - 1] = page_phys;
+			}
+
+			err = xnvme_buf_vtophys(dev, prp_bufs[i], &prp_list_phys);
+			if (err) {
+				xnvme_cli_perr("Failed: xnvme_buf_vtophys()", err);
+				goto done;
+			}
+
+			cerr = cudaMemcpy(prp_bufs[i], prp_list, (npages - 1) * sizeof(*prp_list),
+					  cudaMemcpyHostToDevice);
+			if (cerr) {
+				fprintf(stderr, "Failed: cudaMemcpy(): %s\n",
+					cudaGetErrorString(cerr));
+				err = (int)cerr;
+				goto done;
+			}
+
+			h_cmds[i].common.dptr.prp.prp2 = prp_list_phys;
+		}
+	}
+
+done:
+	free(prp_list);
+	return err;
+}
+
+static int
+xnvmeperf_cuda_build_cmds(struct xnvme_dev **devs, int ndevs, uint32_t iosize, uint32_t qdepth,
+			  uint8_t opcode, uint32_t nqueues, void ***bufs, void ***prp_bufs,
+			  struct xnvme_spec_cmd *h_cmds)
+{
+	struct xnvme_dev *dev;
+	uint32_t nsid, qi;
+	uint16_t nlb;
+	int err;
+
+	for (int d = 0; d < ndevs; d++) {
+		dev = devs[d];
+		nsid = xnvme_dev_get_nsid(dev);
+		nlb = (uint16_t)(iosize / xnvme_dev_get_geo(dev)->lba_nbytes) - 1;
+
+		for (uint32_t q = 0; q < nqueues; q++) {
+			qi = (uint32_t)d * nqueues + q;
+
+			err = xnvmeperf_cuda_fill_cmds(dev, iosize, qdepth, opcode, nsid, nlb,
+						       bufs[qi], prp_bufs[qi],
+						       h_cmds + qi * qdepth);
+			if (err) {
+				xnvme_cli_perr("Failed: xnvmeperf_cuda_fill_cmds()", err);
+				return err;
+			}
+		}
+	}
+	return 0;
+}
+
+/**
+ * Creates queues and allocates I/O buffers for all devices. On partial failure
+ * the successfully created resources are left in place for the caller to tear
+ * down via xnvmeperf_cuda_cleanup().
+ */
+static int
+xnvmeperf_cuda_setup(struct xnvme_dev **devs, int ndevs, uint32_t iosize, uint32_t qdepth,
+		     uint32_t nqueues, struct xnvme_cuda_queue **h_qps, void ***bufs,
+		     void ***prp_bufs, uint64_t *h_nblocks)
+{
+	struct xnvme_dev *dev;
+	uint64_t nblocks;
+	uint32_t qi;
+	int err;
+
+	for (int d = 0; d < ndevs; d++) {
+		dev = devs[d];
+		nblocks = xnvme_dev_get_geo(dev)->tbytes / iosize;
+		if ((uint64_t)nqueues * qdepth > nblocks) {
+			fprintf(stderr, "Error: device %d has %lu IO slots but need %u\n", d,
+				(unsigned long)nblocks, nqueues * qdepth);
+			return -EINVAL;
+		}
+
+		for (uint32_t q = 0; q < nqueues; q++) {
+			qi = (uint32_t)d * nqueues + q;
+
+			if (h_nblocks) {
+				h_nblocks[qi] = nblocks;
+			}
+
+			err = xnvme_cuda_queue_create(dev, qdepth, &h_qps[qi]);
+			if (err) {
+				xnvme_cli_perr("Failed: xnvme_cuda_queue_create()", err);
+				return err;
+			}
+
+			err = xnvmeperf_cuda_alloc_bufs(dev, iosize, qdepth, &bufs[qi],
+							&prp_bufs[qi]);
+			if (err) {
+				xnvme_cli_perr("Failed: xnvmeperf_cuda_alloc_bufs()", err);
+				return err;
+			}
+		}
+	}
+	return 0;
+}
+
+/* Safe to call with NULL per-slot entries; designed for partial-setup teardown. */
+static void
+xnvmeperf_cuda_cleanup(struct xnvme_dev **devs, int ndevs, uint32_t nqueues, uint32_t qdepth,
+		       struct xnvme_cuda_queue **h_qps, void ***bufs, void ***prp_bufs)
+{
+	struct xnvme_dev *dev;
+	uint32_t qi;
+
+	for (int d = 0; d < ndevs; d++) {
+		dev = devs[d];
+
+		for (uint32_t q = 0; q < nqueues; q++) {
+			qi = (uint32_t)d * nqueues + q;
+
+			if (bufs && bufs[qi]) {
+				for (uint32_t i = 0; i < qdepth; i++) {
+					if (bufs[qi][i]) {
+						xnvme_buf_free(dev, bufs[qi][i]);
+					}
+					if (prp_bufs && prp_bufs[qi] && prp_bufs[qi][i]) {
+						xnvme_buf_free(dev, prp_bufs[qi][i]);
+					}
+				}
+				free(bufs[qi]);
+			}
+			if (prp_bufs && prp_bufs[qi]) {
+				free(prp_bufs[qi]);
+			}
+			if (h_qps && h_qps[qi]) {
+				xnvme_cuda_queue_destroy(dev, h_qps[qi]);
+			}
+		}
+	}
+}
+
+/**
+ * Launches one CUDA block per queue and runs for runtime_secs. Selects the
+ * random kernel when h_seeds is non-NULL, sequential otherwise.
+ */
+static int
+xnvmeperf_cuda_launch(struct xnvme_cuda_queue **h_qps, struct xnvme_spec_cmd *h_cmds,
+		      uint64_t *h_seeds, uint32_t nqueues, uint64_t *h_nblocks, uint16_t nlbas,
+		      uint32_t runtime_secs, unsigned int qdepth, uint64_t *h_rounds,
+		      uint64_t *h_failed, float *elapsed_ms)
+{
+	struct xnvme_cuda_queue **d_qps = NULL;
+	struct xnvme_spec_cmd *d_cmds = NULL;
+	uint64_t *d_seeds = NULL, *d_nblocks = NULL, *d_rounds = NULL, *d_failed = NULL;
+	void *d_stop;
+	int *h_stop = NULL;
+	cudaEvent_t t0 = NULL, t1 = NULL;
+	cudaError_t cerr;
+
+	cerr = cuda_upload((void **)&d_qps, h_qps, nqueues * sizeof(*d_qps));
+	if (cerr) {
+		goto done;
+	}
+
+	cerr = cuda_upload((void **)&d_cmds, h_cmds, nqueues * qdepth * sizeof(*d_cmds));
+	if (cerr) {
+		goto done;
+	}
+
+	cerr = cuda_upload((void **)&d_nblocks, h_nblocks, nqueues * sizeof(*d_nblocks));
+	if (cerr) {
+		goto done;
+	}
+
+	cerr = cudaMalloc((void **)&d_rounds, nqueues * sizeof(*d_rounds));
+	if (cerr) {
+		fprintf(stderr, "Failed: cudaMalloc(): %s\n", cudaGetErrorString(cerr));
+		goto done;
+	}
+
+	cerr = cudaMalloc((void **)&d_failed, nqueues * sizeof(*d_failed));
+	if (cerr) {
+		fprintf(stderr, "Failed: cudaMalloc(): %s\n", cudaGetErrorString(cerr));
+		goto done;
+	}
+	cerr = cudaMemset(d_failed, 0, nqueues * sizeof(*d_failed));
+	if (cerr) {
+		fprintf(stderr, "Failed: cudaMemset(): %s\n", cudaGetErrorString(cerr));
+		goto done;
+	}
+
+	cerr = cudaHostAlloc((void **)&h_stop, sizeof(*h_stop), cudaHostAllocMapped);
+	if (cerr) {
+		fprintf(stderr, "Failed: cudaHostAlloc(): %s\n", cudaGetErrorString(cerr));
+		goto done;
+	}
+
+	cerr = cudaHostGetDevicePointer(&d_stop, h_stop, 0);
+	if (cerr) {
+		fprintf(stderr, "Failed: cudaHostGetDevicePointer(): %s\n",
+			cudaGetErrorString(cerr));
+		goto done;
+	}
+
+	if (h_seeds) {
+		cerr = cuda_upload((void **)&d_seeds, h_seeds,
+				   nqueues * qdepth * sizeof(*d_seeds));
+		if (cerr) {
+			goto done;
+		}
+	}
+
+	*h_stop = 0;
+
+	cerr = cudaEventCreate(&t0);
+	if (cerr) {
+		fprintf(stderr, "Failed: cudaEventCreate(): %s\n", cudaGetErrorString(cerr));
+		goto done;
+	}
+	cerr = cudaEventCreate(&t1);
+	if (cerr) {
+		fprintf(stderr, "Failed: cudaEventCreate(): %s\n", cudaGetErrorString(cerr));
+		goto done;
+	}
+	cerr = cudaEventRecord(t0);
+	if (cerr) {
+		fprintf(stderr, "Failed: cudaEventRecord(): %s\n", cudaGetErrorString(cerr));
+		goto done;
+	}
+
+	if (h_seeds) {
+		xnvmeperf_cuda_kernel_rand<<<nqueues, qdepth>>>(d_qps, d_cmds, d_nblocks, nlbas,
+								d_seeds, (volatile int *)d_stop,
+								d_rounds, d_failed);
+	} else {
+		xnvmeperf_cuda_kernel_seq<<<nqueues, qdepth>>>(d_qps, d_cmds, d_nblocks, nlbas,
+							       (volatile int *)d_stop, d_rounds,
+							       d_failed);
+	}
+
+	sleep(runtime_secs);
+	*h_stop = 1;
+
+	cerr = cudaEventRecord(t1);
+	if (cerr) {
+		fprintf(stderr, "Failed: cudaEventRecord(): %s\n", cudaGetErrorString(cerr));
+		goto done;
+	}
+	cerr = cuda_sync_check();
+	if (!cerr) {
+		cudaEventElapsedTime(elapsed_ms, t0, t1);
+		cerr = cudaMemcpy(h_rounds, d_rounds, nqueues * sizeof(*h_rounds),
+				  cudaMemcpyDeviceToHost);
+		if (cerr) {
+			fprintf(stderr, "Failed: cudaMemcpy(): %s\n", cudaGetErrorString(cerr));
+			goto done;
+		}
+		cerr = cudaMemcpy(h_failed, d_failed, nqueues * sizeof(*h_failed),
+				  cudaMemcpyDeviceToHost);
+		if (cerr) {
+			fprintf(stderr, "Failed: cudaMemcpy(): %s\n", cudaGetErrorString(cerr));
+			goto done;
+		}
+	}
+
+done:
+	if (t0) {
+		cudaEventDestroy(t0);
+	}
+	if (t1) {
+		cudaEventDestroy(t1);
+	}
+	cudaFree(d_seeds);
+	cudaFreeHost(h_stop);
+	cudaFree(d_failed);
+	cudaFree(d_rounds);
+	cudaFree(d_nblocks);
+	cudaFree(d_cmds);
+	cudaFree(d_qps);
+	return (int)cerr;
+}
+
+static int
+xnvmeperf_cuda_validate_lba(struct xnvme_dev **devs, const struct xnvmeperf_args *args)
+{
+	for (int d = 1; d < args->ndevs; d++) {
+		if (xnvme_dev_get_geo(devs[d])->lba_nbytes !=
+		    xnvme_dev_get_geo(devs[0])->lba_nbytes) {
+			fprintf(stderr, "Error: device %s LBA size mismatch\n", args->dev_uris[d]);
+			return -EINVAL;
+		}
+	}
+
+	if (args->iosize % xnvme_dev_get_geo(devs[0])->lba_nbytes) {
+		fprintf(stderr, "Error: iosize %u is not a multiple of LBA size %u\n",
+			args->iosize, xnvme_dev_get_geo(devs[0])->lba_nbytes);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+extern "C" int
+xnvmeperf_cuda_run_io(struct xnvme_dev **devs, const struct xnvmeperf_args *args,
+		      uint64_t *rounds_per_dev, uint64_t *failed_per_dev, float *elapsed_ms)
+{
+	struct xnvme_cuda_queue **h_qps;
+	struct xnvme_spec_cmd *h_cmds;
+	void ***bufs, ***prp_bufs;
+	uint64_t *nblocks, *rounds, *failed, *h_seeds = NULL;
+	uint32_t total_queues;
+	uint16_t nlbas;
+	uint8_t opcode;
+	int random = 0, err = 0;
+
+	switch (args->pattern) {
+	case IOPATTERN_READ:
+		opcode = XNVME_SPEC_NVM_OPC_READ;
+		break;
+	case IOPATTERN_WRITE:
+		opcode = XNVME_SPEC_NVM_OPC_WRITE;
+		break;
+	case IOPATTERN_RANDREAD:
+		opcode = XNVME_SPEC_NVM_OPC_READ;
+		random = 1;
+		break;
+	case IOPATTERN_RANDWRITE:
+		opcode = XNVME_SPEC_NVM_OPC_WRITE;
+		random = 1;
+		break;
+	default:
+		err = -EINVAL;
+		xnvme_cli_perr("Error: unsupported pattern", err);
+		return err;
+	}
+
+	err = xnvmeperf_cuda_validate_lba(devs, args);
+	if (err) {
+		return err;
+	}
+
+	nlbas = (uint16_t)(args->iosize / xnvme_dev_get_geo(devs[0])->lba_nbytes);
+
+	total_queues = (uint32_t)args->ndevs * args->nqueues;
+	/* Flat arrays; device d owns slots [d*nqueues .. (d+1)*nqueues). */
+	h_qps = (struct xnvme_cuda_queue **)calloc(total_queues, sizeof(*h_qps));
+	h_cmds = (struct xnvme_spec_cmd *)calloc(total_queues * args->qdepth, sizeof(*h_cmds));
+	bufs = (void ***)calloc(total_queues, sizeof(*bufs));
+	prp_bufs = (void ***)calloc(total_queues, sizeof(*prp_bufs));
+	nblocks = (uint64_t *)calloc(total_queues, sizeof(*nblocks));
+	rounds = (uint64_t *)calloc(total_queues, sizeof(*rounds));
+	failed = (uint64_t *)calloc(total_queues, sizeof(*failed));
+
+	if (!h_qps || !h_cmds || !nblocks || !bufs || !prp_bufs || !rounds || !failed) {
+		err = -ENOMEM;
+		xnvme_cli_perr("Failed: calloc()", err);
+		goto cleanup;
+	}
+
+	err = xnvmeperf_cuda_setup(devs, args->ndevs, args->iosize, args->qdepth, args->nqueues,
+				   h_qps, bufs, prp_bufs, nblocks);
+	if (err) {
+		xnvme_cli_perr("Failed: xnvmeperf_cuda_setup()", err);
+		goto cleanup;
+	}
+
+	err = xnvmeperf_cuda_build_cmds(devs, args->ndevs, args->iosize, args->qdepth, opcode,
+					args->nqueues, bufs, prp_bufs, h_cmds);
+	if (err) {
+		xnvme_cli_perr("Failed: xnvmeperf_cuda_build_cmds()", err);
+		goto cleanup;
+	}
+
+	if (random) {
+		h_seeds = (uint64_t *)malloc(total_queues * args->qdepth * sizeof(*h_seeds));
+		if (!h_seeds) {
+			err = -ENOMEM;
+			xnvme_cli_perr("Failed: malloc()", err);
+			goto cleanup;
+		}
+
+		for (uint32_t i = 0; i < total_queues * args->qdepth; i++) {
+			h_seeds[i] = 0x12345678ULL + i * 0x9e3779b97f4a7c15ULL;
+		}
+	}
+
+	err = xnvmeperf_cuda_launch(h_qps, h_cmds, h_seeds, total_queues, nblocks, nlbas,
+				    args->time, args->qdepth, rounds, failed, elapsed_ms);
+
+	if (!err) {
+		for (int d = 0; d < args->ndevs; d++) {
+			rounds_per_dev[d] = 0;
+			failed_per_dev[d] = 0;
+			for (uint32_t q = 0; q < args->nqueues; q++) {
+				rounds_per_dev[d] += rounds[(uint32_t)d * args->nqueues + q];
+				failed_per_dev[d] += failed[(uint32_t)d * args->nqueues + q];
+			}
+		}
+	}
+
+cleanup:
+	free(h_seeds);
+	free(h_cmds);
+	xnvmeperf_cuda_cleanup(devs, args->ndevs, args->nqueues, args->qdepth, h_qps, bufs,
+			       prp_bufs);
+	free(bufs);
+	free(prp_bufs);
+	free(nblocks);
+	free(rounds);
+	free(failed);
+	free(h_qps);
+	return err;
+}

--- a/tools/xnvmeperf/xnvmeperf_cuda.cu
+++ b/tools/xnvmeperf/xnvmeperf_cuda.cu
@@ -696,3 +696,213 @@ cleanup:
 	free(h_qps);
 	return err;
 }
+
+/**
+ * Issues one NVMe I/O per thread. All threads in a block must enter together
+ * because xnvme_cuda_cmd_io() contains a __syncthreads() internally.
+ */
+__global__ static void
+xnvmeperf_cuda_kernel_verify_round(struct xnvme_cuda_queue **qps, struct xnvme_spec_cmd *cmds,
+				   int *out_err)
+{
+	const size_t bid = blockIdx.x;
+	const size_t tid = threadIdx.x;
+	const size_t qdepth = blockDim.x;
+	struct xnvme_spec_cmd cmd = cmds[bid * qdepth + tid];
+
+	out_err[bid * qdepth + tid] = xnvme_cuda_cmd_io(qps[bid], &cmd, tid, qdepth);
+}
+
+static int
+verify_dispatch(struct xnvme_cuda_queue **d_qps, struct xnvme_spec_cmd *h_cmds,
+		struct xnvme_spec_cmd *d_cmds, int *d_errs, int *h_errs, uint32_t nqueues,
+		uint32_t qdepth, const char *phase)
+{
+	uint32_t total = nqueues * qdepth;
+	cudaError_t cerr;
+
+	cerr = cudaMemcpy(d_cmds, h_cmds, total * sizeof(*d_cmds), cudaMemcpyHostToDevice);
+	if (cerr) {
+		fprintf(stderr, "Failed: cudaMemcpy(): %s\n", cudaGetErrorString(cerr));
+		return (int)cerr;
+	}
+
+	xnvmeperf_cuda_kernel_verify_round<<<nqueues, qdepth>>>(d_qps, d_cmds, d_errs);
+	cerr = cuda_sync_check();
+	if (cerr) {
+		return (int)cerr;
+	}
+
+	cerr = cudaMemcpy(h_errs, d_errs, total * sizeof(*h_errs), cudaMemcpyDeviceToHost);
+	if (cerr) {
+		fprintf(stderr, "Failed: cudaMemcpy(): %s\n", cudaGetErrorString(cerr));
+		return (int)cerr;
+	}
+
+	for (uint32_t i = 0; i < total; i++) {
+		if (h_errs[i]) {
+			fprintf(stderr, "%s failure at slot %u: err(%d)\n", phase, i, h_errs[i]);
+			return h_errs[i];
+		}
+	}
+
+	return 0;
+}
+
+extern "C" int
+xnvmeperf_cuda_verify_io(struct xnvme_dev **devs, const struct xnvmeperf_args *args)
+{
+	struct xnvme_cuda_queue **h_qps, **d_qps = NULL;
+	struct xnvme_spec_cmd *h_cmds, *d_cmds = NULL;
+	void ***bufs, ***prp_bufs;
+	void *cmp_buf;
+	uint32_t threads_per_dev, total_threads, total_queues;
+	uint16_t nlbas;
+	int *h_errs, *d_errs = NULL;
+	cudaError_t cerr;
+	int err = 0;
+
+	err = xnvmeperf_cuda_validate_lba(devs, args);
+	if (err) {
+		return err;
+	}
+
+	nlbas = (uint16_t)(args->iosize / xnvme_dev_get_geo(devs[0])->lba_nbytes);
+	threads_per_dev = args->nqueues * args->qdepth;
+	total_threads = (uint32_t)args->ndevs * threads_per_dev;
+	total_queues = (uint32_t)args->ndevs * args->nqueues;
+
+	h_qps = (struct xnvme_cuda_queue **)calloc(total_queues, sizeof(*h_qps));
+	h_cmds = (struct xnvme_spec_cmd *)calloc(total_threads, sizeof(*h_cmds));
+	bufs = (void ***)calloc(total_queues, sizeof(*bufs));
+	prp_bufs = (void ***)calloc(total_queues, sizeof(*prp_bufs));
+	h_errs = (int *)malloc(total_threads * sizeof(*h_errs));
+	cmp_buf = malloc(args->iosize);
+
+	if (!h_qps || !h_cmds || !bufs || !prp_bufs || !h_errs || !cmp_buf) {
+		err = -ENOMEM;
+		xnvme_cli_perr("Failed: calloc()", err);
+		goto cleanup;
+	}
+
+	err = xnvmeperf_cuda_setup(devs, args->ndevs, args->iosize, args->qdepth, args->nqueues,
+				   h_qps, bufs, prp_bufs, NULL);
+	if (err) {
+		xnvme_cli_perr("Failed: xnvmeperf_cuda_setup()", err);
+		goto cleanup;
+	}
+
+	err = xnvmeperf_cuda_build_cmds(devs, args->ndevs, args->iosize, args->qdepth,
+					XNVME_SPEC_NVM_OPC_WRITE, args->nqueues, bufs, prp_bufs,
+					h_cmds);
+	if (err) {
+		xnvme_cli_perr("Failed: xnvmeperf_cuda_build_cmds()", err);
+		goto cleanup;
+	}
+
+	cerr = cuda_upload((void **)&d_qps, h_qps, total_queues * sizeof(*d_qps));
+	if (cerr) {
+		err = (int)cerr;
+		goto cleanup;
+	}
+
+	cerr = cudaMalloc(&d_cmds, total_threads * sizeof(*d_cmds));
+	if (cerr) {
+		err = (int)cerr;
+		fprintf(stderr, "Failed: cudaMalloc(): %s\n", cudaGetErrorString(cerr));
+		goto cleanup;
+	}
+
+	cerr = cudaMalloc(&d_errs, total_threads * sizeof(*d_errs));
+	if (cerr) {
+		err = (int)cerr;
+		fprintf(stderr, "Failed: cudaMalloc(): %s\n", cudaGetErrorString(cerr));
+		goto cleanup;
+	}
+
+	/* Write: stamp each thread's LBA range with a unique pattern */
+	for (uint32_t idx = 0; idx < total_threads; idx++) {
+		h_cmds[idx].nvm.slba = (uint64_t)idx * nlbas;
+		err = fill_pattern(bufs[idx / args->qdepth][idx % args->qdepth], args->iosize,
+				   h_cmds[idx].nvm.slba, nlbas);
+		if (err) {
+			xnvme_cli_perr("Failed: fill_pattern()", err);
+			goto cleanup;
+		}
+	}
+
+	err = verify_dispatch(d_qps, h_cmds, d_cmds, d_errs, h_errs, total_queues, args->qdepth,
+			      "write");
+	if (err) {
+		xnvme_cli_perr("Failed: verify_dispatch(write)", err);
+		goto cleanup;
+	}
+
+	/* Read back through the same GPU queue path */
+	for (uint32_t idx = 0; idx < total_threads; idx++)
+		h_cmds[idx].common.opcode = XNVME_SPEC_NVM_OPC_READ;
+
+	err = verify_dispatch(d_qps, h_cmds, d_cmds, d_errs, h_errs, total_queues, args->qdepth,
+			      "read");
+	if (err) {
+		xnvme_cli_perr("Failed: verify_dispatch(read)", err);
+		goto cleanup;
+	}
+
+	/* Compare read-back data against expected pattern, report per device */
+	for (int d = 0; d < args->ndevs; d++) {
+		uint64_t mismatches = 0;
+		uint32_t base = (uint32_t)d * threads_per_dev;
+
+		for (uint32_t i = 0; i < threads_per_dev; i++) {
+			uint32_t idx = base + i;
+			uint32_t q = i / args->qdepth;
+			uint32_t t = i % args->qdepth;
+			size_t diff = 0;
+
+			err = fill_pattern(cmp_buf, args->iosize, h_cmds[idx].nvm.slba, nlbas);
+			if (err) {
+				fprintf(stderr,
+					"Failed: fill_pattern() for dev=%s q=%u t=%u, err: %d\n",
+					args->dev_uris[d], q, t, err);
+				goto cleanup;
+			}
+			err = xnvme_buf_diff(cmp_buf, bufs[(uint32_t)d * args->nqueues + q][t],
+					     args->iosize, &diff);
+			if (err) {
+				fprintf(stderr,
+					"Failed: xnvme_buf_diff() for dev=%s q=%u t=%u, err: %d\n",
+					args->dev_uris[d], q, t, err);
+				goto cleanup;
+			}
+
+			if (diff) {
+				fprintf(stderr, "  MISMATCH at dev=%s q=%u t=%u slba=%lu\n",
+					args->dev_uris[d], q, t,
+					(unsigned long)h_cmds[idx].nvm.slba);
+				mismatches++;
+			}
+		}
+
+		printf(" %-20s  verified %u IOs, %lu mismatches\n", args->dev_uris[d],
+		       threads_per_dev, mismatches);
+
+		if (mismatches) {
+			err = -EIO;
+		}
+	}
+
+cleanup:
+	cudaFree(d_errs);
+	cudaFree(d_cmds);
+	cudaFree(d_qps);
+	xnvmeperf_cuda_cleanup(devs, args->ndevs, args->nqueues, args->qdepth, h_qps, bufs,
+			       prp_bufs);
+	free(bufs);
+	free(prp_bufs);
+	free(h_cmds);
+	free(h_qps);
+	free(h_errs);
+	free(cmp_buf);
+	return err;
+}


### PR DESCRIPTION
Adds GPU-direct NVMe benchmarking to `xnvmeperf` via two new CUDA-only subcommands, along with refactoring work to support the new GPU path cleanly.

  ### New features
  - **`gpu-run`**: time-bounded GPU NVMe benchmark using CUDA kernels (sequential and random), issuing commands via `xnvme_gpu_cmd_io()`. Command templates are built host-side with `xnvme_buf_vtophys()` for PRP entries (1-page, 2-page, PRP-list), then copied to device memory before kernel launch. Reports IOPS and MiB/s.
  - **`gpu-verify`**: writes an LBA-stamped pattern to each device through GPU queues and reads it back to verify data integrity. Uses the same queue topology as `gpu-run`, providing  confidence that benchmark results are correct.
  - **`--queues`**: new CLI option to control the number of NVMe queues per device. Total job slots = devices × queues, distributed evenly across threads.

  ### Refactoring (preparatory)
  - Moved `xnvmeperf.c` into `tools/xnvmeperf/` subdirectory with its own `meson.build`
  - Extracted `xnvmeperf.h` with shared types (`enum iopattern`, `struct xnvmeperf_args`) used by both CPU and GPU paths
  - Extracted `parse_common_args()` / `parse_run_args()` helpers to remove duplicated argument parsing across subcommands
  - Extracted `xnvmeperf_open_devs()` helper to consolidate the repeated open-all-devices loop
  - Extracted `print_run_args()` and `print_perf_results()` helpers for consistent output formatting
  - `meson.build` adds the CUDA language and links `xnvmeperf_gpu.cu` when `XNVME_BE_UPCIE_CUDA_ENABLED`

  ### Docs
  - Added `gpu-run` and `gpu-verify` usage docs with `.cmd`/`.out` files
  - Cross-referenced the `upcie-cuda` backend and `libxnvme_cuda` API sections in `docs/tools/xnvmeperf/index.rst`