### PR TITLE
test(cijoe): add uPCIe IOMMU overhead benchmark workflow

### DIFF
--- a/cijoe/auxiliary/bench-upcie-iommu-overhead-runs.yaml
+++ b/cijoe/auxiliary/bench-upcie-iommu-overhead-runs.yaml
@@ -1,0 +1,13 @@
+---
+runtime: 10
+repeat: 3
+cpumask: "0x1"
+workload_pause: 5
+
+workloads:
+- pattern: randread
+  iosizes: [4096]
+  iodepths: [1, 2, 4, 8, 16, 32]
+- pattern: read
+  iosizes: [131072]
+  iodepths: [1, 2, 4, 8, 16, 32]

--- a/cijoe/auxiliary/bench-upcie-iommu-overhead-runs.yaml
+++ b/cijoe/auxiliary/bench-upcie-iommu-overhead-runs.yaml
@@ -2,6 +2,8 @@
 runtime: 10
 repeat: 3
 cpumask: "0x1"
+fio_ramp_time: 5
+fio_size: "100%"
 workload_pause: 5
 
 workloads:

--- a/cijoe/configs/upcie-iommu-overhead-report.toml
+++ b/cijoe/configs/upcie-iommu-overhead-report.toml
@@ -1,0 +1,3 @@
+[upcie_iommu_overhead.compare]
+uio_output = "cijoe-output-upcie-uio"
+vfio_output = "cijoe-output-upcie-vfio"

--- a/cijoe/configs/upcie-iommu-overhead-uio.toml
+++ b/cijoe/configs/upcie-iommu-overhead-uio.toml
@@ -1,0 +1,5 @@
+[upcie_iommu_overhead]
+driver = "uio_pci_generic"
+# Update this BDF to match the target NVMe device on the test system.
+device = "0000:02:00.0"
+nsid = 1

--- a/cijoe/configs/upcie-iommu-overhead-vfio.toml
+++ b/cijoe/configs/upcie-iommu-overhead-vfio.toml
@@ -1,0 +1,5 @@
+[upcie_iommu_overhead]
+driver = "vfio-pci"
+# Update this BDF to match the target NVMe device on the test system.
+device = "0000:02:00.0"
+nsid = 1

--- a/cijoe/scripts/upcie_iommu_overhead.py
+++ b/cijoe/scripts/upcie_iommu_overhead.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""
+Collect uPCIe IOMMU overhead benchmark inputs
+=============================================
+
+This script runs one driver in the current boot configuration. UIO and VFIO
+comparisons are assembled later from two separate CIJOE outputs.
+"""
+import errno
+import logging as log
+import re
+import shlex
+import shutil
+import time
+import traceback
+from argparse import ArgumentParser
+from itertools import product
+from pathlib import Path
+
+from cijoe.core.resources import dict_from_yamlfile
+
+GROUP = "upcie-iommu-overhead"
+RUN_DEFAULTS = {
+    "runtime": 10,
+    "repeat": 3,
+    "cpumask": "0x1",
+    "workload_pause": 5,
+}
+IOMMU_ENABLED_PATTERNS = [
+    r"\bDMAR:\s+IOMMU enabled\b",
+    r"\bAMD-Vi:\s+IOMMU enabled\b",
+    r"\bIntel-IOMMU:\s+enabled\b",
+    r"\bIOMMU enabled\b",
+    r"\biommu:\s+Default domain type:\b",
+    r"\bAdding to iommu group\b",
+    r"\bDMAR:\s+Intel\(R\) Virtualization Technology for Directed I/O\b",
+    r"\bDMAR:\s+dmar\d+:\s+Using Queued invalidation\b",
+]
+IOMMU_DISABLED_PATTERNS = [
+    r"\bintel_iommu=off\b",
+    r"\bamd_iommu=off\b",
+    r"\biommu=off\b",
+    r"\bIOMMU disabled\b",
+    r"\bIOMMU not enabled\b",
+]
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--runs",
+        type=Path,
+        default=None,
+        help="Path to a yaml file describing the upcie benchmark workload matrix",
+    )
+
+
+def conf(cijoe, key, default=None):
+    return cijoe.getconf(f"upcie_iommu_overhead.{key}", default)
+
+
+def runconf(runs, key):
+    return runs.get(key, RUN_DEFAULTS[key])
+
+
+def repo_path(cijoe):
+    return Path(cijoe.getconf("xnvme.repository.path", str(Path.cwd().parent)))
+
+
+def q(value):
+    return shlex.quote(str(value))
+
+
+def resolve_bin(cijoe, name, default):
+    path = Path(conf(cijoe, f"bins.{name}", str(repo_path(cijoe) / default)))
+    if path.is_dir():
+        return path / name
+    return path
+
+
+def workload_cases(runs):
+    for workload in runs.get("workloads", []):
+        pattern = workload["pattern"]
+        for iosize, iodepth in product(workload["iosizes"], workload["iodepths"]):
+            yield pattern, int(iosize), int(iodepth)
+
+
+def run_and_copy(cijoe, cmd, output_path):
+    err, state = cijoe.run(cmd)
+    shutil.copyfile(state.output_fpath, output_path)
+    if err:
+        log.error(f"failed: {state}")
+    return err
+
+
+def dmesg_indicates_iommu_enabled(text):
+    for pattern in IOMMU_DISABLED_PATTERNS:
+        if re.search(pattern, text, re.IGNORECASE):
+            return False
+
+    return any(
+        re.search(pattern, text, re.IGNORECASE) for pattern in IOMMU_ENABLED_PATTERNS
+    )
+
+
+def check_iommu_state(cijoe, driver):
+    cmd = "sudo dmesg"
+
+    err, state = cijoe.run(cmd)
+    if err:
+        log.error(f"failed: {state}")
+        return err, None
+
+    dmesg = Path(state.output_fpath).read_text(encoding="utf-8", errors="replace")
+    iommu_enabled = dmesg_indicates_iommu_enabled(dmesg)
+
+    output_fpath = state.output_fpath
+
+    if driver == "uio_pci_generic" and iommu_enabled:
+        log.error(
+            "uio_pci_generic expects an IOMMU-off boot, but dmesg "
+            f"indicates that IOMMU is enabled: {output_fpath}"
+        )
+        return errno.EINVAL, None
+
+    if driver == "vfio-pci" and not iommu_enabled:
+        log.error(
+            "vfio-pci expects an IOMMU-enabled boot, but dmesg does "
+            f"not indicate that IOMMU is enabled: {output_fpath}"
+        )
+        return errno.EINVAL, None
+
+    return 0, dmesg
+
+
+def write_dmesg_artifact(artifacts, driver, dmesg):
+    output_path = artifacts / f"dmesg-iommu_LABEL={driver}_GROUP={GROUP}.txt"
+    output_path.write_text(dmesg, encoding="utf-8")
+
+
+def print_progress(message):
+    print(f"{message}\033[K", end="\r", flush=True)
+
+
+def configure_driver(cijoe, driver_script, driver, device, huge_mem):
+    env = {
+        "PCI_WHITELIST": device,
+        "DRIVER_OVERRIDE": driver,
+    }
+    if huge_mem:
+        env["HUGEMEM"] = str(huge_mem)
+
+    env_args = " ".join(f"{key}={q(value)}" for key, value in env.items())
+    cmd = f"sudo env {env_args} bash {q(driver_script)}"
+
+    err, state = cijoe.run(cmd)
+    if err:
+        log.error(f"failed: {state}")
+    return err
+
+
+def reset_driver(cijoe, driver_script, device):
+    cmd = f"sudo env PCI_WHITELIST={q(device)} " f"bash {q(driver_script)} reset"
+    err, state = cijoe.run(cmd)
+    if err:
+        log.error(f"failed: {state}")
+    return err
+
+
+def capture_device_info(cijoe, xnvme_bin, device, nsid, output_path):
+    cmd = f"sudo {q(xnvme_bin)} info --be upcie " f"--dev-nsid {q(nsid)} {q(device)}"
+    return run_and_copy(cijoe, cmd, output_path)
+
+
+def xnvmeperf_cmd(cijoe, runs, xnvmeperf_bin, device, pattern, iosize, iodepth):
+    runtime = int(runconf(runs, "runtime"))
+    cpumask = runconf(runs, "cpumask")
+
+    return " ".join(
+        [
+            f"sudo {q(xnvmeperf_bin)}",
+            "run",
+            "--be upcie",
+            f"--iopattern {q(pattern)}",
+            f"--qdepth {q(iodepth)}",
+            f"--iosize {q(iosize)}",
+            f"--runtime {q(runtime)}",
+            f"--cpumask {q(cpumask)}",
+            q(device),
+        ]
+    )
+
+
+def write_metadata(artifacts, runs, driver, device, nsid, runs_path):
+    meta_path = artifacts / "upcie-iommu-overhead-meta.txt"
+    values = {
+        "driver": driver,
+        "device": device,
+        "nsid": nsid,
+        "runner": "xnvmeperf",
+        "runtime": runconf(runs, "runtime"),
+        "repeat": runconf(runs, "repeat"),
+        "cpumask": runconf(runs, "cpumask"),
+        "workload_pause": runconf(runs, "workload_pause"),
+        "runs": runs_path,
+    }
+
+    with meta_path.open("w") as meta:
+        for key, value in values.items():
+            meta.write(f"{key}={value}\n")
+
+
+def prune_artifacts(artifacts):
+    # CIJOE usually creates a fresh output directory, but local iteration often
+    # reuses one. Keep reruns from mixing old raw inputs with new normalized data.
+    for pattern in [
+        "xnvmeperf-output_*.txt",
+        "dmesg-iommu_*.txt",
+        "xnvme-info_*.txt",
+    ]:
+        for path in artifacts.glob(pattern):
+            path.unlink()
+    normalized = artifacts / "benchmark-output-normalized.json"
+    if normalized.exists():
+        normalized.unlink()
+
+
+def main(args, cijoe):
+    if not args.runs:
+        log.error("Missing path to auxiliary file describing the runs")
+        return errno.EINVAL
+
+    driver = conf(cijoe, "driver")
+    device = conf(cijoe, "device")
+    nsid = int(conf(cijoe, "nsid", 1))
+    huge_mem = conf(cijoe, "huge_mem", None)
+    runs = dict_from_yamlfile(args.runs)
+    repeat = int(runconf(runs, "repeat"))
+    workload_pause = int(runconf(runs, "workload_pause"))
+
+    if not driver or not device:
+        log.error("Missing upcie_iommu_overhead.driver or .device")
+        return errno.EINVAL
+
+    xnvme_bin = resolve_bin(cijoe, "xnvme", "builddir/tools/xnvme")
+    xnvmeperf_bin = resolve_bin(
+        cijoe, "xnvmeperf", "builddir/tools/xnvmeperf/xnvmeperf"
+    )
+    driver_script = resolve_bin(cijoe, "driver_script", "toolbox/xnvme-driver.sh")
+
+    err = 0
+    driver_configured = False
+    cases = list(workload_cases(runs))
+
+    try:
+        err, dmesg = check_iommu_state(cijoe, driver)
+        if err:
+            return err
+
+        artifacts = Path(args.output) / "artifacts"
+        artifacts.mkdir(parents=True, exist_ok=True)
+        prune_artifacts(artifacts)
+        write_metadata(artifacts, runs, driver, device, nsid, args.runs)
+        write_dmesg_artifact(artifacts, driver, dmesg)
+
+        err = configure_driver(cijoe, driver_script, driver, device, huge_mem)
+        if err:
+            return err
+        driver_configured = True
+
+        info_path = artifacts / f"xnvme-info_LABEL={driver}_GROUP={GROUP}.txt"
+        err = capture_device_info(cijoe, xnvme_bin, device, nsid, info_path)
+        if err:
+            return err
+
+        combinations = len(cases) * repeat
+        completed = 0
+        print(
+            "run:",
+            "{",
+            f"'driver': '{driver}'",
+            f"'workloads': {len(cases)}",
+            f"'repeat': {repeat}",
+            "}",
+        )
+        print_progress(f"0% completed (0/{combinations})")
+
+        for case_idx, (pattern, iosize, iodepth) in enumerate(cases, start=1):
+            for rep in range(1, repeat + 1):
+                workload = (
+                    f"RW={pattern} IOSIZE={iosize} "
+                    f"IODEPTH={iodepth} REP={rep}/{repeat}"
+                )
+                print_progress(
+                    f"{completed / combinations * 100:.0f}% completed "
+                    f"({completed}/{combinations}); running {workload}"
+                )
+
+                output_path = artifacts / (
+                    f"xnvmeperf-output_IOSIZE={iosize}_IODEPTH={iodepth}_"
+                    f"LABEL={driver}_GROUP={GROUP}_RW={pattern}_REP={rep}.txt"
+                )
+                cmd = xnvmeperf_cmd(
+                    cijoe, runs, xnvmeperf_bin, device, pattern, iosize, iodepth
+                )
+                err = run_and_copy(cijoe, cmd, output_path)
+                if err:
+                    return err
+
+                completed += 1
+                print_progress(
+                    f"{completed / combinations * 100:.0f}% completed "
+                    f"({completed}/{combinations}); finished {workload}"
+                )
+
+            if workload_pause > 0 and case_idx < len(cases):
+                time.sleep(workload_pause)
+
+        print(f"100% completed ({completed}/{combinations})", flush=True)
+
+    except Exception as exc:
+        log.error(f"Something failed({exc})")
+        log.error("".join(traceback.format_exception(None, exc, exc.__traceback__)))
+        return 1
+    finally:
+        if driver_configured:
+            reset_driver(cijoe, driver_script, device)
+
+    return err

--- a/cijoe/scripts/upcie_iommu_overhead.py
+++ b/cijoe/scripts/upcie_iommu_overhead.py
@@ -20,10 +20,13 @@ from pathlib import Path
 from cijoe.core.resources import dict_from_yamlfile
 
 GROUP = "upcie-iommu-overhead"
+FIO_PERCENTILE_LIST = "99.9:99.99:99.999"
 RUN_DEFAULTS = {
     "runtime": 10,
     "repeat": 3,
     "cpumask": "0x1",
+    "fio_ramp_time": 5,
+    "fio_size": "100%",
     "workload_pause": 5,
 }
 IOMMU_ENABLED_PATTERNS = [
@@ -68,6 +71,26 @@ def repo_path(cijoe):
 
 def q(value):
     return shlex.quote(str(value))
+
+
+def cpumask_to_cpu_list(cpumask):
+    mask = int(str(cpumask), 0)
+    if mask <= 0:
+        raise ValueError("cpumask must be a non-zero integer")
+
+    bit = 0
+    cpus = []
+    while mask:
+        if mask & 1:
+            cpus.append(str(bit))
+        mask >>= 1
+        bit += 1
+
+    return ",".join(cpus)
+
+
+def cpumask_to_cpu_count(cpumask):
+    return len(cpumask_to_cpu_list(cpumask).split(","))
 
 
 def resolve_bin(cijoe, name, default):
@@ -190,16 +213,56 @@ def xnvmeperf_cmd(cijoe, runs, xnvmeperf_bin, device, pattern, iosize, iodepth):
     )
 
 
+def fio_cmd(cijoe, runs, fio_bin, device, nsid, pattern, iosize, iodepth):
+    runtime = int(runconf(runs, "runtime"))
+    ramp_time = int(runconf(runs, "fio_ramp_time"))
+    size = runconf(runs, "fio_size")
+    cpumask = runconf(runs, "cpumask")
+    fio_device = str(device).replace(":", r"\:")
+
+    return " ".join(
+        [
+            f"sudo {q(fio_bin)}",
+            "--name=upcie-iommu-overhead",
+            f"--filename={q(fio_device)}",
+            "--ioengine=xnvme",
+            "--xnvme_be=upcie",
+            f"--xnvme_dev_nsid={q(nsid)}",
+            "--thread=1",
+            "--direct=1",
+            f"--rw={q(pattern)}",
+            f"--size={q(size)}",
+            f"--bs={q(iosize)}",
+            f"--iodepth={q(iodepth)}",
+            "--time_based=1",
+            f"--runtime={q(runtime)}",
+            f"--ramp_time={q(ramp_time)}",
+            "--norandommap=1",
+            "--group_reporting=1",
+            "--output-format=json",
+            f"--percentile_list={FIO_PERCENTILE_LIST}",
+            f"--numjobs={cpumask_to_cpu_count(cpumask)}",
+            f"--cpus_allowed={q(cpumask_to_cpu_list(cpumask))}",
+            "--cpus_allowed_policy=split",
+        ]
+    )
+
+
 def write_metadata(artifacts, runs, driver, device, nsid, runs_path):
     meta_path = artifacts / "upcie-iommu-overhead-meta.txt"
+    cpumask = runconf(runs, "cpumask")
     values = {
         "driver": driver,
         "device": device,
         "nsid": nsid,
-        "runner": "xnvmeperf",
+        "runners": "xnvmeperf,fio",
         "runtime": runconf(runs, "runtime"),
         "repeat": runconf(runs, "repeat"),
-        "cpumask": runconf(runs, "cpumask"),
+        "cpumask": cpumask,
+        "fio_numjobs": cpumask_to_cpu_count(cpumask),
+        "fio_cpus_allowed": cpumask_to_cpu_list(cpumask),
+        "fio_ramp_time": runconf(runs, "fio_ramp_time"),
+        "fio_size": runconf(runs, "fio_size"),
         "workload_pause": runconf(runs, "workload_pause"),
         "runs": runs_path,
     }
@@ -214,6 +277,7 @@ def prune_artifacts(artifacts):
     # reuses one. Keep reruns from mixing old raw inputs with new normalized data.
     for pattern in [
         "xnvmeperf-output_*.txt",
+        "fio-output_*.txt",
         "dmesg-iommu_*.txt",
         "xnvme-info_*.txt",
     ]:
@@ -245,6 +309,7 @@ def main(args, cijoe):
     xnvmeperf_bin = resolve_bin(
         cijoe, "xnvmeperf", "builddir/tools/xnvmeperf/xnvmeperf"
     )
+    fio_bin = conf(cijoe, "bins.fio", cijoe.getconf("fio.bin", "fio"))
     driver_script = resolve_bin(cijoe, "driver_script", "toolbox/xnvme-driver.sh")
 
     err = 0
@@ -272,7 +337,8 @@ def main(args, cijoe):
         if err:
             return err
 
-        combinations = len(cases) * repeat
+        runners = ["xnvmeperf", "fio"]
+        combinations = len(cases) * repeat * len(runners)
         completed = 0
         print(
             "run:",
@@ -280,6 +346,7 @@ def main(args, cijoe):
             f"'driver': '{driver}'",
             f"'workloads': {len(cases)}",
             f"'repeat': {repeat}",
+            f"'runners': {runners}",
             "}",
         )
         print_progress(f"0% completed (0/{combinations})")
@@ -292,7 +359,7 @@ def main(args, cijoe):
                 )
                 print_progress(
                     f"{completed / combinations * 100:.0f}% completed "
-                    f"({completed}/{combinations}); running {workload}"
+                    f"({completed}/{combinations}); running xnvmeperf {workload}"
                 )
 
                 output_path = artifacts / (
@@ -309,7 +376,28 @@ def main(args, cijoe):
                 completed += 1
                 print_progress(
                     f"{completed / combinations * 100:.0f}% completed "
-                    f"({completed}/{combinations}); finished {workload}"
+                    f"({completed}/{combinations}); finished xnvmeperf {workload}"
+                )
+
+                print_progress(
+                    f"{completed / combinations * 100:.0f}% completed "
+                    f"({completed}/{combinations}); running fio {workload}"
+                )
+                output_path = artifacts / (
+                    f"fio-output_IOSIZE={iosize}_IODEPTH={iodepth}_"
+                    f"LABEL={driver}_GROUP={GROUP}_RW={pattern}_REP={rep}.txt"
+                )
+                cmd = fio_cmd(
+                    cijoe, runs, fio_bin, device, nsid, pattern, iosize, iodepth
+                )
+                err = run_and_copy(cijoe, cmd, output_path)
+                if err:
+                    return err
+
+                completed += 1
+                print_progress(
+                    f"{completed / combinations * 100:.0f}% completed "
+                    f"({completed}/{combinations}); finished fio {workload}"
                 )
 
             if workload_pause > 0 and case_idx < len(cases):

--- a/cijoe/scripts/upcie_iommu_overhead_compare.py
+++ b/cijoe/scripts/upcie_iommu_overhead_compare.py
@@ -18,6 +18,7 @@ OUTPUT_NORMALIZED_FILENAME = "benchmark-output-normalized.json"
 COMPARISON_JSON = "upcie-iommu-overhead-comparison.json"
 COMPARISON_CSV = "upcie-iommu-overhead-comparison.csv"
 JSON_DUMP = {"indent": 4}
+TAIL_LATENCIES = ["p99_9", "p99_99", "p99_999"]
 
 
 def add_args(parser: ArgumentParser):
@@ -69,6 +70,41 @@ def pct_delta(base, value):
     return (value - base) / base * 100.0
 
 
+def metric_latency_ns(metrics):
+    ctx = metrics.get("ctx", {})
+    if ctx.get("latency_source") != "fio.lat_ns.mean":
+        raise ValueError(f"missing fio latency source for {ctx}")
+
+    lat = float(metrics.get("lat", 0))
+    if lat <= 0:
+        raise ValueError(f"missing fio latency for {ctx}")
+    return lat
+
+
+def metric_tail_latency_ns(metrics):
+    ctx = metrics.get("ctx", {})
+    if ctx.get("tail_latency_source") != "fio.clat_ns.percentile":
+        raise ValueError(f"missing fio tail latency source for {ctx}")
+
+    values = metrics.get("tail_lat_ns", {})
+    missing = [name for name in TAIL_LATENCIES if float(values.get(name, 0)) <= 0]
+    if missing:
+        raise ValueError(f"missing fio tail latency {missing} for {ctx}")
+
+    return {name: float(values[name]) for name in TAIL_LATENCIES}
+
+
+def metric_fio_iops(metrics):
+    ctx = metrics.get("ctx", {})
+    if ctx.get("throughput_source") != "fio.iops":
+        raise ValueError(f"missing fio metrics for {ctx}")
+
+    iops = float(metrics.get("fio_iops", 0))
+    if iops <= 0:
+        raise ValueError(f"missing fio iops for {ctx}")
+    return iops
+
+
 def compare(args, cijoe):
     uio_output = args.uio_output or cijoe.getconf(
         "upcie_iommu_overhead.compare.uio_output", None
@@ -93,6 +129,12 @@ def compare(args, cijoe):
         rw, iosize, iodepth = key
         uio_metrics = uio[key]
         vfio_metrics = vfio[key]
+        uio_lat_ns = metric_latency_ns(uio_metrics)
+        vfio_lat_ns = metric_latency_ns(vfio_metrics)
+        uio_tail_lat_ns = metric_tail_latency_ns(uio_metrics)
+        vfio_tail_lat_ns = metric_tail_latency_ns(vfio_metrics)
+        uio_fio_iops = metric_fio_iops(uio_metrics)
+        vfio_fio_iops = metric_fio_iops(vfio_metrics)
 
         items.append(
             {
@@ -106,19 +148,45 @@ def compare(args, cijoe):
                     "driver": uio_metrics["ctx"].get("driver", "uio_pci_generic"),
                     "iops": uio_metrics["iops"],
                     "bwps": uio_metrics["bwps"],
+                    "fio_iops": uio_fio_iops,
+                    "fio_bwps": uio_metrics.get("fio_bwps", 0),
+                    "fio_iops_stddev": uio_metrics.get("fio_iops_stddev", 0),
+                    "fio_iops_cv": uio_metrics.get("fio_iops_cv", 0),
+                    "lat_ns": uio_lat_ns,
                     "repeat": uio_metrics["ctx"].get("repeat", 1),
                     "iops_stddev": uio_metrics.get("stddev", 0),
                     "iops_cv": uio_metrics.get("iops_cv", 0),
+                    "lat_stddev_ns": uio_metrics.get("lat_stddev", 0),
+                    "lat_cv": uio_metrics.get("lat_cv", 0),
+                    "tail_lat_ns": uio_tail_lat_ns,
+                    "tail_lat_stddev_ns": uio_metrics.get("tail_lat_stddev_ns", {}),
+                    "tail_lat_cv": uio_metrics.get("tail_lat_cv", {}),
                 },
                 "vfio": {
                     "driver": vfio_metrics["ctx"].get("driver", "vfio-pci"),
                     "iops": vfio_metrics["iops"],
                     "bwps": vfio_metrics["bwps"],
+                    "fio_iops": vfio_fio_iops,
+                    "fio_bwps": vfio_metrics.get("fio_bwps", 0),
+                    "fio_iops_stddev": vfio_metrics.get("fio_iops_stddev", 0),
+                    "fio_iops_cv": vfio_metrics.get("fio_iops_cv", 0),
+                    "lat_ns": vfio_lat_ns,
                     "repeat": vfio_metrics["ctx"].get("repeat", 1),
                     "iops_stddev": vfio_metrics.get("stddev", 0),
                     "iops_cv": vfio_metrics.get("iops_cv", 0),
+                    "lat_stddev_ns": vfio_metrics.get("lat_stddev", 0),
+                    "lat_cv": vfio_metrics.get("lat_cv", 0),
+                    "tail_lat_ns": vfio_tail_lat_ns,
+                    "tail_lat_stddev_ns": vfio_metrics.get("tail_lat_stddev_ns", {}),
+                    "tail_lat_cv": vfio_metrics.get("tail_lat_cv", {}),
                 },
                 "delta_pct": pct_delta(uio_metrics["iops"], vfio_metrics["iops"]),
+                "fio_delta_pct": pct_delta(uio_fio_iops, vfio_fio_iops),
+                "lat_delta_pct": pct_delta(uio_lat_ns, vfio_lat_ns),
+                "tail_lat_delta_pct": {
+                    name: pct_delta(uio_tail_lat_ns[name], vfio_tail_lat_ns[name])
+                    for name in TAIL_LATENCIES
+                },
             }
         )
 
@@ -145,8 +213,25 @@ def compare(args, cijoe):
             "uio_iops",
             "vfio_iops",
             "delta_pct",
+            "uio_fio_iops",
+            "vfio_fio_iops",
+            "fio_delta_pct",
+            "uio_lat_ns",
+            "vfio_lat_ns",
+            "lat_delta_pct",
+            "uio_p99_9_ns",
+            "vfio_p99_9_ns",
+            "p99_9_delta_pct",
+            "uio_p99_99_ns",
+            "vfio_p99_99_ns",
+            "p99_99_delta_pct",
+            "uio_p99_999_ns",
+            "vfio_p99_999_ns",
+            "p99_999_delta_pct",
             "uio_cv",
             "vfio_cv",
+            "uio_fio_cv",
+            "vfio_fio_cv",
         ]
         writer = csv.DictWriter(cfd, fieldnames=fieldnames)
         writer.writeheader()
@@ -159,8 +244,25 @@ def compare(args, cijoe):
                     "uio_iops": f"{item['uio']['iops']:.6f}",
                     "vfio_iops": f"{item['vfio']['iops']:.6f}",
                     "delta_pct": f"{item['delta_pct']:.6f}",
+                    "uio_fio_iops": f"{item['uio']['fio_iops']:.6f}",
+                    "vfio_fio_iops": f"{item['vfio']['fio_iops']:.6f}",
+                    "fio_delta_pct": f"{item['fio_delta_pct']:.6f}",
+                    "uio_lat_ns": f"{item['uio']['lat_ns']:.6f}",
+                    "vfio_lat_ns": f"{item['vfio']['lat_ns']:.6f}",
+                    "lat_delta_pct": f"{item['lat_delta_pct']:.6f}",
+                    "uio_p99_9_ns": f"{item['uio']['tail_lat_ns']['p99_9']:.6f}",
+                    "vfio_p99_9_ns": f"{item['vfio']['tail_lat_ns']['p99_9']:.6f}",
+                    "p99_9_delta_pct": f"{item['tail_lat_delta_pct']['p99_9']:.6f}",
+                    "uio_p99_99_ns": f"{item['uio']['tail_lat_ns']['p99_99']:.6f}",
+                    "vfio_p99_99_ns": f"{item['vfio']['tail_lat_ns']['p99_99']:.6f}",
+                    "p99_99_delta_pct": f"{item['tail_lat_delta_pct']['p99_99']:.6f}",
+                    "uio_p99_999_ns": f"{item['uio']['tail_lat_ns']['p99_999']:.6f}",
+                    "vfio_p99_999_ns": f"{item['vfio']['tail_lat_ns']['p99_999']:.6f}",
+                    "p99_999_delta_pct": f"{item['tail_lat_delta_pct']['p99_999']:.6f}",
                     "uio_cv": f"{item['uio']['iops_cv']:.6f}",
                     "vfio_cv": f"{item['vfio']['iops_cv']:.6f}",
+                    "uio_fio_cv": f"{item['uio']['fio_iops_cv']:.6f}",
+                    "vfio_fio_cv": f"{item['vfio']['fio_iops_cv']:.6f}",
                 }
             )
 

--- a/cijoe/scripts/upcie_iommu_overhead_compare.py
+++ b/cijoe/scripts/upcie_iommu_overhead_compare.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Compare normalized uPCIe IOMMU overhead outputs
+===============================================
+"""
+import csv
+import errno
+import json
+import logging as log
+import traceback
+from argparse import ArgumentParser
+from itertools import product
+from pathlib import Path
+
+from cijoe.core.resources import dict_from_yamlfile
+
+OUTPUT_NORMALIZED_FILENAME = "benchmark-output-normalized.json"
+COMPARISON_JSON = "upcie-iommu-overhead-comparison.json"
+COMPARISON_CSV = "upcie-iommu-overhead-comparison.csv"
+JSON_DUMP = {"indent": 4}
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--uio-output", "--uio_output", type=Path, default=None)
+    parser.add_argument("--vfio-output", "--vfio_output", type=Path, default=None)
+    parser.add_argument(
+        "--runs",
+        type=Path,
+        default=None,
+        help="Path to a yaml file describing the workload matrix to compare",
+    )
+
+
+def load_normalized(output_path):
+    path = Path(output_path) / "artifacts" / OUTPUT_NORMALIZED_FILENAME
+    if not path.exists():
+        path = Path(output_path) / OUTPUT_NORMALIZED_FILENAME
+    with path.open() as jfd:
+        return json.load(jfd)
+
+
+def index_by_workload(data):
+    indexed = {}
+    for _, metrics in data:
+        ctx = metrics["ctx"]
+        key = (ctx["rw"], int(ctx["iosize"]), int(ctx["iodepth"]))
+        indexed[key] = metrics
+    return indexed
+
+
+def workload_keys(runs_path):
+    if not runs_path:
+        return None
+
+    keys = set()
+    runs = dict_from_yamlfile(runs_path)
+    for workload in runs.get("workloads", []):
+        rw = workload["pattern"]
+        for iosize, iodepth in product(workload["iosizes"], workload["iodepths"]):
+            keys.add((rw, int(iosize), int(iodepth)))
+    return keys
+
+
+def pct_delta(base, value):
+    if not base:
+        log.warning(f"pct_delta baseline is zero (value={value})")
+        return float("nan")
+
+    return (value - base) / base * 100.0
+
+
+def compare(args, cijoe):
+    uio_output = args.uio_output or cijoe.getconf(
+        "upcie_iommu_overhead.compare.uio_output", None
+    )
+    vfio_output = args.vfio_output or cijoe.getconf(
+        "upcie_iommu_overhead.compare.vfio_output", None
+    )
+
+    if not uio_output or not vfio_output:
+        log.error("Missing --uio-output and --vfio-output")
+        return errno.EINVAL
+
+    uio = index_by_workload(load_normalized(uio_output))
+    vfio = index_by_workload(load_normalized(vfio_output))
+    allowed_keys = workload_keys(args.runs)
+    common_keys = set(uio) & set(vfio)
+    if allowed_keys is not None:
+        common_keys &= allowed_keys
+
+    items = []
+    for key in sorted(common_keys, key=lambda item: (item[0], item[1], item[2])):
+        rw, iosize, iodepth = key
+        uio_metrics = uio[key]
+        vfio_metrics = vfio[key]
+
+        items.append(
+            {
+                "ctx": {
+                    "rw": rw,
+                    "iosize": iosize,
+                    "iodepth": iodepth,
+                    "group": "upcie-iommu-overhead",
+                },
+                "uio": {
+                    "driver": uio_metrics["ctx"].get("driver", "uio_pci_generic"),
+                    "iops": uio_metrics["iops"],
+                    "bwps": uio_metrics["bwps"],
+                    "repeat": uio_metrics["ctx"].get("repeat", 1),
+                    "iops_stddev": uio_metrics.get("stddev", 0),
+                    "iops_cv": uio_metrics.get("iops_cv", 0),
+                },
+                "vfio": {
+                    "driver": vfio_metrics["ctx"].get("driver", "vfio-pci"),
+                    "iops": vfio_metrics["iops"],
+                    "bwps": vfio_metrics["bwps"],
+                    "repeat": vfio_metrics["ctx"].get("repeat", 1),
+                    "iops_stddev": vfio_metrics.get("stddev", 0),
+                    "iops_cv": vfio_metrics.get("iops_cv", 0),
+                },
+                "delta_pct": pct_delta(uio_metrics["iops"], vfio_metrics["iops"]),
+            }
+        )
+
+    if not items:
+        log.error("No matching workloads found between UIO and VFIO outputs")
+        return errno.ENOENT
+
+    artifacts = Path(args.output) / "artifacts"
+    artifacts.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "uio_output": str(uio_output),
+        "vfio_output": str(vfio_output),
+        "items": items,
+    }
+    with (artifacts / COMPARISON_JSON).open("w") as jfd:
+        json.dump(payload, jfd, **JSON_DUMP)
+
+    with (artifacts / COMPARISON_CSV).open("w", newline="") as cfd:
+        fieldnames = [
+            "rw",
+            "iosize",
+            "iodepth",
+            "uio_iops",
+            "vfio_iops",
+            "delta_pct",
+            "uio_cv",
+            "vfio_cv",
+        ]
+        writer = csv.DictWriter(cfd, fieldnames=fieldnames)
+        writer.writeheader()
+        for item in items:
+            writer.writerow(
+                {
+                    "rw": item["ctx"]["rw"],
+                    "iosize": item["ctx"]["iosize"],
+                    "iodepth": item["ctx"]["iodepth"],
+                    "uio_iops": f"{item['uio']['iops']:.6f}",
+                    "vfio_iops": f"{item['vfio']['iops']:.6f}",
+                    "delta_pct": f"{item['delta_pct']:.6f}",
+                    "uio_cv": f"{item['uio']['iops_cv']:.6f}",
+                    "vfio_cv": f"{item['vfio']['iops_cv']:.6f}",
+                }
+            )
+
+    return 0
+
+
+def main(args, cijoe):
+    try:
+        return compare(args, cijoe)
+    except Exception as exc:
+        log.error(f"Something failed({exc})")
+        log.error("".join(traceback.format_exception(None, exc, exc.__traceback__)))
+        return 1

--- a/cijoe/scripts/upcie_iommu_overhead_normalize.py
+++ b/cijoe/scripts/upcie_iommu_overhead_normalize.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-Normalize xnvmeperf uPCIe IOMMU overhead outputs
-================================================
+Normalize uPCIe IOMMU overhead outputs
+======================================
 """
 import errno
 import hashlib
@@ -17,9 +17,19 @@ from pathlib import Path
 OUTPUT_NORMALIZED_FILENAME = "benchmark-output-normalized.json"
 JSON_DUMP = {"indent": 4}
 GROUP = "upcie-iommu-overhead"
+TAIL_LATENCIES = {
+    "p99_9": "99.900000",
+    "p99_99": "99.990000",
+    "p99_999": "99.999000",
+}
 
 STEM_REGEX = re.compile(
     r"xnvmeperf-output_IOSIZE=(?P<iosize>\d+)_IODEPTH=(?P<iodepth>\d+)_"
+    r"LABEL=(?P<label>.+)_GROUP=(?P<group>.+)_RW=(?P<rw>.+)_"
+    r"REP=(?P<rep>\d+)"
+)
+FIO_STEM_REGEX = re.compile(
+    r"fio-output_IOSIZE=(?P<iosize>\d+)_IODEPTH=(?P<iodepth>\d+)_"
     r"LABEL=(?P<label>.+)_GROUP=(?P<group>.+)_RW=(?P<rw>.+)_"
     r"REP=(?P<rep>\d+)"
 )
@@ -51,6 +61,39 @@ def parse_xnvmeperf_output(path):
     }
 
 
+def parse_fio_output(path, rw):
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not data.get("jobs"):
+        raise ValueError(f"fio output has no jobs: {path}")
+
+    kind = "read" if "read" in rw else "write"
+    job = data["jobs"][0]
+    section = job.get(kind, {})
+    lat_ns = section.get("lat_ns", {})
+    clat_ns = section.get("clat_ns", {})
+    percentile = clat_ns.get("percentile", lat_ns.get("percentile", {}))
+
+    if not lat_ns:
+        raise ValueError(f"fio output has no {kind}.lat_ns: {path}")
+
+    tail_lat_ns = {
+        name: float(percentile.get(fio_key, 0))
+        for name, fio_key in TAIL_LATENCIES.items()
+    }
+
+    return {
+        "runtime_ms": float(job.get("job_runtime", 0)),
+        "iops": float(section.get("iops", 0.0)),
+        "bwps": float(section.get("bw_bytes", 0)),
+        "lat_ns": float(lat_ns.get("mean", 0.0)),
+        "lat_stddev_ns": float(lat_ns.get("stddev", 0.0)),
+        "clat_ns": float(clat_ns.get("mean", lat_ns.get("mean", 0.0))),
+        "clat_p99_ns": float(percentile.get("99.000000", percentile.get("99.00", 0))),
+        "tail_lat_ns": tail_lat_ns,
+        "error": float(job.get("error", 0)),
+    }
+
+
 def mean(values):
     return sum(values) / len(values)
 
@@ -79,7 +122,7 @@ def stable_ident(context):
 def normalize(args):
     search = Path(args.path or args.output)
 
-    groups = OrderedDict()
+    xnvmeperf_groups = OrderedDict()
 
     for path in sorted(search.rglob("xnvmeperf-output_*.txt")):
         match = STEM_REGEX.match(path.stem)
@@ -94,42 +137,86 @@ def normalize(args):
             int(match.group("iosize")),
             int(match.group("iodepth")),
         )
-        groups.setdefault(key, []).append(parsed)
+        xnvmeperf_groups.setdefault(key, []).append(parsed)
 
-    if not groups:
+    if not xnvmeperf_groups:
         log.error("No xnvmeperf-output_*.txt files found")
         return errno.ENOENT
 
+    fio_groups = OrderedDict()
+    for path in sorted(search.rglob("fio-output_*.txt")):
+        match = FIO_STEM_REGEX.match(path.stem)
+        if not match:
+            continue
+
+        key = (
+            match.group("label"),
+            match.group("group"),
+            match.group("rw"),
+            int(match.group("iosize")),
+            int(match.group("iodepth")),
+        )
+        parsed = parse_fio_output(path, match.group("rw"))
+        fio_groups.setdefault(key, []).append(parsed)
+
     collection = []
-    for (label, group, rw, iosize, iodepth), samples in groups.items():
-        iops = [sample["iops"] for sample in samples]
-        mibps = [sample["mibps"] for sample in samples]
-        elapsed = [sample["elapsed"] for sample in samples]
-        failed = [sample["failed"] for sample in samples]
+    for key, xnvmeperf_samples in xnvmeperf_groups.items():
+        label, group, rw, iosize, iodepth = key
+        fio_samples = fio_groups.get(key)
+        if not fio_samples:
+            raise ValueError(f"missing fio latency samples for {key}")
+
+        iops = [sample["iops"] for sample in xnvmeperf_samples]
+        mibps = [sample["mibps"] for sample in xnvmeperf_samples]
+        elapsed = [sample["elapsed"] for sample in xnvmeperf_samples]
+        failed = [sample["failed"] for sample in xnvmeperf_samples]
+        lat = [sample["lat_ns"] for sample in fio_samples]
+        tail_lat = {
+            name: [sample["tail_lat_ns"][name] for sample in fio_samples]
+            for name in TAIL_LATENCIES
+        }
+        fio_iops = [sample["iops"] for sample in fio_samples]
+        fio_bwps = [sample["bwps"] for sample in fio_samples]
+        fio_errors = [sample["error"] for sample in fio_samples]
 
         context = {
             "name": label,
             "label": label,
             "group": group,
-            "ioengine": "xnvmeperf",
+            "ioengine": "xnvmeperf+fio",
             "rw": rw,
             "iosize": iosize,
             "iodepth": iodepth,
             "driver": label,
             "xnvme_be": "upcie",
-            "repeat": len(samples),
+            "repeat": len(xnvmeperf_samples),
+            "throughput_source": "fio.iops",
+            "latency_source": "fio.lat_ns.mean",
+            "tail_latency_source": "fio.clat_ns.percentile",
         }
 
         metrics = {
             "ctx": context,
             "iops": mean(iops),
             "bwps": mean(mibps),
-            "lat": 0,
+            "lat": mean(lat),
             "stddev": stdev(iops),
+            "lat_stddev": stdev(lat),
+            "tail_lat_ns": {name: mean(values) for name, values in tail_lat.items()},
+            "tail_lat_stddev_ns": {
+                name: stdev(values) for name, values in tail_lat.items()
+            },
+            "tail_lat_cv": {name: cv(values) for name, values in tail_lat.items()},
             "cpu": 0,
             "elapsed": mean(elapsed),
             "failed": sum(failed),
             "iops_cv": cv(iops),
+            "lat_cv": cv(lat),
+            "fio_iops": mean(fio_iops),
+            "fio_iops_stddev": stdev(fio_iops),
+            "fio_iops_cv": cv(fio_iops),
+            "fio_bwps": mean(fio_bwps),
+            "fio_error": sum(fio_errors),
         }
         collection.append((stable_ident(context), metrics))
 

--- a/cijoe/scripts/upcie_iommu_overhead_normalize.py
+++ b/cijoe/scripts/upcie_iommu_overhead_normalize.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Normalize xnvmeperf uPCIe IOMMU overhead outputs
+================================================
+"""
+import errno
+import hashlib
+import json
+import logging as log
+import re
+import statistics
+import traceback
+from argparse import ArgumentParser
+from collections import OrderedDict
+from pathlib import Path
+
+OUTPUT_NORMALIZED_FILENAME = "benchmark-output-normalized.json"
+JSON_DUMP = {"indent": 4}
+GROUP = "upcie-iommu-overhead"
+
+STEM_REGEX = re.compile(
+    r"xnvmeperf-output_IOSIZE=(?P<iosize>\d+)_IODEPTH=(?P<iodepth>\d+)_"
+    r"LABEL=(?P<label>.+)_GROUP=(?P<group>.+)_RW=(?P<rw>.+)_"
+    r"REP=(?P<rep>\d+)"
+)
+ELAPSED_REGEX = re.compile(r"xnvmeperf \(elapsed:\s*(?P<elapsed>\d+(?:\.\d+)?)s\)")
+TOTAL_REGEX = re.compile(
+    r"^\s*Total\s*:\s+(?P<iops>\d+(?:\.\d+)?)\s+"
+    r"(?P<mibps>\d+(?:\.\d+)?)\s+(?P<failed>\d+(?:\.\d+)?)",
+    re.MULTILINE,
+)
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--path", type=Path, default=None)
+
+
+def parse_xnvmeperf_output(path):
+    text = path.read_text(encoding="utf-8", errors="replace")
+    elapsed = ELAPSED_REGEX.search(text)
+    total = TOTAL_REGEX.search(text)
+
+    if not total:
+        raise ValueError(f"failed to parse {path}")
+
+    return {
+        "elapsed": float(elapsed.group("elapsed")) if elapsed else 0.0,
+        "iops": float(total.group("iops")),
+        "mibps": float(total.group("mibps")),
+        "failed": float(total.group("failed")),
+    }
+
+
+def mean(values):
+    return sum(values) / len(values)
+
+
+def stdev(values):
+    return statistics.stdev(values) if len(values) > 1 else 0.0
+
+
+def cv(values):
+    avg = mean(values)
+    return stdev(values) / avg * 100.0 if avg else 0.0
+
+
+def stable_ident(context):
+    digest = hashlib.md5()
+    digest.update(
+        "".join(
+            f"{key}={value}"
+            for key, value in sorted(context.items())
+            if key not in ["repeat"]
+        ).encode()
+    )
+    return digest.hexdigest()
+
+
+def normalize(args):
+    search = Path(args.path or args.output)
+
+    groups = OrderedDict()
+
+    for path in sorted(search.rglob("xnvmeperf-output_*.txt")):
+        match = STEM_REGEX.match(path.stem)
+        if not match:
+            continue
+
+        parsed = parse_xnvmeperf_output(path)
+        key = (
+            match.group("label"),
+            match.group("group"),
+            match.group("rw"),
+            int(match.group("iosize")),
+            int(match.group("iodepth")),
+        )
+        groups.setdefault(key, []).append(parsed)
+
+    if not groups:
+        log.error("No xnvmeperf-output_*.txt files found")
+        return errno.ENOENT
+
+    collection = []
+    for (label, group, rw, iosize, iodepth), samples in groups.items():
+        iops = [sample["iops"] for sample in samples]
+        mibps = [sample["mibps"] for sample in samples]
+        elapsed = [sample["elapsed"] for sample in samples]
+        failed = [sample["failed"] for sample in samples]
+
+        context = {
+            "name": label,
+            "label": label,
+            "group": group,
+            "ioengine": "xnvmeperf",
+            "rw": rw,
+            "iosize": iosize,
+            "iodepth": iodepth,
+            "driver": label,
+            "xnvme_be": "upcie",
+            "repeat": len(samples),
+        }
+
+        metrics = {
+            "ctx": context,
+            "iops": mean(iops),
+            "bwps": mean(mibps),
+            "lat": 0,
+            "stddev": stdev(iops),
+            "cpu": 0,
+            "elapsed": mean(elapsed),
+            "failed": sum(failed),
+            "iops_cv": cv(iops),
+        }
+        collection.append((stable_ident(context), metrics))
+
+    artifacts = Path(args.output) / "artifacts"
+    artifacts.mkdir(parents=True, exist_ok=True)
+    with (artifacts / OUTPUT_NORMALIZED_FILENAME).open("w") as jfd:
+        json.dump(collection, jfd, **JSON_DUMP)
+
+    return 0
+
+
+def main(args, cijoe):
+    try:
+        return normalize(args)
+    except Exception as exc:
+        log.error(f"Something failed({exc})")
+        log.error("".join(traceback.format_exception(None, exc, exc.__traceback__)))
+        return 1

--- a/cijoe/scripts/upcie_iommu_overhead_plotter.py
+++ b/cijoe/scripts/upcie_iommu_overhead_plotter.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Plot uPCIe IOMMU overhead comparisons
+=====================================
+"""
+import errno
+import json
+import logging as log
+import os
+import traceback
+from argparse import ArgumentParser
+from collections import defaultdict
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+COMPARISON_JSON = "upcie-iommu-overhead-comparison.json"
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--path", type=Path, default=None)
+
+
+def safe_name(value):
+    return str(value).replace("/", "-")
+
+
+def grouped_items(items):
+    grouped = defaultdict(list)
+    for item in items:
+        ctx = item["ctx"]
+        grouped[(ctx["rw"], ctx["iosize"])].append(item)
+    for entries in grouped.values():
+        entries.sort(key=lambda item: item["ctx"]["iodepth"])
+    return grouped
+
+
+def load_comparison(search):
+    path = Path(search) / "artifacts" / COMPARISON_JSON
+    if not path.exists():
+        path = Path(search) / COMPARISON_JSON
+    with path.open() as jfd:
+        return json.load(jfd)
+
+
+def plot_iops(entries, output_path):
+    qdepths = [item["ctx"]["iodepth"] for item in entries]
+    uio = [item["uio"]["iops"] for item in entries]
+    vfio = [item["vfio"]["iops"] for item in entries]
+    xs = range(len(qdepths))
+    width = 0.35
+
+    plt.clf()
+    fig, ax = plt.subplots()
+    ax.bar([x - width / 2 for x in xs], uio, width, label="uio_pci_generic")
+    ax.bar([x + width / 2 for x in xs], vfio, width, label="vfio-pci")
+    ax.set_xlabel("iodepth")
+    ax.set_ylabel("IOPS")
+    ax.set_xticks(list(xs), [str(qd) for qd in qdepths])
+    ax.legend()
+    fig.tight_layout()
+    plt.savefig(output_path)
+
+
+def plot_delta(entries, output_path):
+    qdepths = [item["ctx"]["iodepth"] for item in entries]
+    delta = [item["delta_pct"] for item in entries]
+    xs = range(len(qdepths))
+
+    plt.clf()
+    fig, ax = plt.subplots()
+    ax.bar(xs, delta, 0.5, color="#2B7B9B")
+    ax.axhline(0, color="black", linewidth=0.8)
+    ax.set_xlabel("iodepth")
+    ax.set_ylabel("VFIO vs UIO IOPS delta (%)")
+    ax.set_xticks(list(xs), [str(qd) for qd in qdepths])
+    fig.tight_layout()
+    plt.savefig(output_path)
+
+
+def create_plots(args):
+    search = args.path or args.output
+    if not search:
+        return errno.EINVAL
+
+    artifacts = args.output / "artifacts"
+    os.makedirs(artifacts, exist_ok=True)
+
+    comparison = load_comparison(search)
+    for (rw, iosize), entries in grouped_items(comparison["items"]).items():
+        prefix = f"upcie_iommu_overhead_RW={safe_name(rw)}_IOSIZE={iosize}"
+        plot_iops(entries, artifacts / f"{prefix}_TYPE=iops.png")
+        plot_delta(entries, artifacts / f"{prefix}_TYPE=delta.png")
+
+    return 0
+
+
+def main(args, cijoe):
+    try:
+        return create_plots(args)
+    except Exception as exc:
+        log.error(f"Something failed({exc})")
+        log.error("".join(traceback.format_exception(None, exc, exc.__traceback__)))
+        return 1

--- a/cijoe/scripts/upcie_iommu_overhead_plotter.py
+++ b/cijoe/scripts/upcie_iommu_overhead_plotter.py
@@ -15,6 +15,11 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 
 COMPARISON_JSON = "upcie-iommu-overhead-comparison.json"
+TAIL_LATENCIES = [
+    ("p99_9", "P99.9"),
+    ("p99_99", "P99.99"),
+    ("p99_999", "P99.999"),
+]
 
 
 def add_args(parser: ArgumentParser):
@@ -44,36 +49,95 @@ def load_comparison(search):
 
 
 def plot_iops(entries, output_path):
+    plot_dual_series(
+        entries,
+        output_path,
+        y_key="iops",
+        ylabel="IOPS",
+        legend_uio="uio_pci_generic (IOMMU off)",
+        legend_vfio="vfio-pci (IOMMU on)",
+    )
+
+
+def plot_fio_iops(entries, output_path):
+    plot_dual_series(
+        entries,
+        output_path,
+        y_key="fio_iops",
+        ylabel="FIO IOPS",
+        legend_uio="uio_pci_generic (IOMMU off)",
+        legend_vfio="vfio-pci (IOMMU on)",
+    )
+
+
+def plot_latency(entries, output_path):
+    plot_dual_series(
+        entries,
+        output_path,
+        y_key="lat_ns",
+        ylabel="FIO mean latency (us)",
+        legend_uio="uio_pci_generic (IOMMU off)",
+        legend_vfio="vfio-pci (IOMMU on)",
+        scale=1000.0,
+    )
+
+
+def plot_tail_latency(entries, output_path, percentile, label):
     qdepths = [item["ctx"]["iodepth"] for item in entries]
-    uio = [item["uio"]["iops"] for item in entries]
-    vfio = [item["vfio"]["iops"] for item in entries]
+    uio = [item["uio"]["tail_lat_ns"][percentile] / 1000.0 for item in entries]
+    vfio = [item["vfio"]["tail_lat_ns"][percentile] / 1000.0 for item in entries]
     xs = range(len(qdepths))
     width = 0.35
 
     plt.clf()
     fig, ax = plt.subplots()
-    ax.bar([x - width / 2 for x in xs], uio, width, label="uio_pci_generic")
-    ax.bar([x + width / 2 for x in xs], vfio, width, label="vfio-pci")
+    ax.bar(
+        [x - width / 2 for x in xs],
+        uio,
+        width,
+        label="uio_pci_generic (IOMMU off)",
+    )
+    ax.bar(
+        [x + width / 2 for x in xs],
+        vfio,
+        width,
+        label="vfio-pci (IOMMU on)",
+    )
     ax.set_xlabel("iodepth")
-    ax.set_ylabel("IOPS")
+    ax.set_ylabel(f"FIO {label} completion latency (us)")
     ax.set_xticks(list(xs), [str(qd) for qd in qdepths])
     ax.legend()
     fig.tight_layout()
     plt.savefig(output_path)
 
 
-def plot_delta(entries, output_path):
+def plot_dual_series(
+    entries, output_path, y_key, ylabel, legend_uio, legend_vfio, scale=1.0
+):
     qdepths = [item["ctx"]["iodepth"] for item in entries]
-    delta = [item["delta_pct"] for item in entries]
+    uio = [item["uio"][y_key] / scale for item in entries]
+    vfio = [item["vfio"][y_key] / scale for item in entries]
     xs = range(len(qdepths))
+    width = 0.35
 
     plt.clf()
     fig, ax = plt.subplots()
-    ax.bar(xs, delta, 0.5, color="#2B7B9B")
-    ax.axhline(0, color="black", linewidth=0.8)
+    ax.bar(
+        [x - width / 2 for x in xs],
+        uio,
+        width,
+        label=legend_uio,
+    )
+    ax.bar(
+        [x + width / 2 for x in xs],
+        vfio,
+        width,
+        label=legend_vfio,
+    )
     ax.set_xlabel("iodepth")
-    ax.set_ylabel("VFIO vs UIO IOPS delta (%)")
+    ax.set_ylabel(ylabel)
     ax.set_xticks(list(xs), [str(qd) for qd in qdepths])
+    ax.legend()
     fig.tight_layout()
     plt.savefig(output_path)
 
@@ -85,12 +149,22 @@ def create_plots(args):
 
     artifacts = args.output / "artifacts"
     os.makedirs(artifacts, exist_ok=True)
+    for path in artifacts.glob("upcie_iommu_overhead_RW=*_IOSIZE=*_TYPE=*.png"):
+        path.unlink()
 
     comparison = load_comparison(search)
     for (rw, iosize), entries in grouped_items(comparison["items"]).items():
         prefix = f"upcie_iommu_overhead_RW={safe_name(rw)}_IOSIZE={iosize}"
         plot_iops(entries, artifacts / f"{prefix}_TYPE=iops.png")
-        plot_delta(entries, artifacts / f"{prefix}_TYPE=delta.png")
+        plot_fio_iops(entries, artifacts / f"{prefix}_TYPE=fio_iops.png")
+        plot_latency(entries, artifacts / f"{prefix}_TYPE=latency.png")
+        for percentile, label in TAIL_LATENCIES:
+            plot_tail_latency(
+                entries,
+                artifacts / f"{prefix}_TYPE={percentile}_latency.png",
+                percentile,
+                label,
+            )
 
     return 0
 

--- a/cijoe/scripts/upcie_iommu_overhead_reporter.py
+++ b/cijoe/scripts/upcie_iommu_overhead_reporter.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Produce a uPCIe IOMMU overhead report
+=====================================
+"""
+import errno
+import json
+import logging as log
+import re
+import shlex
+import shutil
+import traceback
+from argparse import ArgumentParser
+from collections import defaultdict
+from pathlib import Path
+
+import jinja2
+from reporter import (
+    copy_graphs,
+    create_stylesheet,
+    create_test_setup,
+    create_xnvme_cover,
+    create_xnvme_info,
+)
+
+from cijoe.core.resources import dict_from_yamlfile
+
+COMPARISON_JSON = "upcie-iommu-overhead-comparison.json"
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--templates", type=Path, default=Path.cwd() / "templates" / "perf_report"
+    )
+    parser.add_argument("--path", type=Path, default=None)
+    parser.add_argument(
+        "--runs",
+        type=Path,
+        default=None,
+        help="Path to the workload matrix used by the compared benchmark runs",
+    )
+    parser.add_argument("--report_title", type=str, default="xNVMe uPCIe")
+    parser.add_argument("--report_subtitle", type=str, default="IOMMU Overhead Report")
+
+
+def load_comparison(search):
+    path = Path(search) / "artifacts" / COMPARISON_JSON
+    if not path.exists():
+        path = Path(search) / COMPARISON_JSON
+    with path.open() as jfd:
+        return json.load(jfd)
+
+
+def format_items(items):
+    rows = []
+    for item in items:
+        rows.append(
+            {
+                "rw": item["ctx"]["rw"],
+                "iosize": item["ctx"]["iosize"],
+                "iodepth": item["ctx"]["iodepth"],
+                "uio_iops": f"{item['uio']['iops']:.2f}",
+                "vfio_iops": f"{item['vfio']['iops']:.2f}",
+                "delta_pct": f"{item['delta_pct']:.2f}",
+                "uio_cv": f"{item['uio']['iops_cv']:.2f}",
+                "vfio_cv": f"{item['vfio']['iops_cv']:.2f}",
+            }
+        )
+    return rows
+
+
+def plot_groups(artifacts):
+    groups = defaultdict(dict)
+    for path in artifacts.glob("upcie_iommu_overhead_RW=*_IOSIZE=*_TYPE=*.png"):
+        parts = dict(
+            part.split("=", 1)
+            for part in path.stem.removeprefix("upcie_iommu_overhead_").split("_")
+            if "=" in part
+        )
+        key = (parts["RW"], parts["IOSIZE"])
+        groups[key][parts["TYPE"]] = path.name
+    return groups
+
+
+def workload_matrix(runs_path):
+    if not runs_path:
+        return []
+
+    runs = dict_from_yamlfile(runs_path)
+    matrix = []
+    for workload in runs.get("workloads", []):
+        matrix.append(
+            {
+                "rw": workload["pattern"],
+                "iosizes": ", ".join(str(value) for value in workload["iosizes"]),
+                "iodepths": ", ".join(str(value) for value in workload["iodepths"]),
+            }
+        )
+    return matrix
+
+
+def main(args, cijoe):
+    try:
+        templates_path = args.templates.resolve()
+        search_path = Path(args.path or cijoe.output_path).resolve()
+        artifacts = search_path / "artifacts"
+
+        report_path = cijoe.output_path / "artifacts" / "perf_report"
+        report_path.mkdir(parents=False, exist_ok=True)
+
+        body_path = report_path / "report.rst"
+        pdf_path = report_path / "upcie-iommu-overhead.pdf"
+        style_path = create_stylesheet(templates_path, report_path)
+        cover_path = create_xnvme_cover(
+            templates_path, report_path, args.report_title, args.report_subtitle
+        )
+        create_xnvme_info(templates_path, report_path)
+        create_test_setup(templates_path, report_path, artifacts)
+        copy_graphs(report_path, artifacts)
+
+        comparison = load_comparison(search_path)
+        rows = format_items(comparison["items"])
+        plots = plot_groups(artifacts)
+        workloads = workload_matrix(args.runs)
+
+        template_loader = jinja2.FileSystemLoader(templates_path)
+        template_env = jinja2.Environment(loader=template_loader)
+        template = template_env.get_template("upcie_iommu_overhead.jinja2.rst")
+
+        with body_path.open("w") as body:
+            body.write(
+                template.render(
+                    {
+                        "title": args.report_title,
+                        "subtitle": args.report_subtitle,
+                        "comparison": comparison,
+                        "rows": rows,
+                        "plots": plots,
+                        "workloads": workloads,
+                    }
+                )
+            )
+
+        err, _ = cijoe.run_local(
+            f"rst2pdf {shlex.quote(str(body_path))}"
+            f" -b1"
+            f" --custom-cover {shlex.quote(str(cover_path))}"
+            f" -s {shlex.quote(str(style_path))}"
+            f" -o {shlex.quote(str(pdf_path))}"
+        )
+        return err
+    except StopIteration:
+        log.error("Missing comparison artifact")
+        return errno.ENOENT
+    except Exception as exc:
+        log.error(f"Something failed({exc})")
+        log.error("".join(traceback.format_exception(None, exc, exc.__traceback__)))
+        return 1

--- a/cijoe/scripts/upcie_iommu_overhead_reporter.py
+++ b/cijoe/scripts/upcie_iommu_overhead_reporter.py
@@ -26,6 +26,12 @@ from reporter import (
 from cijoe.core.resources import dict_from_yamlfile
 
 COMPARISON_JSON = "upcie-iommu-overhead-comparison.json"
+PLOT_PATH_REGEX = r".*_RW=(?P<rw>.+)_IOSIZE=(?P<iosize>\d+)_TYPE=(?P<type>.+)\.png"
+TAIL_LATENCIES = [
+    ("p99_9", "P99.9"),
+    ("p99_99", "P99.99"),
+    ("p99_999", "P99.999"),
+]
 
 
 def add_args(parser: ArgumentParser):
@@ -54,31 +60,48 @@ def load_comparison(search):
 def format_items(items):
     rows = []
     for item in items:
-        rows.append(
-            {
-                "rw": item["ctx"]["rw"],
-                "iosize": item["ctx"]["iosize"],
-                "iodepth": item["ctx"]["iodepth"],
-                "uio_iops": f"{item['uio']['iops']:.2f}",
-                "vfio_iops": f"{item['vfio']['iops']:.2f}",
-                "delta_pct": f"{item['delta_pct']:.2f}",
-                "uio_cv": f"{item['uio']['iops_cv']:.2f}",
-                "vfio_cv": f"{item['vfio']['iops_cv']:.2f}",
-            }
-        )
+        row = {
+            "rw": item["ctx"]["rw"],
+            "iosize": item["ctx"]["iosize"],
+            "iodepth": item["ctx"]["iodepth"],
+            "throughput_runner": "xnvmeperf",
+            "latency_runner": "fio",
+            "uio_iops": f"{item['uio']['iops']:.2f}",
+            "vfio_iops": f"{item['vfio']['iops']:.2f}",
+            "delta_pct": f"{item['delta_pct']:.2f}",
+            "uio_fio_iops": f"{item['uio']['fio_iops']:.2f}",
+            "vfio_fio_iops": f"{item['vfio']['fio_iops']:.2f}",
+            "fio_delta_pct": f"{item['fio_delta_pct']:.2f}",
+            "uio_fio_cv": f"{item['uio']['fio_iops_cv']:.2f}",
+            "vfio_fio_cv": f"{item['vfio']['fio_iops_cv']:.2f}",
+            "uio_lat_us": f"{item['uio']['lat_ns'] / 1000.0:.2f}",
+            "vfio_lat_us": f"{item['vfio']['lat_ns'] / 1000.0:.2f}",
+            "lat_delta_pct": f"{item['lat_delta_pct']:.2f}",
+            "uio_cv": f"{item['uio']['iops_cv']:.2f}",
+            "vfio_cv": f"{item['vfio']['iops_cv']:.2f}",
+        }
+        for percentile, _ in TAIL_LATENCIES:
+            row[f"uio_{percentile}_us"] = (
+                f"{item['uio']['tail_lat_ns'][percentile] / 1000.0:.2f}"
+            )
+            row[f"vfio_{percentile}_us"] = (
+                f"{item['vfio']['tail_lat_ns'][percentile] / 1000.0:.2f}"
+            )
+            row[f"{percentile}_delta_pct"] = (
+                f"{item['tail_lat_delta_pct'][percentile]:.2f}"
+            )
+        rows.append(row)
     return rows
 
 
 def plot_groups(artifacts):
     groups = defaultdict(dict)
     for path in artifacts.glob("upcie_iommu_overhead_RW=*_IOSIZE=*_TYPE=*.png"):
-        parts = dict(
-            part.split("=", 1)
-            for part in path.stem.removeprefix("upcie_iommu_overhead_").split("_")
-            if "=" in part
-        )
-        key = (parts["RW"], parts["IOSIZE"])
-        groups[key][parts["TYPE"]] = path.name
+        match = re.match(PLOT_PATH_REGEX, path.name)
+        if not match:
+            continue
+        key = (match.group("rw"), match.group("iosize"))
+        groups[key][match.group("type")] = path.name
     return groups
 
 
@@ -99,6 +122,28 @@ def workload_matrix(runs_path):
     return matrix
 
 
+def report_sections(plots, rows):
+    grouped_rows = defaultdict(list)
+    for row in rows:
+        grouped_rows[(row["rw"], str(row["iosize"]))].append(row)
+
+    sections = []
+    for key, group_plots in sorted(plots.items(), key=lambda item: item[0]):
+        group_rows = sorted(
+            grouped_rows.get(key, []),
+            key=lambda row: int(row["iodepth"]),
+        )
+        sections.append(
+            {
+                "rw": key[0],
+                "iosize": key[1],
+                "plots": group_plots,
+                "rows": group_rows,
+            }
+        )
+    return sections
+
+
 def main(args, cijoe):
     try:
         templates_path = args.templates.resolve()
@@ -106,6 +151,8 @@ def main(args, cijoe):
         artifacts = search_path / "artifacts"
 
         report_path = cijoe.output_path / "artifacts" / "perf_report"
+        if report_path.exists():
+            shutil.rmtree(report_path)
         report_path.mkdir(parents=False, exist_ok=True)
 
         body_path = report_path / "report.rst"
@@ -122,6 +169,7 @@ def main(args, cijoe):
         rows = format_items(comparison["items"])
         plots = plot_groups(artifacts)
         workloads = workload_matrix(args.runs)
+        sections = report_sections(plots, rows)
 
         template_loader = jinja2.FileSystemLoader(templates_path)
         template_env = jinja2.Environment(loader=template_loader)
@@ -137,6 +185,8 @@ def main(args, cijoe):
                         "rows": rows,
                         "plots": plots,
                         "workloads": workloads,
+                        "sections": sections,
+                        "tail_latencies": TAIL_LATENCIES,
                     }
                 )
             )

--- a/cijoe/templates/perf_report/upcie_iommu_overhead.jinja2.rst
+++ b/cijoe/templates/perf_report/upcie_iommu_overhead.jinja2.rst
@@ -1,0 +1,122 @@
+.. footer::
+
+   ###Page### / ###Total###
+
+.. header::
+
+   ###Title### - ###Section###
+
+====================================
+ {{title}} - {{subtitle}}
+====================================
+
+.. contents:: Table of Contents
+   :depth: 2
+
+.. raw:: pdf
+
+   PageBreak oneColumn
+
+Audience
+========
+
+This report is for evaluating the steady-state performance difference between
+the ``uio_pci_generic`` and ``vfio-pci`` uPCIe paths in xNVMe.
+
+.. include:: xnvme.rst
+
+Purpose
+========
+
+The benchmark compares xNVMe ``upcie`` results collected from two separate boot
+configurations:
+
+* ``uio_pci_generic`` from a no-IOMMU setup
+* ``vfio-pci`` from an IOMMU-enabled setup
+
+The goal is to quantify the observed IOPS delta between the two paths for the
+same workload matrix.
+
+.. raw:: pdf
+
+   PageBreak
+
+.. include:: testsetup.rst
+
+.. raw:: pdf
+
+   PageBreak
+
+Methodology
+===========
+
+Each input run executes ``xnvmeperf`` against a single driver in the current boot
+configuration. The comparison step combines the normalized UIO and VFIO outputs
+by matching ``rw``, ``iosize``, and ``iodepth``.
+
+The reported delta is:
+
+``(vfio_iops - uio_iops) / uio_iops * 100``
+
+{% if workloads %}
+Workload Matrix
+---------------
+
+.. list-table::
+   :widths: 18 24 40
+   :header-rows: 1
+
+   * - RW
+     - IO sizes
+     - IO depths
+{% for workload in workloads %}
+   * - {{ workload.rw }}
+     - {{ workload.iosizes }}
+     - {{ workload.iodepths }}
+{% endfor %}
+
+{% endif %}
+
+Results
+=======
+
+{% for key, group_plots in plots.items() %}
+
+{{ key[0] }} / {{ key[1] }} bytes
+-------------------------------
+
+.. image:: {{ group_plots["iops"] }}
+   :align: center
+   :width: 85%
+
+.. image:: {{ group_plots["delta"] }}
+   :align: center
+   :width: 85%
+
+{% endfor %}
+
+Summary
+=======
+
+.. list-table::
+   :widths: 12 12 12 16 16 12 10 10
+   :header-rows: 1
+
+   * - RW
+     - IO size
+     - IO depth
+     - UIO IOPS
+     - VFIO IOPS
+     - Delta %
+     - UIO CV %
+     - VFIO CV %
+{% for row in rows %}
+   * - {{ row.rw }}
+     - {{ row.iosize }}
+     - {{ row.iodepth }}
+     - {{ row.uio_iops }}
+     - {{ row.vfio_iops }}
+     - {{ row.delta_pct }}
+     - {{ row.uio_cv }}
+     - {{ row.vfio_cv }}
+{% endfor %}

--- a/cijoe/templates/perf_report/upcie_iommu_overhead.jinja2.rst
+++ b/cijoe/templates/perf_report/upcie_iommu_overhead.jinja2.rst
@@ -50,13 +50,32 @@ same workload matrix.
 Methodology
 ===========
 
-Each input run executes ``xnvmeperf`` against a single driver in the current boot
-configuration. The comparison step combines the normalized UIO and VFIO outputs
-by matching ``rw``, ``iosize``, and ``iodepth``.
+Each input run executes ``xnvmeperf`` and ``fio`` against a single driver in the
+current boot configuration. ``xnvmeperf`` provides the primary throughput result.
+``fio`` provides an independent throughput result, the reported mean latency from
+``lat_ns.mean``, and tail completion latency from ``clat_ns.percentile``. The
+comparison step combines the normalized UIO and VFIO outputs by matching ``rw``,
+``iosize``, and ``iodepth``.
 
-The reported delta is:
+``xnvmeperf`` receives the configured CPU mask directly. ``fio`` runs with
+``numjobs`` set to the CPU mask popcount and ``cpus_allowed`` set to the expanded
+CPU list.
+
+Throughput deltas are reported per source using:
 
 ``(vfio_iops - uio_iops) / uio_iops * 100``
+
+A positive IOPS delta means VFIO delivered higher throughput than UIO. A negative
+IOPS delta means VFIO delivered lower throughput than UIO.
+
+The latency plots and summary table present ``fio`` latency in microseconds for
+readability. The latency delta is computed as ``(vfio - uio) / uio * 100``. A
+positive latency delta means VFIO has higher measured latency. A negative latency
+delta means VFIO has lower measured latency.
+
+Tail latency uses the same delta convention: a positive tail latency delta means
+VFIO has higher tail latency, while a negative tail latency delta means VFIO has
+lower tail latency. Delta values are reported in the summary tables.
 
 {% if workloads %}
 Workload Matrix
@@ -77,34 +96,81 @@ Workload Matrix
 
 {% endif %}
 
-Results
-=======
+xnvmeperf Throughput
+====================
 
-{% for key, group_plots in plots.items() %}
+{% for section in sections %}
 
-{{ key[0] }} / {{ key[1] }} bytes
+{{ section.rw }} / {{ section.iosize }} bytes
 -------------------------------
 
-.. image:: {{ group_plots["iops"] }}
+.. image:: {{ section.plots["iops"] }}
    :align: center
    :width: 85%
 
-.. image:: {{ group_plots["delta"] }}
-   :align: center
-   :width: 85%
+Delta: ``(vfio - uio) / uio * 100``. Positive means VFIO has higher IOPS;
+negative means VFIO has lower IOPS.
+
+.. list-table::
+   :widths: 12 12 12 12
+   :header-rows: 1
+
+   * - IO depth
+     - UIO IOPS
+     - VFIO IOPS
+     - Delta %
+{% for row in section.rows %}
+   * - {{ row.iodepth }}
+     - {{ row.uio_iops }}
+     - {{ row.vfio_iops }}
+     - {{ row.delta_pct }}
+{% endfor %}
 
 {% endfor %}
 
-Summary
-=======
+fio Throughput
+==============
+
+{% for section in sections %}
+
+{{ section.rw }} / {{ section.iosize }} bytes
+-------------------------------
+
+.. image:: {{ section.plots["fio_iops"] }}
+   :align: center
+   :width: 85%
+
+Delta: ``(vfio - uio) / uio * 100``. Positive means VFIO has higher IOPS;
+negative means VFIO has lower IOPS.
 
 .. list-table::
-   :widths: 12 12 12 16 16 12 10 10
+   :widths: 12 12 12 12
+   :header-rows: 1
+
+   * - IO depth
+     - UIO IOPS
+     - VFIO IOPS
+     - Delta %
+{% for row in section.rows %}
+   * - {{ row.iodepth }}
+     - {{ row.uio_fio_iops }}
+     - {{ row.vfio_fio_iops }}
+     - {{ row.fio_delta_pct }}
+{% endfor %}
+
+{% endfor %}
+
+Throughput Summary
+==================
+
+.. list-table::
+   :widths: 10 10 10 12 12 12 12 10 10
    :header-rows: 1
 
    * - RW
      - IO size
      - IO depth
+     - Source
      - UIO IOPS
      - VFIO IOPS
      - Delta %
@@ -114,9 +180,137 @@ Summary
    * - {{ row.rw }}
      - {{ row.iosize }}
      - {{ row.iodepth }}
+     - {{ row.throughput_runner }}
      - {{ row.uio_iops }}
      - {{ row.vfio_iops }}
      - {{ row.delta_pct }}
      - {{ row.uio_cv }}
      - {{ row.vfio_cv }}
+   * - {{ row.rw }}
+     - {{ row.iosize }}
+     - {{ row.iodepth }}
+     - {{ row.latency_runner }}
+     - {{ row.uio_fio_iops }}
+     - {{ row.vfio_fio_iops }}
+     - {{ row.fio_delta_pct }}
+     - {{ row.uio_fio_cv }}
+     - {{ row.vfio_fio_cv }}
+{% endfor %}
+
+fio Latency
+===========
+
+{% for section in sections %}
+
+{{ section.rw }} / {{ section.iosize }} bytes
+-------------------------------
+
+.. image:: {{ section.plots["latency"] }}
+   :align: center
+   :width: 85%
+
+Delta: ``(vfio - uio) / uio * 100``. Positive means VFIO has higher latency;
+negative means VFIO has lower latency.
+
+.. list-table::
+   :widths: 12 12 12 12
+   :header-rows: 1
+
+   * - IO depth
+     - UIO us
+     - VFIO us
+     - Delta %
+{% for row in section.rows %}
+   * - {{ row.iodepth }}
+     - {{ row.uio_lat_us }}
+     - {{ row.vfio_lat_us }}
+     - {{ row.lat_delta_pct }}
+{% endfor %}
+
+{% for percentile, label in tail_latencies %}
+
+.. image:: {{ section.plots[percentile ~ "_latency"] }}
+   :align: center
+   :width: 85%
+
+Delta: ``(vfio - uio) / uio * 100``. Positive means VFIO has higher {{ label }}
+latency; negative means VFIO has lower {{ label }} latency.
+
+.. list-table::
+   :widths: 12 12 12 12
+   :header-rows: 1
+
+   * - IO depth
+     - UIO us
+     - VFIO us
+     - Delta %
+{% for row in section.rows %}
+   * - {{ row.iodepth }}
+     - {{ row["uio_" ~ percentile ~ "_us"] }}
+     - {{ row["vfio_" ~ percentile ~ "_us"] }}
+     - {{ row[percentile ~ "_delta_pct"] }}
+{% endfor %}
+
+{% endfor %}
+
+{% endfor %}
+
+Latency Summary
+===============
+
+.. list-table::
+   :widths: 10 10 10 12 12 12 12
+   :header-rows: 1
+
+   * - RW
+     - IO size
+     - IO depth
+     - Source
+     - UIO FIO Latency (us)
+     - VFIO FIO Latency (us)
+     - Latency Delta %
+{% for row in rows %}
+   * - {{ row.rw }}
+     - {{ row.iosize }}
+     - {{ row.iodepth }}
+     - {{ row.latency_runner }}
+     - {{ row.uio_lat_us }}
+     - {{ row.vfio_lat_us }}
+     - {{ row.lat_delta_pct }}
+{% endfor %}
+
+Tail Latency Summary
+====================
+
+.. list-table::
+   :widths: 9 9 9 10 10 10 10 10 10 10 10 10 10
+   :header-rows: 1
+
+   * - RW
+     - IO size
+     - IO depth
+     - Source
+     - UIO P99.9 us
+     - VFIO P99.9 us
+     - P99.9 Delta %
+     - UIO P99.99 us
+     - VFIO P99.99 us
+     - P99.99 Delta %
+     - UIO P99.999 us
+     - VFIO P99.999 us
+     - P99.999 Delta %
+{% for row in rows %}
+   * - {{ row.rw }}
+     - {{ row.iosize }}
+     - {{ row.iodepth }}
+     - {{ row.latency_runner }}
+     - {{ row.uio_p99_9_us }}
+     - {{ row.vfio_p99_9_us }}
+     - {{ row.p99_9_delta_pct }}
+     - {{ row.uio_p99_99_us }}
+     - {{ row.vfio_p99_99_us }}
+     - {{ row.p99_99_delta_pct }}
+     - {{ row.uio_p99_999_us }}
+     - {{ row.vfio_p99_999_us }}
+     - {{ row.p99_999_delta_pct }}
 {% endfor %}

--- a/cijoe/workflows/benchmark-upcie-iommu-overhead.yaml
+++ b/cijoe/workflows/benchmark-upcie-iommu-overhead.yaml
@@ -1,6 +1,6 @@
 ---
 doc: |
-  Collect uPCIe IOMMU overhead benchmark inputs using xnvmeperf.
+  Collect uPCIe IOMMU overhead benchmark inputs using xnvmeperf and fio.
 
   This workflow measures one driver in the current boot configuration. A full
   comparison requires two benchmark runs and one report run:

--- a/cijoe/workflows/benchmark-upcie-iommu-overhead.yaml
+++ b/cijoe/workflows/benchmark-upcie-iommu-overhead.yaml
@@ -1,0 +1,33 @@
+---
+doc: |
+  Collect uPCIe IOMMU overhead benchmark inputs using xnvmeperf.
+
+  This workflow measures one driver in the current boot configuration. A full
+  comparison requires two benchmark runs and one report run:
+  1. boot with IOMMU off and collect uio_pci_generic
+  2. boot with IOMMU on and collect vfio-pci
+  3. run report-upcie-iommu-overhead.yaml to compare both outputs
+
+  VFIO example:
+  cijoe --config configs/default-config.toml
+        --config configs/upcie-iommu-overhead-vfio.toml
+        --output cijoe-output-upcie-vfio
+        workflows/benchmark-upcie-iommu-overhead.yaml
+
+  UIO example:
+  cijoe --config configs/default-config.toml
+        --config configs/upcie-iommu-overhead-uio.toml
+        --output cijoe-output-upcie-uio
+        workflows/benchmark-upcie-iommu-overhead.yaml
+
+steps:
+- name: sysinfo_report
+  uses: sysinfo_report
+
+- name: benchmark
+  uses: upcie_iommu_overhead
+  with:
+    runs: auxiliary/bench-upcie-iommu-overhead-runs.yaml
+
+- name: normalize
+  uses: upcie_iommu_overhead_normalize

--- a/cijoe/workflows/report-upcie-iommu-overhead.yaml
+++ b/cijoe/workflows/report-upcie-iommu-overhead.yaml
@@ -1,0 +1,33 @@
+---
+doc: |
+  Compare and report uPCIe IOMMU overhead benchmark outputs.
+
+  This workflow is the final step of a three-step measurement flow. It expects
+  two output directories produced by benchmark-upcie-iommu-overhead.yaml:
+  one from an IOMMU-off uio_pci_generic run and one from an IOMMU-on vfio-pci
+  run.
+
+  Example:
+  cijoe --config configs/default-config.toml
+        --config configs/upcie-iommu-overhead-report.toml
+        --output cijoe-output-upcie-iommu-report
+        workflows/report-upcie-iommu-overhead.yaml
+
+steps:
+- name: sysinfo_report
+  uses: sysinfo_report
+
+- name: compare
+  uses: upcie_iommu_overhead_compare
+  with:
+    runs: auxiliary/bench-upcie-iommu-overhead-runs.yaml
+
+- name: plot
+  uses: upcie_iommu_overhead_plotter
+
+- name: report
+  uses: upcie_iommu_overhead_reporter
+  with:
+    runs: auxiliary/bench-upcie-iommu-overhead-runs.yaml
+    report_title: "xNVMe uPCIe"
+    report_subtitle: "IOMMU Overhead Report"


### PR DESCRIPTION
  ## Summary

  Adds a CIJOE-based benchmark suite for measuring the IOMMU overhead of the
  uPCIe backend by comparing `uio_pci_generic` (IOMMU-off) and `vfio-pci`
  (IOMMU-on) under the same workload matrix.

  The flow is split into two commands and three steps:

  * `workflows/benchmark-upcie-iommu-overhead.yaml` — collect single-driver
    inputs (run twice, once per boot configuration). Runs `xnvmeperf` for
    primary throughput and `fio` for an independent throughput cross-check
    plus mean/tail completion latency. Validates `dmesg` to ensure the boot
    configuration matches the requested driver.
  * `workflows/report-upcie-iommu-overhead.yaml` — combine the two
    normalized outputs, emit comparison JSON/CSV artifacts and IOPS / FIO
    IOPS / latency / tail-latency plots, and render the result into a PDF
    report via `rst2pdf`.

  The benchmark recipe (runtime, repeat, cpumask, fio ramp/size, workload
  matrix) lives in `cijoe/auxiliary/bench-upcie-iommu-overhead-runs.yaml`;
  driver / BDF / nsid live in the per-driver config presets.


  The PR is split into four commits that build on each other:

  1. `test(cijoe): collect upcie IOMMU overhead inputs` — workflow,
     per-driver configs, runs YAML, collect + normalize scripts.
  2. `test(cijoe): compare upcie IOMMU overhead results` — combine + plot
     helpers (no workflow yet).
  3. `test(cijoe): report upcie IOMMU overhead comparisons` — report
     workflow, reporter, jinja2 template wiring (1) and (2) together.
  4. `test(cijoe): add fio metrics to upcie IOMMU report` — extend the
     pipeline end-to-end with fio mean/tail latency and FIO IOPS in
     comparison artifacts, plots, and the report template.

  ## Report
[upcie-iommu-overhead.pdf](https://github.com/user-attachments/files/27506895/upcie-iommu-overhead.pdf)


  ## How to run

  ```sh
  cd cijoe

  # Boot with intel_iommu=off / amd_iommu=off (or equivalent)
  cijoe \
    --config configs/default-config.toml \
    --config configs/upcie-iommu-overhead-uio.toml \
    --output cijoe-output-upcie-uio \
    workflows/benchmark-upcie-iommu-overhead.yaml

  # Reboot with IOMMU enabled
  cijoe \
    --config configs/default-config.toml \
    --config configs/upcie-iommu-overhead-vfio.toml \
    --output cijoe-output-upcie-vfio \
    workflows/benchmark-upcie-iommu-overhead.yaml

  # Combine + report
  cijoe \
    --config configs/default-config.toml \
    --config configs/upcie-iommu-overhead-report.toml \
    --output cijoe-output-upcie-iommu-report \
    workflows/report-upcie-iommu-overhead.yaml

  Update the BDF in configs/upcie-iommu-overhead-{uio,vfio}.toml to match
  the target NVMe device.

  Test plan

  - Run the UIO collect workflow on an IOMMU-off boot — artifacts
  contain xnvmeperf-output_*, fio-output_*, dmesg-iommu_*,
  xnvme-info_*, and benchmark-output-normalized.json
  - Run the VFIO collect workflow on an IOMMU-on boot — same artifacts
  - Driver/dmesg mismatch is rejected (UIO on IOMMU-on or vice versa)
  - Run the report workflow — emits upcie-iommu-overhead-comparison.{json,csv},
  per-workload plots, and perf_report/upcie-iommu-overhead.pdf
  - pre-commit run --all-files passes on the changed paths

 ## TODO
  - [ ] Support running against multiple NVMe devices in a single benchmark run