### PR TITLE
refactor(be/cref): simplify cref API and remove per-backend enumerate

### DIFF
--- a/include/libxnvme_dev.h
+++ b/include/libxnvme_dev.h
@@ -44,11 +44,11 @@ int
 xnvme_dev_pr(const struct xnvme_dev *dev, int opts);
 
 /**
- * Signature of callback function used with 'xnvme_enumerate' invoked for each discoved device
+ * Signature of callback function used with 'xnvme_enumerate', invoked for each discovered device
  *
- * The callback function signals whether the device-handle it receives should by closed, that is,
- * backend with invoke 'xnvme_dev_close(), after the callback returns or kept open. In the latter
- * case then it is up to the user to invoke 'xnvme_dev_close()' on the device-handle.
+ * The callback function signals whether the device-handle it receives should be closed, that is,
+ * the platform will invoke 'xnvme_dev_close()' after the callback returns, or kept open. In the
+ * latter case it is up to the user to invoke 'xnvme_dev_close()' on the device-handle.
  *
  * Each signal is represented by the enum #xnvme_enumerate_action, and the values
  * XNVME_ENUMERATE_DEV_KEEP_OPEN or XNVME_ENUMERATE_DEV_CLOSE.

--- a/include/xnvme_be.h
+++ b/include/xnvme_be.h
@@ -14,7 +14,7 @@
 #define XNVME_BE_ASYNC_NBYTES 64
 #define XNVME_BE_SYNC_NBYTES  24
 #define XNVME_BE_ADMIN_NBYTES 24
-#define XNVME_BE_DEV_NBYTES   48
+#define XNVME_BE_DEV_NBYTES   40
 #define XNVME_BE_MEM_NBYTES   56
 #define XNVME_BE_ATTR_NBYTES  24
 #define XNVME_BE_STATE_NBYTES 128
@@ -88,11 +88,6 @@ struct xnvme_be_admin {
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_be_admin) == XNVME_BE_ADMIN_NBYTES, "Incorrect size")
 
 struct xnvme_be_dev {
-	/**
-	 * enumerate devices on/at the given 'sys_uri' when NULL local devices
-	 */
-	int (*enumerate)(const char *, struct xnvme_opts *, xnvme_enumerate_cb, void *);
-
 	/**
 	 * Construct a device from the given identifier
 	 */

--- a/include/xnvme_be_cref.h
+++ b/include/xnvme_be_cref.h
@@ -20,13 +20,13 @@ typedef int (*xnvme_be_cref_destructor_fn)(void *ctrlr);
  * @return On success, the controller handle. On error, NULL.
  */
 void *
-xnvme_be_cref_lookup(const char *uri, const char **be_name);
+xnvme_be_cref_get(const char *uri, const char **be_name);
 
 /**
  * Insert a new controller entry with refcount=1
  *
  * Does not check for duplicate URIs. The caller must ensure the URI is not
- * already present, e.g. by calling xnvme_be_cref_lookup() first.
+ * already present, e.g. by calling xnvme_be_cref_get() first.
  *
  * @param uri Device URI to associate with the controller
  * @param be_name Backend name pointer, stored for later matching
@@ -42,7 +42,7 @@ xnvme_be_cref_insert(const char *uri, const char *be_name, void *ctrlr,
 /**
  * Mark the controller as deferred, preventing destruction when refcount reaches zero
  *
- * When deferred, xnvme_be_cref_deref() will leave the entry alive at refcount=0
+ * When deferred, xnvme_be_cref_put() will leave the entry alive at refcount=0
  * rather than calling its destructor. The entry is destroyed by xnvme_be_cref_cleanup().
  *
  * @param ctrlr Controller handle to mark, must be non-NULL
@@ -64,7 +64,7 @@ xnvme_be_cref_defer(void *ctrlr);
  * @return 0 on success, negative errno on error.
  */
 int
-xnvme_be_cref_deref(void *ctrlr);
+xnvme_be_cref_put(void *ctrlr);
 
 /**
  * Destroy all deferred entries with refcount=0, calling each entry's destructor

--- a/include/xnvme_be_cref.h
+++ b/include/xnvme_be_cref.h
@@ -17,15 +17,15 @@ enum xnvme_be_cref_flags {
 };
 
 /**
- * Lookup a controller by @uri and @be_name, and increment its refcount
+ * Lookup a controller by @uri, increment its refcount, and return it
  *
  * @param uri Device URI to match against
- * @param be_name Backend name to match (pointer equality), or NULL for any
+ * @param be_name If non-NULL, receives the backend name of the matched entry
  *
  * @return On success, the controller handle. On error, NULL.
  */
 void *
-xnvme_be_cref_lookup(const char *uri, const char *be_name);
+xnvme_be_cref_lookup(const char *uri, const char **be_name);
 
 /**
  * Insert a new controller entry with refcount=1

--- a/include/xnvme_be_cref.h
+++ b/include/xnvme_be_cref.h
@@ -11,11 +11,6 @@
 
 typedef int (*xnvme_be_cref_destructor_fn)(void *ctrlr);
 
-enum xnvme_be_cref_flags {
-	XNVME_BE_CREF_NONE              = 0x0,
-	XNVME_BE_CREF_DESTROY_IMMEDIATE = 0x1,
-};
-
 /**
  * Lookup a controller by @uri, increment its refcount, and return it
  *
@@ -34,7 +29,7 @@ xnvme_be_cref_lookup(const char *uri, const char **be_name);
  * already present, e.g. by calling xnvme_be_cref_lookup() first.
  *
  * @param uri Device URI to associate with the controller
- * @param be_name Backend name pointer, used for filtering in xnvme_be_cref_cleanup()
+ * @param be_name Backend name pointer, stored for later matching
  * @param ctrlr Controller handle to store, must be non-NULL
  * @param destructor Callback invoked to destroy the controller when refcount reaches zero
  *
@@ -45,31 +40,46 @@ xnvme_be_cref_insert(const char *uri, const char *be_name, void *ctrlr,
 		     xnvme_be_cref_destructor_fn destructor);
 
 /**
- * Decrement the refcount for the given controller
+ * Mark the controller as deferred, preventing destruction when refcount reaches zero
  *
- * If the refcount reaches zero and XNVME_BE_CREF_DESTROY_IMMEDIATE is set,
- * call the stored destructor and remove the entry. Otherwise the entry remains
- * with refcount=0 until xnvme_be_cref_cleanup() is called.
+ * When deferred, xnvme_be_cref_deref() will leave the entry alive at refcount=0
+ * rather than calling its destructor. The entry is destroyed by xnvme_be_cref_cleanup().
  *
- * @param ctrlr Controller handle to dereference, must be non-NULL
- * @param flags Bitmask of enum xnvme_be_cref_flags
+ * @param ctrlr Controller handle to mark, must be non-NULL
  *
  * @return 0 on success, negative errno on error.
  */
 int
-xnvme_be_cref_deref(void *ctrlr, enum xnvme_be_cref_flags flags);
+xnvme_be_cref_defer(void *ctrlr);
 
 /**
- * Destroy all entries with zero refcount matching @be_name
+ * Decrement the refcount for the given controller
  *
- * Iterates all entries, and for those matching @be_name with refcount=0,
- * calls the stored destructor and removes the entry.
+ * If the refcount reaches zero and the entry is not deferred, call the stored
+ * destructor and remove the entry. Deferred entries remain at refcount=0 until
+ * xnvme_be_cref_cleanup() is called.
  *
- * @param be_name Backend name pointer to match (compared by pointer equality)
+ * @param ctrlr Controller handle to dereference, must be non-NULL
+ *
+ * @return 0 on success, negative errno on error.
+ */
+int
+xnvme_be_cref_deref(void *ctrlr);
+
+/**
+ * Destroy all deferred entries with refcount=0, calling each entry's destructor
+ *
+ * For entries with refcount>0 (still held by open namespace devices), clears
+ * the deferred flag so xnvme_be_cref_put() will destroy them normally when
+ * the last reference is dropped.
+ *
+ * Must be called only after all deferred xnvme_dev_close() calls for the
+ * current enumeration round have completed, so that refcounts reflect live
+ * namespace devices only.
  *
  * @return 0 on success, negative errno of the last failed destructor on error.
  */
 int
-xnvme_be_cref_cleanup(const char *be_name);
+xnvme_be_cref_cleanup(void);
 
 #endif /* __INTERNAL_XNVME_BE_CREF_H */

--- a/include/xnvme_be_cref.h
+++ b/include/xnvme_be_cref.h
@@ -45,24 +45,6 @@ xnvme_be_cref_insert(const char *uri, const char *be_name, void *ctrlr,
 		     xnvme_be_cref_destructor_fn destructor);
 
 /**
- * Combined lookup-or-insert
- *
- * If an entry with matching @uri exists, increment its refcount and return the
- * stored handle. Otherwise, if @ctrlr is non-NULL, insert it with refcount=1
- * and associate it with @be_name and @destructor.
- *
- * @param uri Device URI to match or insert
- * @param be_name Backend name pointer, stored for filtering in xnvme_be_cref_cleanup()
- * @param ctrlr Controller handle to insert if no match is found, may be NULL for lookup-only
- * @param destructor Callback invoked to destroy the controller when refcount reaches zero
- *
- * @return On success, the controller handle. On error, NULL.
- */
-void *
-xnvme_be_cref_ref(const char *uri, const char *be_name, void *ctrlr,
-		  xnvme_be_cref_destructor_fn destructor);
-
-/**
  * Decrement the refcount for the given controller
  *
  * If the refcount reaches zero and XNVME_BE_CREF_DESTROY_IMMEDIATE is set,

--- a/include/xnvme_be_nosys.h
+++ b/include/xnvme_be_nosys.h
@@ -69,10 +69,6 @@ int
 xnvme_be_nosys_mem_unmap(const struct xnvme_dev *dev, void *buf);
 
 int
-xnvme_be_nosys_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enumerate_cb cb_func,
-			 void *cb_args);
-
-int
 xnvme_be_nosys_dev_open(struct xnvme_dev *dev);
 
 void
@@ -113,7 +109,6 @@ xnvme_be_nosys_dev_close(struct xnvme_dev *dev);
 
 #define XNVME_BE_NOSYS_DEV                              \
 	{                                               \
-		.enumerate  = xnvme_be_nosys_enumerate, \
 		.dev_open   = xnvme_be_nosys_dev_open,  \
 		.dev_close  = xnvme_be_nosys_dev_close, \
 		.id         = "nosys",                  \

--- a/include/xnvme_be_spdk.h
+++ b/include/xnvme_be_spdk.h
@@ -39,20 +39,21 @@ XNVME_STATIC_ASSERT(sizeof(struct spdk_nvme_ns_data) == sizeof(struct xnvme_spec
 		    "Incorrect size")
 
 struct xnvme_be_spdk_state {
-	union {
-		pthread_mutex_t qpair_lock; ///< LOCK for SYNC IO commands
-		uint8_t _fill[64];
-	};
-	struct spdk_nvme_qpair *qpair; ///< QPAIR for SYNC IO commands
-
-	struct spdk_nvme_ctrlr *ctrlr; ///< Pointer to attached controller
+	struct spdk_nvme_ctrlr *ctrlr; ///< Pointer to attached controller (must be first: platform
+				       ///< stores ctrlr at state[0])
 	struct spdk_nvme_ns *ns;       ///< Pointer to associated namespace
+	struct spdk_nvme_qpair *qpair; ///< QPAIR for SYNC IO commands
 
 	uint8_t attached;
 
 	uint8_t _rsvd[7];
 
 	struct xnvme_be_spdk_iov_payload payload;
+
+	union {
+		pthread_mutex_t qpair_lock; ///< LOCK for SYNC IO commands
+		uint8_t _fill[64];
+	};
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_be_spdk_state) == XNVME_BE_STATE_NBYTES, "Incorrect size")
 

--- a/include/xnvme_platform.h
+++ b/include/xnvme_platform.h
@@ -28,7 +28,8 @@ typedef int (*xnvme_scan_cb)(const struct xnvme_ident *ident, void *cb_args);
  * @param dev Opened device handle (caller must close with xnvme_dev_close())
  * @param cb_args User-provided callback arguments
  *
- * @return On success, 0 is returned. On error, negative `errno` is returned.
+ * @return XNVME_ENUMERATE_DEV_KEEP_OPEN to retain the device handle, or
+ *         XNVME_ENUMERATE_DEV_CLOSE to close it after the callback returns.
  */
 typedef int (*xnvme_enumerate_cb)(struct xnvme_dev *dev, void *cb_args);
 
@@ -70,8 +71,8 @@ xnvme_platform_dev_open(struct xnvme_dev *dev, struct xnvme_opts *opts);
  * Shared enumerate implementation using scan + dev_open
  *
  * When sys_uri is NULL, uses platform scan to discover local devices, opens each,
- * and invokes the callback. When sys_uri is provided (fabrics), delegates to the
- * first backend that implements enumerate.
+ * and invokes the callback. When sys_uri is provided (fabrics), delegates to
+ * enumerate_controller to iterate namespaces on the target controller.
  *
  * @param sys_uri NULL for local devices, or fabrics URI for discovery
  * @param opts Options for dev_open (may be NULL for defaults)

--- a/lib/upcie/xnvme_be_upcie.h
+++ b/lib/upcie/xnvme_be_upcie.h
@@ -71,9 +71,6 @@ void
 xnvme_be_upcie_dev_close(struct xnvme_dev *dev);
 int
 xnvme_be_upcie_dev_open(struct xnvme_dev *dev);
-int
-xnvme_be_upcie_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enumerate_cb cb_func,
-			 void *cb_args);
 void *
 xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev);
 int

--- a/lib/upcie/xnvme_be_upcie_cuda_dev.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_dev.c
@@ -154,14 +154,12 @@ xnvme_be_upcie_cuda_ctrlr_init(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_upcie_cuda_dev = {
 #ifdef XNVME_BE_UPCIE_CUDA_ENABLED
-	.enumerate = xnvme_be_upcie_enumerate,
 	.dev_open = xnvme_be_upcie_dev_open,
 	.dev_close = xnvme_be_upcie_dev_close,
 	.id = "upcie-cuda",
 	.ctrlr_init = xnvme_be_upcie_cuda_ctrlr_init,
 	.ctrlr_term = xnvme_be_upcie_cuda_ctrlr_term,
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 #endif

--- a/lib/upcie/xnvme_be_upcie_dev.c
+++ b/lib/upcie/xnvme_be_upcie_dev.c
@@ -13,12 +13,6 @@
 
 static _Atomic int g_ctrlr_count;
 
-struct xnvme_be_upcie_enumerate_context {
-	struct xnvme_opts *opts;
-	xnvme_enumerate_cb cb_func;
-	void *cb_args;
-};
-
 int
 xnvme_be_upcie_get_driver_name(const char *bdf, char *driver_name, size_t driver_name_len)
 {
@@ -277,68 +271,16 @@ xnvme_be_upcie_dev_open(struct xnvme_dev *dev)
 	return 0;
 }
 
-static int
-_instantiate(struct pci_func *func, void *callback_arg)
-{
-	struct xnvme_be_upcie_enumerate_context *ectx = callback_arg;
-	struct xnvme_opts opts = *ectx->opts;
-	struct xnvme_dev *dev = NULL;
-
-	if (!(((func->ident.classcode >> 8) & 0xFFFF) == 0x0108)) {
-		return PCI_SCAN_ACTION_RELEASE_FUNC;
-	}
-
-	opts.be = "upcie";
-
-	dev = xnvme_dev_open(func->bdf, &opts);
-	if (!dev) {
-		XNVME_DEBUG("xnvme_dev_open(); errno()")
-		return PCI_SCAN_ACTION_RELEASE_FUNC;
-	}
-
-	if (ectx->cb_func(dev, ectx->cb_args)) {
-		xnvme_dev_close(dev);
-		return PCI_SCAN_ACTION_RELEASE_FUNC;
-	}
-
-	return PCI_SCAN_ACTION_CLAIM_FUNC;
-}
-
-int
-xnvme_be_upcie_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enumerate_cb cb_func,
-			 void *cb_args)
-{
-	struct xnvme_be_upcie_enumerate_context ectx = {0};
-	int err;
-
-	if (sys_uri) {
-		XNVME_DEBUG("FAILED: does not support 'sys_uri'");
-		return -ENOSYS;
-	}
-
-	ectx.opts = opts;
-	ectx.cb_func = cb_func;
-	ectx.cb_args = cb_args;
-
-	err = pci_scan(_instantiate, &ectx);
-	if (err) {
-		perror("pci_scan()");
-	}
-
-	return 0;
-}
 #endif
 
 struct xnvme_be_dev g_xnvme_be_upcie_dev = {
 #ifdef XNVME_BE_UPCIE_ENABLED
-	.enumerate = xnvme_be_upcie_enumerate,
 	.dev_open = xnvme_be_upcie_dev_open,
 	.dev_close = xnvme_be_upcie_dev_close,
 	.id = "upcie",
 	.ctrlr_init = xnvme_be_upcie_ctrlr_init,
 	.ctrlr_term = xnvme_be_upcie_ctrlr_term,
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_be_cref.c
+++ b/lib/xnvme_be_cref.c
@@ -17,19 +17,6 @@ struct xnvme_be_cref_entry {
 
 static struct xnvme_be_cref_entry g_cref_table[XNVME_BE_CREF_MAX_ENTRIES];
 
-static int
-_entry_matches(const struct xnvme_be_cref_entry *entry, const char *uri, const char *be_name)
-{
-	if (strncmp(entry->uri, uri, XNVME_IDENT_URI_LEN)) {
-		return 0;
-	}
-	if (be_name && (!entry->be_name || strcmp(entry->be_name, be_name))) {
-		return 0;
-	}
-
-	return 1;
-}
-
 void *
 xnvme_be_cref_lookup(const char *uri, const char **be_name)
 {
@@ -83,56 +70,6 @@ xnvme_be_cref_insert(const char *uri, const char *be_name, void *ctrlr,
 
 	XNVME_DEBUG("FAILED: out of slots");
 	return -ENOMEM;
-}
-
-void *
-xnvme_be_cref_ref(const char *uri, const char *be_name, void *ctrlr,
-		  xnvme_be_cref_destructor_fn destructor)
-{
-	int free_pos = -1;
-
-	for (int i = 0; i < XNVME_BE_CREF_MAX_ENTRIES; ++i) {
-		if (!g_cref_table[i].ctrlr) {
-			if (free_pos < 0) {
-				free_pos = i;
-			}
-			continue;
-		}
-		if (!_entry_matches(&g_cref_table[i], uri, be_name)) {
-			continue;
-		}
-		if (g_cref_table[i].refcount < 0) {
-			XNVME_DEBUG("FAILED: corrupted refcount");
-			return NULL;
-		}
-		if (ctrlr != NULL && ctrlr != g_cref_table[i].ctrlr) {
-			XNVME_DEBUG("FAILED: multiple ctrlr with same ident");
-			return NULL;
-		}
-
-		g_cref_table[i].refcount += 1;
-
-		return g_cref_table[i].ctrlr;
-	}
-
-	if (!ctrlr) {
-		XNVME_DEBUG("FAILED: no matching ctrlr and no ctrlr provided");
-		return NULL;
-	}
-
-	if (free_pos < 0) {
-		XNVME_DEBUG("FAILED: out of slots");
-		return NULL;
-	}
-
-	g_cref_table[free_pos].ctrlr = ctrlr;
-	g_cref_table[free_pos].destructor = destructor;
-	g_cref_table[free_pos].be_name = be_name;
-	g_cref_table[free_pos].refcount = 1;
-	strncpy(g_cref_table[free_pos].uri, uri, XNVME_IDENT_URI_LEN);
-	g_cref_table[free_pos].uri[XNVME_IDENT_URI_LEN] = '\0';
-
-	return g_cref_table[free_pos].ctrlr;
 }
 
 int

--- a/lib/xnvme_be_cref.c
+++ b/lib/xnvme_be_cref.c
@@ -12,6 +12,7 @@ struct xnvme_be_cref_entry {
 	xnvme_be_cref_destructor_fn destructor;
 	const char *be_name;
 	int refcount;
+	int deferred;
 	char uri[XNVME_IDENT_URI_LEN + 1];
 };
 
@@ -54,7 +55,7 @@ xnvme_be_cref_insert(const char *uri, const char *be_name, void *ctrlr,
 	}
 
 	for (int i = 0; i < XNVME_BE_CREF_MAX_ENTRIES; ++i) {
-		if (g_cref_table[i].refcount) {
+		if (g_cref_table[i].ctrlr) {
 			continue;
 		}
 
@@ -73,7 +74,28 @@ xnvme_be_cref_insert(const char *uri, const char *be_name, void *ctrlr,
 }
 
 int
-xnvme_be_cref_deref(void *ctrlr, enum xnvme_be_cref_flags flags)
+xnvme_be_cref_defer(void *ctrlr)
+{
+	if (!ctrlr) {
+		XNVME_DEBUG("FAILED: !ctrlr");
+		return -EINVAL;
+	}
+
+	for (int i = 0; i < XNVME_BE_CREF_MAX_ENTRIES; ++i) {
+		if (g_cref_table[i].ctrlr != ctrlr) {
+			continue;
+		}
+
+		g_cref_table[i].deferred = 1;
+		return 0;
+	}
+
+	XNVME_DEBUG("FAILED: no tracking for %p", ctrlr);
+	return -EINVAL;
+}
+
+int
+xnvme_be_cref_deref(void *ctrlr)
 {
 	if (!ctrlr) {
 		XNVME_DEBUG("FAILED: !ctrlr");
@@ -92,7 +114,7 @@ xnvme_be_cref_deref(void *ctrlr, enum xnvme_be_cref_flags flags)
 
 		g_cref_table[i].refcount -= 1;
 
-		if (g_cref_table[i].refcount == 0 && (flags & XNVME_BE_CREF_DESTROY_IMMEDIATE)) {
+		if (g_cref_table[i].refcount == 0 && !g_cref_table[i].deferred) {
 			int err = 0;
 
 			XNVME_DEBUG("INFO: refcount: %d => detaching", g_cref_table[i].refcount);
@@ -114,7 +136,7 @@ xnvme_be_cref_deref(void *ctrlr, enum xnvme_be_cref_flags flags)
 }
 
 int
-xnvme_be_cref_cleanup(const char *be_name)
+xnvme_be_cref_cleanup(void)
 {
 	int ret = 0;
 
@@ -123,27 +145,20 @@ xnvme_be_cref_cleanup(const char *be_name)
 			continue;
 		}
 
-		if (!be_name != !g_cref_table[i].be_name ||
-		    (be_name && strcmp(g_cref_table[i].be_name, be_name))) {
+		if (g_cref_table[i].refcount != 0) {
+			g_cref_table[i].deferred = 0;
 			continue;
 		}
 
-		if (g_cref_table[i].refcount < 0) {
-			XNVME_DEBUG("FAILED: invalid refcount: %d", g_cref_table[i].refcount);
-			continue;
-		}
-
-		if (g_cref_table[i].refcount == 0) {
-			XNVME_DEBUG("INFO: refcount: %d => detaching", g_cref_table[i].refcount);
-			if (g_cref_table[i].destructor) {
-				int err = g_cref_table[i].destructor(g_cref_table[i].ctrlr);
-				if (err) {
-					XNVME_DEBUG("FAILED: destructor(): %d", err);
-					ret = err;
-				}
+		XNVME_DEBUG("INFO: cleaning up refcount=0 entry for %p", g_cref_table[i].ctrlr);
+		if (g_cref_table[i].destructor) {
+			int err = g_cref_table[i].destructor(g_cref_table[i].ctrlr);
+			if (err) {
+				XNVME_DEBUG("FAILED: destructor(): %d", err);
+				ret = err;
 			}
-			memset(&g_cref_table[i], 0, sizeof(g_cref_table[i]));
 		}
+		memset(&g_cref_table[i], 0, sizeof(g_cref_table[i]));
 	}
 
 	return ret;

--- a/lib/xnvme_be_cref.c
+++ b/lib/xnvme_be_cref.c
@@ -19,7 +19,7 @@ struct xnvme_be_cref_entry {
 static struct xnvme_be_cref_entry g_cref_table[XNVME_BE_CREF_MAX_ENTRIES];
 
 void *
-xnvme_be_cref_lookup(const char *uri, const char **be_name)
+xnvme_be_cref_get(const char *uri, const char **be_name)
 {
 	for (int i = 0; i < XNVME_BE_CREF_MAX_ENTRIES; ++i) {
 		if (!g_cref_table[i].ctrlr) {
@@ -95,7 +95,7 @@ xnvme_be_cref_defer(void *ctrlr)
 }
 
 int
-xnvme_be_cref_deref(void *ctrlr)
+xnvme_be_cref_put(void *ctrlr)
 {
 	if (!ctrlr) {
 		XNVME_DEBUG("FAILED: !ctrlr");

--- a/lib/xnvme_be_cref.c
+++ b/lib/xnvme_be_cref.c
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include <libxnvme.h>
 #include <string.h>
 #include <errno.h>
 #include <xnvme_be_cref.h>
@@ -30,13 +31,13 @@ _entry_matches(const struct xnvme_be_cref_entry *entry, const char *uri, const c
 }
 
 void *
-xnvme_be_cref_lookup(const char *uri, const char *be_name)
+xnvme_be_cref_lookup(const char *uri, const char **be_name)
 {
 	for (int i = 0; i < XNVME_BE_CREF_MAX_ENTRIES; ++i) {
 		if (!g_cref_table[i].ctrlr) {
 			continue;
 		}
-		if (!_entry_matches(&g_cref_table[i], uri, be_name)) {
+		if (strncmp(g_cref_table[i].uri, uri, XNVME_IDENT_URI_LEN)) {
 			continue;
 		}
 		if (g_cref_table[i].refcount < 1) {
@@ -45,6 +46,10 @@ xnvme_be_cref_lookup(const char *uri, const char *be_name)
 		}
 
 		g_cref_table[i].refcount += 1;
+
+		if (be_name) {
+			*be_name = g_cref_table[i].be_name;
+		}
 
 		return g_cref_table[i].ctrlr;
 	}

--- a/lib/xnvme_be_fbsd_dev.c
+++ b/lib/xnvme_be_fbsd_dev.c
@@ -160,12 +160,10 @@ xnvme_be_fbsd_dev_open(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_fbsd_dev = {
 #ifdef XNVME_PLATFORM_FREEBSD_ENABLED
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_fbsd_dev_open,
 	.dev_close = xnvme_be_fbsd_dev_close,
 	.id = "freebsd",
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_be_linux_dev.c
+++ b/lib/xnvme_be_linux_dev.c
@@ -189,12 +189,10 @@ xnvme_be_linux_dev_close(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_dev_linux = {
 #ifdef XNVME_PLATFORM_LINUX_ENABLED
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_linux_dev_open,
 	.dev_close = xnvme_be_linux_dev_close,
 	.id = "linux",
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_be_macos_dev.c
+++ b/lib/xnvme_be_macos_dev.c
@@ -228,12 +228,10 @@ xnvme_be_macos_dev_open(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_macos_dev = {
 #ifdef XNVME_PLATFORM_MACOS_ENABLED
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_macos_dev_open,
 	.dev_close = xnvme_be_macos_dev_close,
 	.id = "macos",
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_be_macos_driverkit_dev.c
+++ b/lib/xnvme_be_macos_driverkit_dev.c
@@ -202,14 +202,12 @@ xnvme_be_macos_driverkit_dev_open(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_macos_driverkit_dev = {
 #ifdef XNVME_PLATFORM_MACOS_ENABLED
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_macos_driverkit_dev_open,
 	.dev_close = xnvme_be_macos_driverkit_dev_close,
 	.id = "driverkit",
 	.ctrlr_init = xnvme_be_macos_driverkit_ctrlr_init,
 	.ctrlr_term = xnvme_be_macos_driverkit_ctrlr_term,
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_be_nosys.c
+++ b/lib/xnvme_be_nosys.c
@@ -162,14 +162,6 @@ xnvme_be_nosys_mem_unmap(const struct xnvme_dev *XNVME_UNUSED(dev), void *XNVME_
 }
 
 int
-xnvme_be_nosys_enumerate(const char *XNVME_UNUSED(sys_uri), struct xnvme_opts *XNVME_UNUSED(opts),
-			 xnvme_enumerate_cb XNVME_UNUSED(cb_func), void *XNVME_UNUSED(cb_args))
-{
-	XNVME_DEBUG("FAILED: not implemented(possibly intentional)");
-	return -ENOSYS;
-}
-
-int
 xnvme_be_nosys_dev_open(struct xnvme_dev *XNVME_UNUSED(dev))
 {
 	XNVME_DEBUG("FAILED: not implemented(possibly intentional)");

--- a/lib/xnvme_be_ramdisk_dev.c
+++ b/lib/xnvme_be_ramdisk_dev.c
@@ -87,12 +87,10 @@ xnvme_be_ramdisk_dev_open(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_ramdisk_dev = {
 #ifdef XNVME_BE_RAMDISK_ENABLED
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_ramdisk_dev_open,
 	.dev_close = xnvme_be_ramdisk_dev_close,
 	.id = "ramdisk",
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_be_spdk_dev.c
+++ b/lib/xnvme_be_spdk_dev.c
@@ -24,19 +24,6 @@
 #define XNVME_BE_SPDK_MAX_PROBE_ATTEMPTS 1
 #define XNVME_BE_SPDK_AVLB_TRANSPORTS 3
 
-static int
-_spdk_ctrlr_destructor(void *ctrlr)
-{
-	int err;
-
-	err = spdk_nvme_detach((struct spdk_nvme_ctrlr *)ctrlr);
-	if (err) {
-		XNVME_DEBUG("FAILED: spdk_nvme_detach()");
-	}
-
-	return err;
-}
-
 static int g_xnvme_be_spdk_transport[] = {
 #ifdef XNVME_BE_SPDK_TRANSPORT_PCIE_ENABLED
 	SPDK_NVME_TRANSPORT_PCIE,
@@ -361,8 +348,12 @@ timeout_cb_func(void *XNVME_UNUSED(cb_arg), struct spdk_nvme_ctrlr *ctrlr,
 }
 
 /**
- * Sets up the state{ns, ctrlr, attached} given via the cb_ctx
- * detached if dev->nsid is not a match
+ * Records the attached controller in state so ctrlr_init can return it.
+ *
+ * When nsid is set, rejects controllers that do not have the requested namespace active.
+ * This is needed for NVMe-oF auto-discovery, where SPDK may call attach_cb for both
+ * the discovery controller and the actual NVM subsystem controllers; we must skip the
+ * discovery controller (which has no data namespaces) and wait for the right one.
  */
 static void
 attach_cb(void *cb_ctx, const struct spdk_nvme_transport_id *trid, struct spdk_nvme_ctrlr *ctrlr,
@@ -371,78 +362,64 @@ attach_cb(void *cb_ctx, const struct spdk_nvme_transport_id *trid, struct spdk_n
 	struct xnvme_dev *dev = cb_ctx;
 	struct xnvme_opts *opts = &dev->opts;
 	struct xnvme_be_spdk_state *state = (void *)dev->be.state;
-	struct spdk_nvme_ns *ns = NULL;
 
-	XNVME_DEBUG("INFO: nsid: %d", opts->nsid);
+	if (state->attached) {
+		XNVME_DEBUG("SKIP: Already attached");
+		spdk_nvme_detach(ctrlr);
+		return;
+	}
 
 	if (opts->nsid) {
-		ns = spdk_nvme_ctrlr_get_ns(ctrlr, opts->nsid);
-		if (!ns) {
-			XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_get_ns(0x%x)", opts->nsid);
-			spdk_nvme_detach(ctrlr);
-			return;
-		}
-		if (!spdk_nvme_ns_is_active(ns)) {
-			XNVME_DEBUG("FAILED: !spdk_nvme_ns_is_active(opts->nsid:0x%x)",
+		struct spdk_nvme_ns *ns = spdk_nvme_ctrlr_get_ns(ctrlr, opts->nsid);
+		if (!ns || !spdk_nvme_ns_is_active(ns)) {
+			XNVME_DEBUG("SKIP: nsid 0x%x not found or inactive on this controller",
 				    opts->nsid);
 			spdk_nvme_detach(ctrlr);
 			return;
 		}
-		state->ns = ns;
 	}
 
 	state->ctrlr = ctrlr;
 	state->attached = 1;
 	opts->spdk_fabrics = trid->trtype > SPDK_NVME_TRANSPORT_PCIE;
-
-	if (!xnvme_be_cref_ref(dev->ident.uri, g_xnvme_be_spdk.attr.name, state->ctrlr,
-			       _spdk_ctrlr_destructor)) {
-		XNVME_DEBUG("FAILED: xnvme_be_cref_ref()");
-		return;
-	}
-	if (opts->command_timeout > 0 && opts->admin_timeout > 0) {
-		spdk_nvme_ctrlr_register_timeout_callback(ctrlr, opts->command_timeout,
-							  opts->admin_timeout, timeout_cb_func, 0);
-	}
 }
 
-void
-xnvme_be_spdk_state_term(struct xnvme_be_spdk_state *state)
+static int
+xnvme_be_spdk_ctrlr_term(void *ctrlr)
 {
-	int err;
-
-	if (!state) {
-		return;
-	}
-	if (state->qpair) {
-		spdk_nvme_qp_failure_reason reason;
-		reason = spdk_nvme_qpair_get_failure_reason(state->qpair);
-		if (reason) {
-			// the qpair has already disconnected
-			XNVME_DEBUG("WARNING: qpair in failed state, reason: %d", reason);
-		} else {
-			spdk_nvme_ctrlr_free_io_qpair(state->qpair);
-		}
-		err = pthread_mutex_destroy(&state->qpair_lock);
-		if (err) {
-			printf("UNHANDLED: pthread_mutex_destroy(): '%s'\n", strerror(err));
-		}
-	}
-	err = xnvme_be_cref_deref(state->ctrlr, XNVME_BE_CREF_DESTROY_IMMEDIATE);
+	int err = spdk_nvme_detach((struct spdk_nvme_ctrlr *)ctrlr);
 	if (err) {
-		XNVME_DEBUG("FAILED: xnvme_be_cref_deref():, err: %d", err);
+		XNVME_DEBUG("FAILED: spdk_nvme_detach()");
 	}
+	return err;
 }
 
 void
 xnvme_be_spdk_dev_close(struct xnvme_dev *dev)
 {
+	struct xnvme_be_spdk_state *state = (void *)dev->be.state;
+	spdk_nvme_qp_failure_reason reason;
+	int err;
+
 	if (!dev) {
 		return;
 	}
 
-	xnvme_be_spdk_state_term((void *)dev->be.state);
-	memset(&dev->be, 0, sizeof(dev->be));
+	if (!state->qpair) {
+		return;
+	}
+
+	reason = spdk_nvme_qpair_get_failure_reason(state->qpair);
+	if (reason) {
+		XNVME_DEBUG("WARNING: qpair in failed state, reason: %d", reason);
+	} else {
+		spdk_nvme_ctrlr_free_io_qpair(state->qpair);
+	}
+
+	err = pthread_mutex_destroy(&state->qpair_lock);
+	if (err) {
+		printf("UNHANDLED: pthread_mutex_destroy(): '%s'\n", strerror(err));
+	}
 }
 
 struct xnvme_be_spdk_enumerate_ctx {
@@ -528,7 +505,7 @@ enumerate_attach_cb(void *cb_ctx, const struct spdk_nvme_transport_id *trid,
 
 		// Save the reference to ctrlr so it can be reused when we call xnvme_dev_open()
 		if (!xnvme_be_cref_ref(ident.uri, g_xnvme_be_spdk.attr.name, ctrlr,
-				       _spdk_ctrlr_destructor)) {
+				       xnvme_be_spdk_ctrlr_term)) {
 			XNVME_DEBUG("FAILED: xnvme_be_cref_ref()");
 			return;
 		}
@@ -663,21 +640,18 @@ verify_ctrlr_ok(struct spdk_nvme_ctrlr *ctrlr)
 }
 
 /**
- * - Parse options from dev->ident
- * - Initialize SPDK environment
- * - Attach to controller matching dev->ident
- * - create sync-io-qpair
- * - create lock protecting sync-io-qpair
+ * Initialize a new SPDK controller for the device URI.
+ *
+ * Inits the SPDK environment, if needed, and probes for a device matching the URI.
  */
-int
-xnvme_be_spdk_state_init(struct xnvme_dev *dev)
+static void *
+xnvme_be_spdk_ctrlr_init(struct xnvme_dev *dev)
 {
 	struct xnvme_be_spdk_state *state = (void *)dev->be.state;
 	struct spdk_env_opts env_opts = {0};
 	int err;
 
 	spdk_env_opts_init(&env_opts);
-
 	if (dev->opts.core_mask) {
 		XNVME_DEBUG("INFO: multi-process setup");
 		env_opts.shm_id = dev->opts.shm_id;
@@ -688,74 +662,15 @@ xnvme_be_spdk_state_init(struct xnvme_dev *dev)
 	err = _spdk_env_init(&env_opts);
 	if (err) {
 		XNVME_DEBUG("FAILED: _spdk_env_init(), err: %d", err);
-		return err;
+		return NULL;
 	}
 
-	state->ctrlr = xnvme_be_cref_ref(dev->ident.uri, g_xnvme_be_spdk.attr.name, NULL,
-					 _spdk_ctrlr_destructor);
-	if (state->ctrlr) {
-		struct spdk_nvme_ns *ns;
-
-		XNVME_DEBUG("INFO: found dev->ident.uri: '%s' via cref_lookup()", dev->ident.uri);
-
-		int err = verify_ctrlr_ok(state->ctrlr);
-		if (err < 0) {
-			XNVME_DEBUG("FAILED: verify_ctrlr_ok, err: %d", err);
-		}
-		if (err || spdk_nvme_ctrlr_is_failed(state->ctrlr)) {
-			err = reconnect_ctrlr(state->ctrlr);
-			if (err < 0) {
-				if (xnvme_be_cref_deref(state->ctrlr,
-							XNVME_BE_CREF_DESTROY_IMMEDIATE)) {
-					XNVME_DEBUG("FAILED: xnvme_be_cref_deref");
-				}
-				return -EBUSY;
-			}
-		}
-
-		err = spdk_nvme_ctrlr_process_admin_completions(state->ctrlr);
-		if (err < 0) {
-			XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_process_admin_completions, err: %d",
-				    err);
-			if (xnvme_be_cref_deref(state->ctrlr, XNVME_BE_CREF_DESTROY_IMMEDIATE)) {
-				XNVME_DEBUG("FAILED: xnvme_be_cref_deref");
-			}
-			return -EBUSY;
-		}
-
-		if (dev->opts.nsid) {
-			ns = spdk_nvme_ctrlr_get_ns(state->ctrlr, dev->opts.nsid);
-			if (!ns) {
-				XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_get_ns(0x%x)",
-					    dev->opts.nsid);
-				if (xnvme_be_cref_deref(state->ctrlr,
-							XNVME_BE_CREF_DESTROY_IMMEDIATE)) {
-					XNVME_DEBUG("FAILED: xnvme_be_cref_deref");
-				}
-				return -EBUSY;
-			}
-			if (!spdk_nvme_ns_is_active(ns)) {
-				XNVME_DEBUG("FAILED: !spdk_nvme_ns_is_active(nsid:0x%x)",
-					    dev->opts.nsid);
-				if (xnvme_be_cref_deref(state->ctrlr,
-							XNVME_BE_CREF_DESTROY_IMMEDIATE)) {
-					XNVME_DEBUG("FAILED: xnvme_be_cref_deref");
-				}
-				return -EBUSY;
-			}
-			state->ns = ns;
-		}
-		state->attached = 1;
-		XNVME_DEBUG("INFO: re-using previously attached controller");
-	}
-
-	// Probe for device matching dev->ident
 	for (int i = 0; !state->attached; ++i) {
 		if (XNVME_BE_SPDK_MAX_PROBE_ATTEMPTS == i) {
 			XNVME_DEBUG("FAILED: max attempts exceeded");
-			return -ENXIO;
+			errno = ENXIO;
+			return NULL;
 		}
-
 		for (int t = 0; t < g_xnvme_be_spdk_ntransport; ++t) {
 			int trtype = g_xnvme_be_spdk_transport[t];
 			struct spdk_nvme_transport_id trid = {0};
@@ -771,51 +686,83 @@ xnvme_be_spdk_state_init(struct xnvme_dev *dev)
 			}
 
 			err = spdk_nvme_probe(&trid, dev, probe_cb, attach_cb, NULL);
-			if ((err) || (!state->attached)) {
+			if (err || !state->attached) {
 				XNVME_DEBUG("FAILED: probe a:%d, e:%d, i:%d", state->attached, err,
 					    i);
 			}
 		}
 	}
 
+	XNVME_DEBUG("INFO: ctrlr_init() OK");
+	return state->ctrlr;
+}
+
+int
+xnvme_be_spdk_dev_open(struct xnvme_dev *dev)
+{
+	struct xnvme_be_spdk_state *state = (void *)dev->be.state;
+	int err;
+
+	// ctrlr is at state->ctrlr, placed there by platform (cref reuse or ctrlr_init).
+	// On cref reuse, state->attached is 0 (fresh state); verify health before setting up a new
+	// qpair. On fresh ctrlr_init, attach_cb sets state->attached=1 and we skip verification.
+	if (!state->attached) {
+		int check = verify_ctrlr_ok(state->ctrlr);
+		if (check < 0) {
+			XNVME_DEBUG("FAILED: verify_ctrlr_ok, err: %d", check);
+		}
+		if (check < 0 || spdk_nvme_ctrlr_is_failed(state->ctrlr)) {
+			if (reconnect_ctrlr(state->ctrlr) < 0) {
+				return -EBUSY;
+			}
+		}
+		err = spdk_nvme_ctrlr_process_admin_completions(state->ctrlr);
+		if (err < 0) {
+			XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_process_admin_completions, err: %d",
+				    err);
+			return -EBUSY;
+		}
+	}
+
 	dev->ident.dtype =
 		dev->opts.nsid ? XNVME_DEV_TYPE_NVME_NAMESPACE : XNVME_DEV_TYPE_NVME_CONTROLLER;
-	if (state->ns) {
-		dev->ident.csi = spdk_nvme_ns_get_csi(state->ns);
-	}
 	dev->ident.nsid = dev->opts.nsid;
 
-	// Setup IO qpair lock for SYNC commands
+	if (dev->opts.nsid) {
+		struct spdk_nvme_ns *ns = spdk_nvme_ctrlr_get_ns(state->ctrlr, dev->opts.nsid);
+		if (!ns) {
+			XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_get_ns(0x%x)", dev->opts.nsid);
+			return -EBUSY;
+		}
+		if (!spdk_nvme_ns_is_active(ns)) {
+			XNVME_DEBUG("FAILED: !spdk_nvme_ns_is_active(nsid:0x%x)", dev->opts.nsid);
+			return -EBUSY;
+		}
+		state->ns = ns;
+		dev->ident.csi = spdk_nvme_ns_get_csi(ns);
+	}
+
+	if (dev->opts.command_timeout > 0 && dev->opts.admin_timeout > 0) {
+		spdk_nvme_ctrlr_register_timeout_callback(state->ctrlr, dev->opts.command_timeout,
+							  dev->opts.admin_timeout, timeout_cb_func,
+							  0);
+	}
+
 	err = pthread_mutex_init(&state->qpair_lock, NULL);
 	if (err) {
 		XNVME_DEBUG("FAILED: pthread_mutex_init(): '%s'", strerror(err));
 		return -err;
 	}
 
-	// Setup IO qpair for SYNC commands
 	state->qpair = spdk_nvme_ctrlr_alloc_io_qpair(state->ctrlr, NULL, 0);
 	if (!state->qpair) {
 		XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_alloc_io_qpair()");
+		pthread_mutex_destroy(&state->qpair_lock);
 		return -ENOMEM;
 	}
 
-	XNVME_DEBUG("INFO: open() : OK");
-
+	XNVME_DEBUG("INFO: dev_open() OK");
 	return 0;
-}
-
-int
-xnvme_be_spdk_dev_open(struct xnvme_dev *dev)
-{
-	int err;
-
-	err = xnvme_be_spdk_state_init(dev);
-	if (err) {
-		XNVME_DEBUG("FAILED: xnvme_be_spdk_state_init()");
-		return err;
-	}
-
-	return err;
 }
 #endif
 
@@ -825,6 +772,8 @@ struct xnvme_be_dev g_xnvme_be_spdk_dev = {
 	.dev_open = xnvme_be_spdk_dev_open,
 	.dev_close = xnvme_be_spdk_dev_close,
 	.id = "spdk",
+	.ctrlr_init = xnvme_be_spdk_ctrlr_init,
+	.ctrlr_term = xnvme_be_spdk_ctrlr_term,
 #else
 	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,

--- a/lib/xnvme_be_spdk_dev.c
+++ b/lib/xnvme_be_spdk_dev.c
@@ -18,7 +18,6 @@
 #include <xnvme_queue.h>
 #include <xnvme_be_spdk.h>
 #include <xnvme_be_registry.h>
-#include <xnvme_be_cref.h>
 #include <xnvme_dev.h>
 
 #define XNVME_BE_SPDK_MAX_PROBE_ATTEMPTS 1
@@ -422,168 +421,6 @@ xnvme_be_spdk_dev_close(struct xnvme_dev *dev)
 	}
 }
 
-struct xnvme_be_spdk_enumerate_ctx {
-	struct xnvme_opts *opts;
-	xnvme_enumerate_cb enumerate_cb;
-	void *cb_args;
-};
-
-/**
- * Always attach to supported transports such that `enumerate_probe_cb` can
- * grab namespaces
- *
- * And disable CMB sqs / cqs for now due to shared PMR / CMB
- */
-static bool
-enumerate_probe_cb(void *cb_ctx, const struct spdk_nvme_transport_id *trid,
-		   struct spdk_nvme_ctrlr_opts *ctrlr_opts)
-{
-	struct xnvme_be_spdk_enumerate_ctx *ectx = cb_ctx;
-	struct xnvme_opts *opts = ectx->opts;
-
-	return _spdk_setup_controller_opts(opts, trid, ctrlr_opts);
-}
-
-static void
-enumerate_attach_cb(void *cb_ctx, const struct spdk_nvme_transport_id *trid,
-		    struct spdk_nvme_ctrlr *ctrlr, const struct spdk_nvme_ctrlr_opts *ctrlr_opts)
-{
-	struct xnvme_be_spdk_enumerate_ctx *ectx = cb_ctx;
-
-	for (int nsid = spdk_nvme_ctrlr_get_first_active_ns(ctrlr); nsid;
-	     nsid = spdk_nvme_ctrlr_get_next_active_ns(ctrlr, nsid)) {
-		struct xnvme_opts opts = *ectx->opts;
-		struct xnvme_ident ident = {0};
-		struct xnvme_dev *dev = NULL;
-		struct spdk_nvme_ns *ns;
-		int err;
-
-		// Option options based on what the driver ended up using
-		// NOTE: we communicate the css via the dev->ident.csi
-		opts.use_cmb_sqs = ctrlr_opts->use_cmb_sqs;
-		opts.nsid = nsid;
-		opts.spdk_fabrics = trid->trtype > SPDK_NVME_TRANSPORT_PCIE;
-
-		if (!spdk_nvme_ctrlr_get_data(ctrlr)) {
-			XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_get_data");
-			continue;
-		}
-		ns = spdk_nvme_ctrlr_get_ns(ctrlr, nsid);
-		if (!ns) {
-			XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_get_ns(), for nsid: %d", nsid);
-			continue;
-		}
-		if (!spdk_nvme_ns_get_data(ns)) {
-			XNVME_DEBUG("FAILED: spdk_nvme_ns_get_data()");
-			continue;
-		}
-
-		ident.dtype = XNVME_DEV_TYPE_NVME_NAMESPACE;
-		ident.nsid = nsid;
-		ident.csi = spdk_nvme_ns_get_csi(ns);
-
-		// Namespace looks good, construct xNVMe identifier, and ..
-		switch (trid->trtype) {
-		case SPDK_NVME_TRANSPORT_PCIE:
-			snprintf(ident.uri, sizeof(ident.uri), "%s", trid->traddr);
-			break;
-
-		case SPDK_NVME_TRANSPORT_TCP:
-		case SPDK_NVME_TRANSPORT_RDMA:
-			snprintf(ident.uri, sizeof(ident.uri), "%s:%s", trid->traddr,
-				 trid->trsvcid);
-			break;
-
-		case SPDK_NVME_TRANSPORT_FC:
-		case SPDK_NVME_TRANSPORT_CUSTOM:
-		case SPDK_NVME_TRANSPORT_VFIOUSER:
-		case SPDK_NVME_TRANSPORT_CUSTOM_FABRICS:
-			XNVME_DEBUG("SKIP: ENOSYS trtype: %s",
-				    spdk_nvme_transport_id_trtype_str(trid->trtype));
-			continue;
-		}
-
-		// Save the reference to ctrlr so it can be reused when we call xnvme_dev_open()
-		if (!xnvme_be_cref_ref(ident.uri, g_xnvme_be_spdk.attr.name, ctrlr,
-				       xnvme_be_spdk_ctrlr_term)) {
-			XNVME_DEBUG("FAILED: xnvme_be_cref_ref()");
-			return;
-		}
-
-		dev = xnvme_dev_open(ident.uri, &opts);
-		if (!dev) {
-			XNVME_DEBUG("FAILED: xnvme_dev_open(), err: %d", errno);
-			return;
-		}
-		if (ectx->enumerate_cb(dev, ectx->cb_args)) {
-			xnvme_dev_close(dev);
-			err = xnvme_be_cref_deref(ctrlr, XNVME_BE_CREF_NONE);
-			if (err) {
-				XNVME_DEBUG("FAILED: xnvme_be_cref_deref():, err: %d", err);
-			}
-		}
-	}
-
-	xnvme_be_cref_cleanup(g_xnvme_be_spdk.attr.name);
-}
-
-int
-xnvme_be_spdk_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enumerate_cb cb_func,
-			void *cb_args)
-{
-	struct xnvme_be_spdk_enumerate_ctx ectx = {0};
-	char addr[SPDK_NVMF_TRADDR_MAX_LEN + 1] = {0};
-	struct xnvme_ident ident = {0};
-	int port = 0;
-
-	if (_spdk_env_init(NULL)) {
-		XNVME_DEBUG("FAILED: _spdk_env_init()");
-		return -ESRCH;
-	}
-	if (sys_uri) {
-		if (xnvme_ident_from_uri(sys_uri, &ident)) {
-			XNVME_DEBUG("FAILED: ident_from_uri, uri: %s", sys_uri);
-			return -EINVAL;
-		}
-		if (sscanf(ident.uri, "%[^:]:%d", addr, &port) != 2) {
-			XNVME_DEBUG("FAILED: malformed sys_uri: %s", sys_uri);
-			return -EINVAL;
-		}
-	}
-	XNVME_DEBUG("INFO: sys_uri: %s, addr: %s, port: %d", sys_uri ? sys_uri : "(null)", addr,
-		    port);
-
-	struct xnvme_opts tmp_opts = *opts;
-	tmp_opts.be = g_xnvme_be_spdk.attr.name;
-
-	ectx.opts = &tmp_opts;
-	ectx.enumerate_cb = cb_func;
-	ectx.cb_args = cb_args;
-
-	for (int t = 0; t < g_xnvme_be_spdk_ntransport; ++t) {
-		int trtype = g_xnvme_be_spdk_transport[t];
-		struct spdk_nvme_transport_id trid = {0};
-		int err;
-
-		XNVME_DEBUG("INFO: trtype: %s, # %d of %d",
-			    spdk_nvme_transport_id_trtype_str(trtype), t + 1,
-			    g_xnvme_be_spdk_ntransport);
-
-		err = _xnvme_be_spdk_ident_to_trid(&ident, opts, &trid, trtype);
-		if (err) {
-			XNVME_DEBUG("SKIP: !_xnvme_be_spdk_ident_to_trid()");
-			continue;
-		}
-
-		err = spdk_nvme_probe(&trid, &ectx, enumerate_probe_cb, enumerate_attach_cb, NULL);
-		if (err) {
-			XNVME_DEBUG("FAILED: spdk_nvme_probe(), err: %d", err);
-		}
-	}
-
-	return 0;
-}
-
 static void
 identify_cb(void *ctx, const struct spdk_nvme_cpl *cpl)
 {
@@ -757,14 +594,12 @@ xnvme_be_spdk_dev_open(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_spdk_dev = {
 #ifdef XNVME_BE_SPDK_ENABLED
-	.enumerate = xnvme_be_spdk_enumerate,
 	.dev_open = xnvme_be_spdk_dev_open,
 	.dev_close = xnvme_be_spdk_dev_close,
 	.id = "spdk",
 	.ctrlr_init = xnvme_be_spdk_ctrlr_init,
 	.ctrlr_term = xnvme_be_spdk_ctrlr_term,
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_be_spdk_dev.c
+++ b/lib/xnvme_be_spdk_dev.c
@@ -584,59 +584,58 @@ xnvme_be_spdk_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enum
 	return 0;
 }
 
-static int
-reconnect_ctrlr(struct spdk_nvme_ctrlr *ctrlr)
-{
-	int err;
-	XNVME_DEBUG("WARNING: attempting to reconnect controller");
-	err = spdk_nvme_ctrlr_reset(ctrlr);
-	if (err < 0) {
-		XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_reset, err: %d", err);
-		return -EBUSY;
-	}
-	XNVME_DEBUG("INFO: controller reconnected");
-	return 0;
-}
-
-void
-_identify_cb(void *ctx, const struct spdk_nvme_cpl *cpl)
+static void
+identify_cb(void *ctx, const struct spdk_nvme_cpl *cpl)
 {
 	int *result = (int *)ctx;
 	*result = cpl->status.sc;
 	if (*result != 0) {
-		XNVME_DEBUG("WARNING: bad identify, result: %d", *result);
+		XNVME_DEBUG("WARNING: bad identify, sct: %d, sc: %d", cpl->status.sct,
+			    cpl->status.sc);
 	}
 }
 
-/**
- * See if controller is able to handle a simple admin command if not then the ctrlr is in a bad
- * state
- */
 static int
 verify_ctrlr_ok(struct spdk_nvme_ctrlr *ctrlr)
 {
 	struct spdk_nvme_cmd cmd = {0};
-	int cmd_result = -1;
+	int cmd_result = -1, buf_size = 4096;
+	void *buf;
 	int err;
 
-	int buf_size = 4096;
-	void *buf;
+	err = spdk_nvme_ctrlr_is_failed(ctrlr);
+	if (err) {
+		XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_is_failed()");
+		return -EBUSY;
+	}
+
 	buf = spdk_dma_malloc(buf_size, 0, NULL);
+	if (!buf) {
+		XNVME_DEBUG("FAILED: spdk_dma_malloc()");
+		return -ENOMEM;
+	}
 	cmd.opc = SPDK_NVME_OPC_IDENTIFY;
 	cmd.cdw10_bits.identify.cns = SPDK_NVME_IDENTIFY_CTRLR;
-	spdk_nvme_ctrlr_cmd_admin_raw(ctrlr, &cmd, buf, buf_size, _identify_cb, &cmd_result);
+	err = spdk_nvme_ctrlr_cmd_admin_raw(ctrlr, &cmd, buf, buf_size, identify_cb, &cmd_result);
+	if (err) {
+		XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_cmd_admin_raw(), err: %d", err);
+		goto exit;
+	}
 	while (cmd_result == -1) {
 		err = spdk_nvme_ctrlr_process_admin_completions(ctrlr);
 		if (err < 0) {
-			XNVME_DEBUG(
-				"WARNING: spdk_nvme_ctrlr_process_admin_completions failed, %d",
-				err);
-			cmd_result = err;
-			break;
+			XNVME_DEBUG("WARNING: spdk_nvme_ctrlr_process_admin_completions() failed, "
+				    "err: %d",
+				    err);
+			goto exit;
 		}
 	}
+
+	err = cmd_result;
+
+exit:
 	spdk_dma_free(buf);
-	return cmd_result;
+	return err;
 }
 
 /**
@@ -707,19 +706,9 @@ xnvme_be_spdk_dev_open(struct xnvme_dev *dev)
 	// On cref reuse, state->attached is 0 (fresh state); verify health before setting up a new
 	// qpair. On fresh ctrlr_init, attach_cb sets state->attached=1 and we skip verification.
 	if (!state->attached) {
-		int check = verify_ctrlr_ok(state->ctrlr);
-		if (check < 0) {
-			XNVME_DEBUG("FAILED: verify_ctrlr_ok, err: %d", check);
-		}
-		if (check < 0 || spdk_nvme_ctrlr_is_failed(state->ctrlr)) {
-			if (reconnect_ctrlr(state->ctrlr) < 0) {
-				return -EBUSY;
-			}
-		}
-		err = spdk_nvme_ctrlr_process_admin_completions(state->ctrlr);
-		if (err < 0) {
-			XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_process_admin_completions, err: %d",
-				    err);
+		err = verify_ctrlr_ok(state->ctrlr);
+		if (err) {
+			XNVME_DEBUG("FAILED: verify_ctrlr_ok(), err: %d", err);
 			return -EBUSY;
 		}
 	}

--- a/lib/xnvme_be_vfio_dev.c
+++ b/lib/xnvme_be_vfio_dev.c
@@ -172,14 +172,12 @@ xnvme_be_vfio_dev_close(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_vfio_dev = {
 #ifdef XNVME_BE_VFIO_ENABLED
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_vfio_dev_open,
 	.dev_close = xnvme_be_vfio_dev_close,
 	.id = "libvfn",
 	.ctrlr_init = xnvme_be_vfio_ctrlr_init,
 	.ctrlr_term = xnvme_be_vfio_ctrlr_term,
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_be_windows_dev.c
+++ b/lib/xnvme_be_windows_dev.c
@@ -238,12 +238,10 @@ xnvme_be_windows_dev_close(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_dev_windows = {
 #ifdef XNVME_PLATFORM_WINDOWS_ENABLED
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_windows_dev_open,
 	.dev_close = xnvme_be_windows_dev_close,
 	.id = "windows",
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_dev.c
+++ b/lib/xnvme_dev.c
@@ -791,7 +791,7 @@ xnvme_dev_close(struct xnvme_dev *dev)
 		dev->be.dev.dev_close(dev);
 
 		if (dev->be.dev.ctrlr_term && ctrlr) {
-			xnvme_be_cref_deref(ctrlr, XNVME_BE_CREF_DESTROY_IMMEDIATE);
+			xnvme_be_cref_deref(ctrlr);
 		}
 	}
 

--- a/lib/xnvme_dev.c
+++ b/lib/xnvme_dev.c
@@ -791,7 +791,7 @@ xnvme_dev_close(struct xnvme_dev *dev)
 		dev->be.dev.dev_close(dev);
 
 		if (dev->be.dev.ctrlr_term && ctrlr) {
-			xnvme_be_cref_deref(ctrlr);
+			xnvme_be_cref_put(ctrlr);
 		}
 	}
 

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -96,7 +96,11 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 		}
 
 		((void **)be->state)[0] = ctrlr;
-		return 0;
+		err = be->dev.dev_open(dev);
+		if (err) {
+			xnvme_be_cref_deref(ctrlr, XNVME_BE_CREF_DESTROY_IMMEDIATE);
+		}
+		return err;
 	}
 
 	ctrlr = be->dev.ctrlr_init(dev);

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -83,7 +83,7 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 	int err;
 
 	if (!be->dev.ctrlr_init) {
-		return 0;
+		return be->dev.dev_open(dev);
 	}
 
 	ctrlr = xnvme_be_cref_lookup(dev->ident.uri, &be_name);
@@ -167,13 +167,6 @@ _dev_open_try_config(struct xnvme_dev *dev, const struct xnvme_be_config *cfg,
 	err = _dev_open_init_cref(dev, &dev->be, cfg);
 	if (err) {
 		return err;
-	}
-
-	if (!dev->be.dev.ctrlr_init) {
-		err = dev->be.dev.dev_open(dev);
-		if (err) {
-			return err;
-		}
 	}
 
 	XNVME_DEBUG("INFO: obtained device handle");

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -272,6 +272,7 @@ enumerate_controller(const char *uri, struct xnvme_opts *opts, xnvme_enumerate_c
 	struct xnvme_cmd_ctx ctx;
 	uint32_t nslist[XNVME_MAX_NS_LIST_SIZE];
 	size_t buf_size;
+	void *ctrlr;
 	int err;
 
 	ctrlr_opts.nsid = 0;
@@ -331,7 +332,13 @@ enumerate_controller(const char *uri, struct xnvme_opts *opts, xnvme_enumerate_c
 
 exit:
 	xnvme_buf_free(ctrlr_dev, idfy_buf);
+
+	ctrlr = ((void **)ctrlr_dev->be.state)[0];
+	if (ctrlr_dev->be.dev.ctrlr_term && ctrlr) {
+		xnvme_be_cref_defer(ctrlr);
+	}
 	xnvme_dev_close(ctrlr_dev);
+
 	return 0;
 }
 
@@ -406,6 +413,7 @@ xnvme_platform_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enu
 			 void *cb_args)
 {
 	struct xnvme_opts opts_default = xnvme_opts_default();
+	int err;
 
 	if (!opts) {
 		opts = &opts_default;
@@ -418,11 +426,14 @@ xnvme_platform_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enu
 			.cb_args = cb_args,
 		};
 
-		return g_xnvme_platform->scan(NULL, opts, enumerate_scan_cb, &ctx);
+		err = g_xnvme_platform->scan(NULL, opts, enumerate_scan_cb, &ctx);
+	} else {
+		/** Fabrics / explicit sys_uri: delegate directly to enumerate_controller */
+		err = enumerate_controller(sys_uri, opts, cb_func, cb_args);
 	}
 
-	/** Fabrics / explicit sys_uri: delegate directly to enumerate_controller */
-	return enumerate_controller(sys_uri, opts, cb_func, cb_args);
+	xnvme_be_cref_cleanup();
+	return err;
 }
 
 int

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -78,6 +78,7 @@ static int
 _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnvme_be_config *cfg)
 {
 	void *ctrlr = NULL;
+	const char *be_name = "";
 	int cref_inserted = 0;
 	int err;
 
@@ -85,21 +86,17 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 		return 0;
 	}
 
-	ctrlr = xnvme_be_cref_lookup(dev->ident.uri, cfg->attr.name);
+	ctrlr = xnvme_be_cref_lookup(dev->ident.uri, &be_name);
 	if (ctrlr) {
-		((void **)be->state)[0] = ctrlr;
-		return 0;
-	}
-
-	{
-		void *conflict = xnvme_be_cref_lookup(dev->ident.uri, NULL);
-
-		if (conflict) {
-			xnvme_be_cref_deref(conflict, XNVME_BE_CREF_NONE);
+		if (strcmp(be_name, cfg->attr.name)) {
+			xnvme_be_cref_deref(ctrlr, XNVME_BE_CREF_NONE);
 			XNVME_DEBUG("FAILED: uri '%s' claimed by another backend config",
 				    dev->ident.uri);
 			return -EBUSY;
 		}
+
+		((void **)be->state)[0] = ctrlr;
+		return 0;
 	}
 
 	ctrlr = be->dev.ctrlr_init(dev);

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -293,6 +293,7 @@ enumerate_controller(const char *uri, struct xnvme_opts *opts, xnvme_enumerate_c
 	if (err) {
 		XNVME_DEBUG("FAILED: xnvme_buf_clear(), err: %d", err);
 		xnvme_buf_free(ctrlr_dev, idfy_buf);
+		xnvme_dev_close(ctrlr_dev);
 		return err;
 	}
 

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -89,7 +89,7 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 	ctrlr = xnvme_be_cref_lookup(dev->ident.uri, &be_name);
 	if (ctrlr) {
 		if (strcmp(be_name, cfg->attr.name)) {
-			xnvme_be_cref_deref(ctrlr, XNVME_BE_CREF_NONE);
+			xnvme_be_cref_deref(ctrlr);
 			XNVME_DEBUG("FAILED: uri '%s' claimed by another backend config",
 				    dev->ident.uri);
 			return -EBUSY;
@@ -98,7 +98,7 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 		((void **)be->state)[0] = ctrlr;
 		err = be->dev.dev_open(dev);
 		if (err) {
-			xnvme_be_cref_deref(ctrlr, XNVME_BE_CREF_DESTROY_IMMEDIATE);
+			xnvme_be_cref_deref(ctrlr);
 		}
 		return err;
 	}
@@ -121,7 +121,7 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 
 	err = be->dev.dev_open(dev);
 	if (err && cref_inserted) {
-		xnvme_be_cref_deref(ctrlr, XNVME_BE_CREF_DESTROY_IMMEDIATE);
+		xnvme_be_cref_deref(ctrlr);
 	}
 
 	return err;

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -86,10 +86,10 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 		return be->dev.dev_open(dev);
 	}
 
-	ctrlr = xnvme_be_cref_lookup(dev->ident.uri, &be_name);
+	ctrlr = xnvme_be_cref_get(dev->ident.uri, &be_name);
 	if (ctrlr) {
 		if (strcmp(be_name, cfg->attr.name)) {
-			xnvme_be_cref_deref(ctrlr);
+			xnvme_be_cref_put(ctrlr);
 			XNVME_DEBUG("FAILED: uri '%s' claimed by another backend config",
 				    dev->ident.uri);
 			return -EBUSY;
@@ -98,7 +98,7 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 		((void **)be->state)[0] = ctrlr;
 		err = be->dev.dev_open(dev);
 		if (err) {
-			xnvme_be_cref_deref(ctrlr);
+			xnvme_be_cref_put(ctrlr);
 		}
 		return err;
 	}
@@ -121,7 +121,7 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 
 	err = be->dev.dev_open(dev);
 	if (err && cref_inserted) {
-		xnvme_be_cref_deref(ctrlr);
+		xnvme_be_cref_put(ctrlr);
 	}
 
 	return err;


### PR DESCRIPTION
Simplifies the controller reference-counting API and consolidates the
  enumerate path so backends no longer need to implement it themselves.

  ## cref API changes

  - `cref_lookup(uri, be_name)` → `cref_get(uri, &be_name)`: be_name is
    now an out-parameter rather than a filter, removing the need for a
    separate conflict-detection lookup.
  - `cref_deref(ctrlr, flags)` → `cref_put(ctrlr)`: flags removed;
    destroy-vs-defer is now controlled by explicit `cref_defer(ctrlr)`.
  - `cref_ref()` (combined lookup-or-insert) removed; callers use
    `cref_get` + `cref_insert` explicitly.
  - `cref_cleanup(be_name)` → `cref_cleanup(void)`: the be_name filter
    is no longer needed since deferred state is tracked per-entry.

  ## enumerate consolidation

  Removes the `enumerate` function pointer from `xnvme_be_dev` and all
  backend implementations. Local device enumeration was already handled
  by the platform scan path; fabrics enumeration now goes through
  `enumerate_controller` directly. This eliminates ~200 lines of
  duplicated SPDK-specific enumerate logic.

  ## SPDK backend refactoring

  Splits the old `state_init` / `state_term` into `ctrlr_init` /
  `ctrlr_term`, aligning SPDK with the libvfn and upcie pattern.
  `ctrlr_init` probes and returns the controller handle; namespace
  validation, timeout registration, and qpair setup move to `dev_open`.

  ## Bug fixes

  - `dev_open` was silently skipped on a same-name cref hit.
  - `ctrlr_dev` was not closed on `xnvme_buf_clear` failure in
    `enumerate_controller`.
  - RTE teardown could occur mid-enumeration when the ctrlr_dev was
    closed before all namespace devices were opened; fixed by deferring
    teardown via `cref_defer` and calling `cref_cleanup` once enumeration
    is complete.
  - `cref_insert` scanned for a free slot using `refcount == 0`, which
    is no longer equivalent to an empty slot once deferred entries
    (refcount=0, ctrlr non-NULL) are possible; fixed to check
    `ctrlr == NULL`.
  - `attach_cb` discarded a duplicate controller handle from
    `spdk_nvme_probe` without detaching it.