### PR TITLE
ci(tests): experiment — move pytest.skip to collection-time to reduce CI wall time

### DIFF
--- a/cijoe/tests/apps/test_fio.py
+++ b/cijoe/tests/apps/test_fio.py
@@ -10,16 +10,16 @@ FIO_OUTPUT_FPATH = (
 )
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "admin", "sync", "async", "mem"])
+# mem=[upcie-cuda]: fio engine does not support CUDA memory
+@xnvme_parametrize(
+    labels=["dev"],
+    opts=["be", "admin", "sync", "async", "mem"],
+    exclude={"mem": ["upcie-cuda"]},
+)
 def test_fio_engine(cijoe, device, be_opts, cli_args):
     """
     The construction of the fio-invocation is done in 'fio_fancy'
     """
-    if be_opts["mem"] == "upcie-cuda":
-        pytest.skip(
-            reason="[mem=upcie-cuda] fio xNVMe ioengine does not support CUDA memory"
-        )
-
     size = "64M"
     # size = "1G"
 
@@ -36,24 +36,24 @@ def test_fio_engine(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "admin", "sync", "async", "mem"])
+# async=[posix],sync=[psync]: iovec not implemented; admin=[driverkit]: iovec not implemented; mem=[upcie-cuda]: CUDA memory not supported
+@xnvme_parametrize(
+    labels=["dev"],
+    opts=["be", "admin", "sync", "async", "mem"],
+    exclude={
+        "async": ["posix"],
+        "sync": ["psync"],
+        "admin": ["driverkit"],
+        "mem": ["upcie-cuda"],
+    },
+)
 def test_fio_engine_iov(cijoe, device, be_opts, cli_args):
     """
     The construction of the fio-invocation is done in 'fio_fancy'
     """
 
-    if be_opts["async"] == "posix":
-        pytest.skip(reason="[async=posix] does not implement iovec")
-    if be_opts["sync"] == "psync":
-        pytest.skip(reason="[sync=psync] does not implement iovec")
     if get_osname() == "freebsd" and be_opts["sync"] == "nvme":
         pytest.skip(reason="[sync=nvme] on FreeBSD does not implement iovec")
-    if be_opts["admin"] == "driverkit":
-        pytest.skip(reason="[admin=driverkit] does not implement iovec")
-    if be_opts["mem"] == "upcie-cuda":
-        pytest.skip(
-            reason="[mem=upcie-cuda] fio xNVMe ioengine does not support CUDA memory"
-        )
 
     size = "64M"
     # size = "1G"
@@ -71,7 +71,12 @@ def test_fio_engine_iov(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["zns", "bdev"], opts=["be", "admin", "sync", "async", "mem"])
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; async=[thrpool]: thrpool does not support zbd/zns
+@xnvme_parametrize(
+    labels=["zns", "bdev"],
+    opts=["be", "admin", "sync", "async", "mem"],
+    exclude={"sync": ["psync", "block"], "async": ["thrpool"]},
+)
 def test_fio_engine_zns(cijoe, device, be_opts, cli_args):
     """
     The construction of the fio-invocation is done in 'fio_fancy'
@@ -82,10 +87,6 @@ def test_fio_engine_zns(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["sync"] in ["psync", "block"]:
-        pytest.skip(reason="[sync=psync,block] does not support mgmt. send/receive")
-    if be_opts["async"] == "thrpool":
-        pytest.skip(reason="[async=thrpool] gives Zone Invalid Write")
 
     size = "64M"
     # size = "1G"
@@ -103,15 +104,18 @@ def test_fio_engine_zns(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["fdp"], opts=["be", "admin", "sync", "async", "mem"])
+# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive
+@xnvme_parametrize(
+    labels=["fdp"],
+    opts=["be", "admin", "sync", "async", "mem"],
+    exclude={"sync": ["psync"]},
+)
 def test_fio_engine_fdp(cijoe, device, be_opts, cli_args):
     """
     The construction of the fio-invocation is done in 'fio_fancy'
     """
     if "cdev" not in device["labels"]:
         pytest.skip(reason="FIO requires a char device")
-    if be_opts["sync"] == "psync":
-        pytest.skip(reason="[sync=psync] cannot do write with directives")
 
     size = "64M"
     # size = "1G"

--- a/cijoe/tests/apps/test_fio.py
+++ b/cijoe/tests/apps/test_fio.py
@@ -36,7 +36,7 @@ def test_fio_engine(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-# async=[posix],sync=[psync]: iovec not implemented; admin=[driverkit]: iovec not implemented; mem=[upcie-cuda]: CUDA memory not supported
+# async=[posix],sync=[psync]: iovec not implemented; admin=[driverkit]: iovec not implemented; mem=[upcie-cuda]: CUDA memory not supported; os=[freebsd],sync=[nvme]: FreeBSD does not implement iovec
 @xnvme_parametrize(
     labels=["dev"],
     opts=["be", "admin", "sync", "async", "mem"],
@@ -46,14 +46,12 @@ def test_fio_engine(cijoe, device, be_opts, cli_args):
         "admin": ["driverkit"],
         "mem": ["upcie-cuda"],
     },
+    os_exclude={"freebsd": {"sync": ["nvme"]}},
 )
 def test_fio_engine_iov(cijoe, device, be_opts, cli_args):
     """
     The construction of the fio-invocation is done in 'fio_fancy'
     """
-
-    if get_osname() == "freebsd" and be_opts["sync"] == "nvme":
-        pytest.skip(reason="[sync=nvme] on FreeBSD does not implement iovec")
 
     size = "64M"
     # size = "1G"
@@ -71,22 +69,17 @@ def test_fio_engine_iov(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; async=[thrpool]: thrpool does not support zbd/zns
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; async=[thrpool]: thrpool does not support zbd/zns; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
     labels=["zns", "bdev"],
     opts=["be", "admin", "sync", "async", "mem"],
     exclude={"sync": ["psync", "block"], "async": ["thrpool"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_fio_engine_zns(cijoe, device, be_opts, cli_args):
     """
     The construction of the fio-invocation is done in 'fio_fancy'
     """
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
 
     size = "64M"
     # size = "1G"

--- a/cijoe/tests/conftest.py
+++ b/cijoe/tests/conftest.py
@@ -132,7 +132,7 @@ def xnvme_cli_args(device, be_opts):
     return " ".join(args)
 
 
-def xnvme_setup(labels=[], opts=[], exclude={}):
+def xnvme_setup(labels=[], opts=[], exclude={}, os_exclude={}):
     """Produces a config, yields (device, be_opts, cli_args)"""
 
     parametrization = []
@@ -141,8 +141,12 @@ def xnvme_setup(labels=[], opts=[], exclude={}):
         opts, ["file"] if "file" in labels else ["bdev", "cdev", "pcie", "fabrics"]
     )
 
+    effective_exclude = {k: list(v) for k, v in exclude.items()}
+    for key, vals in os_exclude.get(get_osname(), {}).items():
+        effective_exclude.setdefault(key, []).extend(vals)
+
     for be_opts in combinations:
-        if any(be_opts.get(key) in vals for key, vals in exclude.items()):
+        if any(be_opts.get(key) in vals for key, vals in effective_exclude.items()):
             continue
 
         search = labels + be_opts["label"]
@@ -393,7 +397,7 @@ def device(cijoe, request):
     return request.param
 
 
-def xnvme_parametrize(labels, opts, exclude={}):
+def xnvme_parametrize(labels, opts, exclude={}, os_exclude={}):
     """
     This decorator provides all the pytest-parametrization magic in one.
 
@@ -415,7 +419,9 @@ def xnvme_parametrize(labels, opts, exclude={}):
     def decorator(fun):
         @pytest.mark.parametrize(
             "device,be_opts,cli_args",
-            xnvme_setup(labels=labels, opts=opts, exclude=exclude),
+            xnvme_setup(
+                labels=labels, opts=opts, exclude=exclude, os_exclude=os_exclude
+            ),
             indirect=["device"],
         )
         @wraps(fun)

--- a/cijoe/tests/conftest.py
+++ b/cijoe/tests/conftest.py
@@ -132,7 +132,7 @@ def xnvme_cli_args(device, be_opts):
     return " ".join(args)
 
 
-def xnvme_setup(labels=[], opts=[]):
+def xnvme_setup(labels=[], opts=[], exclude={}):
     """Produces a config, yields (device, be_opts, cli_args)"""
 
     parametrization = []
@@ -142,6 +142,9 @@ def xnvme_setup(labels=[], opts=[]):
     )
 
     for be_opts in combinations:
+        if any(be_opts.get(key) in vals for key, vals in exclude.items()):
+            continue
+
         search = labels + be_opts["label"]
         device = cijoe_config_get_device(search)
 
@@ -390,7 +393,7 @@ def device(cijoe, request):
     return request.param
 
 
-def xnvme_parametrize(labels, opts):
+def xnvme_parametrize(labels, opts, exclude={}):
     """
     This decorator provides all the pytest-parametrization magic in one.
 
@@ -412,7 +415,7 @@ def xnvme_parametrize(labels, opts):
     def decorator(fun):
         @pytest.mark.parametrize(
             "device,be_opts,cli_args",
-            xnvme_setup(labels=labels, opts=opts),
+            xnvme_setup(labels=labels, opts=opts, exclude=exclude),
             indirect=["device"],
         )
         @wraps(fun)

--- a/cijoe/tests/examples/test_zoned_io_async.py
+++ b/cijoe/tests/examples/test_zoned_io_async.py
@@ -15,7 +15,12 @@ def test_write(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["zns"], opts=["be", "admin", "async"])
+# admin=[block]: block layer does not support append; async=[io_uring,libaio,posix]: these async backends do not support append
+@xnvme_parametrize(
+    labels=["zns"],
+    opts=["be", "admin", "async"],
+    exclude={"admin": ["block"], "async": ["io_uring", "libaio", "posix"]},
+)
 def test_append(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -23,11 +28,6 @@ def test_append(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="Block layer does not support append")
-
-    if be_opts["async"] in ["io_uring", "libaio", "posix"]:
-        pytest.skip(reason="Block-layer async does not support append")
 
     err, _ = cijoe.run(f"zoned_io_async append {cli_args}")
     assert not err

--- a/cijoe/tests/examples/test_zoned_io_async.py
+++ b/cijoe/tests/examples/test_zoned_io_async.py
@@ -1,45 +1,35 @@
-import pytest
-
-from ..conftest import get_osname, xnvme_parametrize
+from ..conftest import xnvme_parametrize
 
 
-@xnvme_parametrize(labels=["zns"], opts=["be", "admin", "async"])
+# os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
+@xnvme_parametrize(
+    labels=["zns"],
+    opts=["be", "admin", "async"],
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
+)
 def test_write(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
     err, _ = cijoe.run(f"zoned_io_async write {cli_args}")
     assert not err
 
 
-# admin=[block]: block layer does not support append; async=[io_uring,libaio,posix]: these async backends do not support append
+# admin=[block]: block layer does not support append; async=[io_uring,libaio,posix]: these async backends do not support append; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
     labels=["zns"],
     opts=["be", "admin", "async"],
     exclude={"admin": ["block"], "async": ["io_uring", "libaio", "posix"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_append(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
-
     err, _ = cijoe.run(f"zoned_io_async append {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["zns"], opts=["be", "admin", "async"])
+# os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
+@xnvme_parametrize(
+    labels=["zns"],
+    opts=["be", "admin", "async"],
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
+)
 def test_read(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
     err, _ = cijoe.run(f"zoned_io_async read {cli_args}")
     assert not err

--- a/cijoe/tests/examples/test_zoned_io_sync.py
+++ b/cijoe/tests/examples/test_zoned_io_sync.py
@@ -1,53 +1,37 @@
-import pytest
-
-from ..conftest import get_osname, xnvme_parametrize
+from ..conftest import xnvme_parametrize
 
 
-# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive
+# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
-    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync"]}
+    labels=["zns"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_write(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
-
     err, _ = cijoe.run(f"zoned_io_sync write {cli_args}")
     assert not err
 
 
-# admin=[block]: block layer does not support append; sync=[block,psync]: ENOSYS
+# admin=[block]: block layer does not support append; sync=[block,psync]: ENOSYS; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
     labels=["zns"],
     opts=["be", "admin", "sync"],
     exclude={"admin": ["block"], "sync": ["block", "psync"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_append(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
-
     err, _ = cijoe.run(f"zoned_io_sync append {cli_args}")
     assert not err
 
 
-# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive
+# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
-    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync"]}
+    labels=["zns"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_read(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
-
     err, _ = cijoe.run(f"zoned_io_sync read {cli_args}")
     assert not err

--- a/cijoe/tests/examples/test_zoned_io_sync.py
+++ b/cijoe/tests/examples/test_zoned_io_sync.py
@@ -3,7 +3,10 @@ import pytest
 from ..conftest import get_osname, xnvme_parametrize
 
 
-@xnvme_parametrize(labels=["zns"], opts=["be", "admin", "sync"])
+# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive
+@xnvme_parametrize(
+    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync"]}
+)
 def test_write(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -11,14 +14,17 @@ def test_write(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["sync"] == "psync":
-        pytest.skip(reason="psync(pread/write) does not support mgmt. send/receive")
 
     err, _ = cijoe.run(f"zoned_io_sync write {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["zns"], opts=["be", "admin", "sync"])
+# admin=[block]: block layer does not support append; sync=[block,psync]: ENOSYS
+@xnvme_parametrize(
+    labels=["zns"],
+    opts=["be", "admin", "sync"],
+    exclude={"admin": ["block"], "sync": ["block", "psync"]},
+)
 def test_append(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -26,16 +32,15 @@ def test_append(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["admin"] in ["block"]:
-        pytest.skip(reason="Linux Block layer does not support append")
-    if be_opts["sync"] in ["block", "psync"]:
-        pytest.skip(reason="Linux Block layer does not support append")
 
     err, _ = cijoe.run(f"zoned_io_sync append {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["zns"], opts=["be", "admin", "sync"])
+# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive
+@xnvme_parametrize(
+    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync"]}
+)
 def test_read(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -43,8 +48,6 @@ def test_read(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["sync"] == "psync":
-        pytest.skip(reason="psync(pread/write) does not support mgmt. send/receive")
 
     err, _ = cijoe.run(f"zoned_io_sync read {cli_args}")
     assert not err

--- a/cijoe/tests/logic/test_xnvme_tests_async_intf.py
+++ b/cijoe/tests/logic/test_xnvme_tests_async_intf.py
@@ -1,14 +1,11 @@
-import pytest
-
 from ..conftest import xnvme_parametrize
 
 
-@xnvme_parametrize(["dev"], opts=["be", "admin", "async"])
+# be=[upcie,upcie-cuda]: test requires more memory than available on these backends
+@xnvme_parametrize(
+    ["dev"], opts=["be", "admin", "async"], exclude={"be": ["upcie", "upcie-cuda"]}
+)
 def test_init_term(cijoe, device, be_opts, cli_args):
-    if be_opts["be"] in ("upcie", "upcie-cuda"):
-        pytest.skip(
-            reason=f"[be={be_opts['be']}] This test requires memory beyond what is available"
-        )
     qdepth = 64
     for count in [1, 2, 4, 8, 16, 32, 64, 128]:
         err, _ = cijoe.run(

--- a/cijoe/tests/logic/test_xnvme_tests_compare.py
+++ b/cijoe/tests/logic/test_xnvme_tests_compare.py
@@ -1,12 +1,10 @@
-import pytest
-
 from ..conftest import xnvme_parametrize
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "admin", "sync"])
+# sync=[block,psync]: compare not supported via block/psync
+@xnvme_parametrize(
+    labels=["dev"], opts=["be", "admin", "sync"], exclude={"sync": ["block", "psync"]}
+)
 def test_compare(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] in ["block", "psync"]:
-        pytest.skip(reason=f"Not supported: compare via {be_opts['sync']}")
-
     err, _ = cijoe.run(f"xnvme_tests_compare compare {cli_args}")
     assert not err

--- a/cijoe/tests/logic/test_xnvme_tests_copy.py
+++ b/cijoe/tests/logic/test_xnvme_tests_copy.py
@@ -1,42 +1,34 @@
-import pytest
-
 from ..conftest import xnvme_parametrize
 
 
-@xnvme_parametrize(labels=["scc"], opts=["be", "admin", "sync"])
+# sync=[block,psync]: simple-copy not supported; admin=[block]: doesn't report MSSRL on namespace
+@xnvme_parametrize(
+    labels=["scc"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["block", "psync"], "admin": ["block"]},
+)
 def test_copy(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] in ["block", "psync"]:
-        pytest.skip(reason=f"Not supported: simple-copy via {be_opts['sync']}")
-    if be_opts["admin"] == "block":
-        pytest.skip(
-            reason=f"Admin {be_opts['admin']} doesn't report MSSRL on the namespace"
-        )
-
     err, _ = cijoe.run(f"xnvme_tests_copy copy {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["scc"], opts=["be", "admin", "sync"])
+# sync=[block,psync]: simple-copy not supported; admin=[block]: doesn't report MSSRL on namespace
+@xnvme_parametrize(
+    labels=["scc"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["block", "psync"], "admin": ["block"]},
+)
 def test_copy_src_before_dest(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] in ["block", "psync"]:
-        pytest.skip(reason=f"Not supported: simple-copy via {be_opts['sync']}")
-    if be_opts["admin"] == "block":
-        pytest.skip(
-            reason=f"Admin {be_opts['admin']} doesn't report MSSRL on the namespace"
-        )
-
     err, _ = cijoe.run(f"xnvme_tests_copy copy {cli_args} --slba 0 --nlb 7 --sdlba 8")
     assert not err
 
 
-@xnvme_parametrize(labels=["scc"], opts=["be", "admin", "sync"])
+# sync=[block,psync]: simple-copy not supported; admin=[block]: doesn't report MSSRL on namespace
+@xnvme_parametrize(
+    labels=["scc"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["block", "psync"], "admin": ["block"]},
+)
 def test_copy_src_after_dest(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] in ["block", "psync"]:
-        pytest.skip(reason=f"Not supported: simple-copy via {be_opts['sync']}")
-    if be_opts["admin"] == "block":
-        pytest.skip(
-            reason=f"Admin {be_opts['admin']} doesn't report MSSRL on the namespace"
-        )
-
     err, _ = cijoe.run(f"xnvme_tests_copy copy {cli_args} --slba 8 --nlb 7 --sdlba 0")
     assert not err

--- a/cijoe/tests/logic/test_xnvme_tests_enum.py
+++ b/cijoe/tests/logic/test_xnvme_tests_enum.py
@@ -1,13 +1,11 @@
-import pytest
 import yaml
 
 from ..conftest import XnvmeDriver, cijoe_config_get_all_devices, xnvme_parametrize
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be"])
+# admin=[ramdisk]: ramdisk backend does not support enumeration
+@xnvme_parametrize(labels=["dev"], opts=["be"], exclude={"admin": ["ramdisk"]})
 def test_open(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "ramdisk":
-        pytest.skip(reason=f"[be={be_opts['be']}] does not support enumeration")
     if "fabrics" in device["labels"]:
         err, _ = cijoe.run(
             f"xnvme_tests_enum open --uri {device['uri']} --count 4 --be {be_opts['be']}"
@@ -17,11 +15,9 @@ def test_open(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be"])
+# admin=[ramdisk]: ramdisk backend does not support enumeration
+@xnvme_parametrize(labels=["dev"], opts=["be"], exclude={"admin": ["ramdisk"]})
 def test_keep_open(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "ramdisk":
-        pytest.skip(reason=f"[be={be_opts['be']}] does not support enumeration")
-
     if "fabrics" in device["labels"]:
         err, _ = cijoe.run(
             f"xnvme_tests_enum keep_open --uri {device['uri']} --be {be_opts['be']}"
@@ -31,11 +27,9 @@ def test_keep_open(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be"])
+# admin=[ramdisk]: ramdisk backend does not support enumeration
+@xnvme_parametrize(labels=["dev"], opts=["be"], exclude={"admin": ["ramdisk"]})
 def test_multi(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "ramdisk":
-        pytest.skip(reason=f"[be={be_opts['be']}] does not support enumeration")
-
     if "fabrics" in device["labels"]:
         err, _ = cijoe.run(
             f"xnvme_tests_enum multi --uri {device['uri']} --count 4 --be {be_opts['be']}"

--- a/cijoe/tests/logic/test_xnvme_tests_ioworker.py
+++ b/cijoe/tests/logic/test_xnvme_tests_ioworker.py
@@ -15,16 +15,15 @@ def test_verify_sync(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "sync", "async", "admin"])
+# async=[posix],sync=[psync]: iovec not implemented; admin=[driverkit]: iovec not implemented
+@xnvme_parametrize(
+    labels=["dev"],
+    opts=["be", "sync", "async", "admin"],
+    exclude={"async": ["posix"], "sync": ["psync"], "admin": ["driverkit"]},
+)
 def test_verify_iovec(cijoe, device, be_opts, cli_args):
-    if be_opts["async"] == "posix":
-        pytest.skip(reason="[async=posix] does not implement iovec")
-    if be_opts["sync"] == "psync":
-        pytest.skip(reason="[sync=psync] does not implement iovec")
     if get_osname() == "freebsd" and be_opts["sync"] == "nvme":
         pytest.skip(reason="[sync=nvme] on FreeBSD does not implement iovec")
-    if be_opts["admin"] == "driverkit":
-        pytest.skip(reason="[admin=driverkit] does not implement iovec")
 
     err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --vec-cnt 4")
 
@@ -34,14 +33,15 @@ def test_verify_iovec(cijoe, device, be_opts, cli_args):
         assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "sync", "admin"])
+# sync=[psync],admin=[driverkit]: iovec not implemented
+@xnvme_parametrize(
+    labels=["dev"],
+    opts=["be", "sync", "admin"],
+    exclude={"sync": ["psync"], "admin": ["driverkit"]},
+)
 def test_verify_sync_iovec(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] == "psync":
-        pytest.skip(reason="[sync=psync] does not implement iovec")
     if get_osname() == "freebsd" and be_opts["sync"] == "nvme":
         pytest.skip(reason="[sync=nvme] on FreeBSD does not implement iovec")
-    if be_opts["admin"] == "driverkit":
-        pytest.skip(reason="[admin=driverkit] does not implement iovec")
 
     err, _ = cijoe.run(f"xnvme_tests_ioworker verify-sync {cli_args} --vec-cnt 4")
 
@@ -63,16 +63,15 @@ def test_verify_sync_direct(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "sync", "async", "admin"])
+# async=[posix],sync=[psync]: iovec not implemented; admin=[driverkit]: iovec not implemented
+@xnvme_parametrize(
+    labels=["dev"],
+    opts=["be", "sync", "async", "admin"],
+    exclude={"async": ["posix"], "sync": ["psync"], "admin": ["driverkit"]},
+)
 def test_verify_iovec_direct(cijoe, device, be_opts, cli_args):
-    if be_opts["async"] == "posix":
-        pytest.skip(reason="[async=posix] does not implement iovec")
-    if be_opts["sync"] == "psync":
-        pytest.skip(reason="[sync=psync] does not implement iovec")
     if get_osname() == "freebsd" and be_opts["sync"] == "nvme":
         pytest.skip(reason="[sync=nvme] on FreeBSD does not implement iovec")
-    if be_opts["admin"] == "driverkit":
-        pytest.skip(reason="[admin=driverkit] does not implement iovec")
 
     err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --vec-cnt 4 --direct 1")
 
@@ -82,14 +81,15 @@ def test_verify_iovec_direct(cijoe, device, be_opts, cli_args):
         assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "sync", "admin"])
+# sync=[psync],admin=[driverkit]: iovec not implemented
+@xnvme_parametrize(
+    labels=["dev"],
+    opts=["be", "sync", "admin"],
+    exclude={"sync": ["psync"], "admin": ["driverkit"]},
+)
 def test_verify_sync_iovec_direct(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] == "psync":
-        pytest.skip(reason="[sync=psync] does not implement iovec")
     if get_osname() == "freebsd" and be_opts["sync"] == "nvme":
         pytest.skip(reason="[sync=nvme] on FreeBSD does not implement iovec")
-    if be_opts["admin"] == "driverkit":
-        pytest.skip(reason="[admin=driverkit] does not implement iovec")
 
     err, _ = cijoe.run(
         f"xnvme_tests_ioworker verify-sync {cli_args} --vec-cnt 4 --direct 1"

--- a/cijoe/tests/logic/test_xnvme_tests_ioworker.py
+++ b/cijoe/tests/logic/test_xnvme_tests_ioworker.py
@@ -1,6 +1,4 @@
-import pytest
-
-from ..conftest import get_osname, xnvme_parametrize
+from ..conftest import xnvme_parametrize
 
 
 @xnvme_parametrize(labels=["dev"], opts=["be", "sync", "async", "admin"])
@@ -15,16 +13,14 @@ def test_verify_sync(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-# async=[posix],sync=[psync]: iovec not implemented; admin=[driverkit]: iovec not implemented
+# async=[posix],sync=[psync]: iovec not implemented; admin=[driverkit]: iovec not implemented; os=[freebsd],sync=[nvme]: FreeBSD does not implement iovec
 @xnvme_parametrize(
     labels=["dev"],
     opts=["be", "sync", "async", "admin"],
     exclude={"async": ["posix"], "sync": ["psync"], "admin": ["driverkit"]},
+    os_exclude={"freebsd": {"sync": ["nvme"]}},
 )
 def test_verify_iovec(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["sync"] == "nvme":
-        pytest.skip(reason="[sync=nvme] on FreeBSD does not implement iovec")
-
     err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --vec-cnt 4")
 
     if be_opts["admin"] == "spdk" and "nosgl" in device["labels"]:
@@ -33,16 +29,14 @@ def test_verify_iovec(cijoe, device, be_opts, cli_args):
         assert not err
 
 
-# sync=[psync],admin=[driverkit]: iovec not implemented
+# sync=[psync],admin=[driverkit]: iovec not implemented; os=[freebsd],sync=[nvme]: FreeBSD does not implement iovec
 @xnvme_parametrize(
     labels=["dev"],
     opts=["be", "sync", "admin"],
     exclude={"sync": ["psync"], "admin": ["driverkit"]},
+    os_exclude={"freebsd": {"sync": ["nvme"]}},
 )
 def test_verify_sync_iovec(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["sync"] == "nvme":
-        pytest.skip(reason="[sync=nvme] on FreeBSD does not implement iovec")
-
     err, _ = cijoe.run(f"xnvme_tests_ioworker verify-sync {cli_args} --vec-cnt 4")
 
     if be_opts["admin"] == "spdk" and "nosgl" in device["labels"]:
@@ -63,16 +57,14 @@ def test_verify_sync_direct(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-# async=[posix],sync=[psync]: iovec not implemented; admin=[driverkit]: iovec not implemented
+# async=[posix],sync=[psync]: iovec not implemented; admin=[driverkit]: iovec not implemented; os=[freebsd],sync=[nvme]: FreeBSD does not implement iovec
 @xnvme_parametrize(
     labels=["dev"],
     opts=["be", "sync", "async", "admin"],
     exclude={"async": ["posix"], "sync": ["psync"], "admin": ["driverkit"]},
+    os_exclude={"freebsd": {"sync": ["nvme"]}},
 )
 def test_verify_iovec_direct(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["sync"] == "nvme":
-        pytest.skip(reason="[sync=nvme] on FreeBSD does not implement iovec")
-
     err, _ = cijoe.run(f"xnvme_tests_ioworker verify {cli_args} --vec-cnt 4 --direct 1")
 
     if be_opts["admin"] == "spdk" and "nosgl" in device["labels"]:
@@ -81,15 +73,14 @@ def test_verify_iovec_direct(cijoe, device, be_opts, cli_args):
         assert not err
 
 
-# sync=[psync],admin=[driverkit]: iovec not implemented
+# sync=[psync],admin=[driverkit]: iovec not implemented; os=[freebsd],sync=[nvme]: FreeBSD does not implement iovec
 @xnvme_parametrize(
     labels=["dev"],
     opts=["be", "sync", "admin"],
     exclude={"sync": ["psync"], "admin": ["driverkit"]},
+    os_exclude={"freebsd": {"sync": ["nvme"]}},
 )
 def test_verify_sync_iovec_direct(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["sync"] == "nvme":
-        pytest.skip(reason="[sync=nvme] on FreeBSD does not implement iovec")
 
     err, _ = cijoe.run(
         f"xnvme_tests_ioworker verify-sync {cli_args} --vec-cnt 4 --direct 1"

--- a/cijoe/tests/logic/test_xnvme_tests_lblk.py
+++ b/cijoe/tests/logic/test_xnvme_tests_lblk.py
@@ -1,5 +1,3 @@
-import pytest
-
 from ..conftest import xnvme_parametrize
 
 
@@ -9,19 +7,23 @@ def test_io(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["write_uncor"], opts=["be", "admin", "sync"])
+# sync=[block,psync]: write_uncorrectable not supported via block/psync
+@xnvme_parametrize(
+    labels=["write_uncor"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["block", "psync"]},
+)
 def test_write_uncorrectable(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] in ["block", "psync"]:
-        pytest.skip(reason=f"Not supported: write_uncor via {be_opts['sync']}")
-
     err, _ = cijoe.run(f"xnvme_tests_lblk write_uncorrectable {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["write_zeroes"], opts=["be", "admin", "sync"])
+# sync=[block,psync]: write_zeroes not supported via block/psync
+@xnvme_parametrize(
+    labels=["write_zeroes"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["block", "psync"]},
+)
 def test_write_zeroes(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] in ["block", "psync"]:
-        pytest.skip(reason=f"Not supported: write_zeroes via {be_opts['sync']}")
-
     err, _ = cijoe.run(f"xnvme_tests_lblk write_zeroes {cli_args}")
     assert not err

--- a/cijoe/tests/logic/test_xnvme_tests_scc.py
+++ b/cijoe/tests/logic/test_xnvme_tests_scc.py
@@ -1,65 +1,67 @@
-import pytest
-
 from ..conftest import xnvme_parametrize
 
 
-@xnvme_parametrize(labels=["scc"], opts=["be", "admin", "sync"])
+# sync=[block,psync]: Linux block layer does not support simple-copy; admin=[block]: same
+@xnvme_parametrize(
+    labels=["scc"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["block", "psync"], "admin": ["block"]},
+)
 def test_idfy(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] in ["block", "psync"]:
-        pytest.skip(reason="Linux Block layer does not support simple-copy")
-
     err, _ = cijoe.run(f"xnvme_tests_scc idfy {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["scc"], opts=["be", "admin", "sync"])
+# sync=[block,psync]: Linux block layer does not support simple-copy; admin=[block]: same
+@xnvme_parametrize(
+    labels=["scc"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["block", "psync"], "admin": ["block"]},
+)
 def test_support(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="Linux Block layer does not support simple-copy")
-
     err, _ = cijoe.run(f"xnvme_tests_scc support {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["scc"], opts=["be", "admin", "sync"])
+# sync=[block,psync]: Linux block layer does not support simple-copy; admin=[block]: same
+@xnvme_parametrize(
+    labels=["scc"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["block", "psync"], "admin": ["block"]},
+)
 def test_scopy(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="Linux Block layer does not support simple-copy")
-    if be_opts["sync"] in ["block", "psync"]:
-        pytest.skip(reason="Does not support simple-copy")
-
     err, _ = cijoe.run(f"xnvme_tests_scc scopy {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["scc"], opts=["be", "admin", "sync"])
+# sync=[block,psync]: Linux block layer does not support simple-copy; admin=[block]: same
+@xnvme_parametrize(
+    labels=["scc"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["block", "psync"], "admin": ["block"]},
+)
 def test_scopy_clear(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="Linux Block layer does not support simple-copy")
-    if be_opts["sync"] in ["block", "psync"]:
-        pytest.skip(reason="Does not support simple-copy")
-
     err, _ = cijoe.run(f"xnvme_tests_scc scopy {cli_args} --clear")
     assert not err
 
 
-@xnvme_parametrize(labels=["scc"], opts=["be", "admin", "sync"])
+# sync=[block,psync]: Linux block layer does not support simple-copy; admin=[block]: same
+@xnvme_parametrize(
+    labels=["scc"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["block", "psync"], "admin": ["block"]},
+)
 def test_scopy_msrc(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="Linux Block layer does not support simple-copy")
-    if be_opts["sync"] in ["block", "psync"]:
-        pytest.skip(reason="Does not support simple-copy")
-
     err, _ = cijoe.run(f"xnvme_tests_scc scopy-msrc {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["scc"], opts=["be", "admin", "sync"])
+# sync=[block,psync]: Linux block layer does not support simple-copy; admin=[block]: same
+@xnvme_parametrize(
+    labels=["scc"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["block", "psync"], "admin": ["block"]},
+)
 def test_scopy_msrc_clear(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="Linux Block layer does not support simple-copy")
-    if be_opts["sync"] in ["block", "psync"]:
-        pytest.skip(reason="Does not support simple-copy")
-
     err, _ = cijoe.run(f"xnvme_tests_scc scopy-msrc {cli_args} --clear")
     assert not err

--- a/cijoe/tests/logic/test_xnvme_tests_znd_append.py
+++ b/cijoe/tests/logic/test_xnvme_tests_znd_append.py
@@ -1,15 +1,12 @@
-import pytest
-
-from ..conftest import get_osname, xnvme_parametrize
+from ..conftest import xnvme_parametrize
 
 
-@xnvme_parametrize(labels=["zns"], opts=["be", "admin", "async"])
+# os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
+@xnvme_parametrize(
+    labels=["zns"],
+    opts=["be", "admin", "async"],
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
+)
 def test_verify(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
     err, _ = cijoe.run(f"xnvme_tests_znd_append verify {cli_args}")
     assert not err

--- a/cijoe/tests/logic/test_xnvme_tests_znd_state.py
+++ b/cijoe/tests/logic/test_xnvme_tests_znd_state.py
@@ -1,19 +1,13 @@
-import pytest
-
-from ..conftest import get_osname, xnvme_parametrize
+from ..conftest import xnvme_parametrize
 
 
-# sync=[psync]: psync cannot do mgmt send/receive
+# sync=[psync]: psync cannot do mgmt send/receive; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
-    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync"]}
+    labels=["zns"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_transition(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
-
     err, _ = cijoe.run(f"xnvme_tests_znd_state transition {cli_args}")
     assert not err

--- a/cijoe/tests/logic/test_xnvme_tests_znd_state.py
+++ b/cijoe/tests/logic/test_xnvme_tests_znd_state.py
@@ -3,7 +3,10 @@ import pytest
 from ..conftest import get_osname, xnvme_parametrize
 
 
-@xnvme_parametrize(labels=["zns"], opts=["be", "admin", "sync"])
+# sync=[psync]: psync cannot do mgmt send/receive
+@xnvme_parametrize(
+    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync"]}
+)
 def test_transition(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -11,8 +14,6 @@ def test_transition(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["sync"] == "psync":
-        pytest.skip(reason="Cannot do mgmt send/receive via psync")
 
     err, _ = cijoe.run(f"xnvme_tests_znd_state transition {cli_args}")
     assert not err

--- a/cijoe/tests/logic/test_xnvme_tests_znd_zrwa.py
+++ b/cijoe/tests/logic/test_xnvme_tests_znd_zrwa.py
@@ -3,29 +3,34 @@ import pytest
 from ..conftest import get_osname, xnvme_parametrize
 
 
-@xnvme_parametrize(labels=["zrwa"], opts=["be", "admin", "sync"])
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same
+@xnvme_parametrize(
+    labels=["zrwa"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync", "block"], "admin": ["block"]},
+)
 def test_idfy(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] in ["psync", "block"]:
-        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do mgmt send/receive")
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="ENOSYS: admin=[block] cannot do mgmt send/receive")
-
     err, _ = cijoe.run(f"xnvme_tests_znd_zrwa idfy {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["zrwa"], opts=["be", "admin", "sync"])
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same
+@xnvme_parametrize(
+    labels=["zrwa"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync", "block"], "admin": ["block"]},
+)
 def test_support(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] in ["psync", "block"]:
-        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do mgmt send/receive")
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="ENOSYS: admin=[block] cannot do mgmt send/receive")
-
     err, _ = cijoe.run(f"xnvme_tests_znd_zrwa support {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["zrwa"], opts=["be", "admin", "sync"])
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same
+@xnvme_parametrize(
+    labels=["zrwa"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync", "block"], "admin": ["block"]},
+)
 def test_open_with_zrwa(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -33,16 +38,16 @@ def test_open_with_zrwa(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["sync"] in ["psync", "block"]:
-        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do mgmt send/receive")
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="ENOSYS: admin=[block] cannot do mgmt send/receive")
-
     err, _ = cijoe.run(f"xnvme_tests_znd_zrwa open-with-zrwa {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["zrwa"], opts=["be", "admin", "sync"])
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same
+@xnvme_parametrize(
+    labels=["zrwa"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync", "block"], "admin": ["block"]},
+)
 def test_open_without_zrwa(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -50,16 +55,16 @@ def test_open_without_zrwa(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["sync"] in ["psync", "block"]:
-        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do mgmt send/receive")
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="ENOSYS: admin=[block] cannot do mgmt send/receive")
-
     err, _ = cijoe.run(f"xnvme_tests_znd_zrwa open-without-zrwa {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["zrwa"], opts=["be", "admin", "sync"])
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same
+@xnvme_parametrize(
+    labels=["zrwa"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync", "block"], "admin": ["block"]},
+)
 def test_flush(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -67,16 +72,16 @@ def test_flush(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["sync"] in ["psync", "block"]:
-        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do mgmt send/receive")
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="ENOSYS: admin=[block] cannot do mgmt send/receive")
-
     err, _ = cijoe.run(f"xnvme_tests_znd_zrwa flush {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["zrwa"], opts=["be", "admin", "sync"])
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same
+@xnvme_parametrize(
+    labels=["zrwa"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync", "block"], "admin": ["block"]},
+)
 def test_flush_explicit(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -84,16 +89,16 @@ def test_flush_explicit(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["sync"] in ["psync", "block"]:
-        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do mgmt send/receive")
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="ENOSYS: admin=[block] cannot do mgmt send/receive")
-
     err, _ = cijoe.run(f"xnvme_tests_znd_zrwa flush-explicit {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["zrwa"], opts=["be", "admin", "sync"])
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same
+@xnvme_parametrize(
+    labels=["zrwa"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync", "block"], "admin": ["block"]},
+)
 def test_flush_implicit(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -101,10 +106,5 @@ def test_flush_implicit(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["sync"] in ["psync", "block"]:
-        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do mgmt send/receive")
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="ENOSYS: admin=[block] cannot do mgmt send/receive")
-
     err, _ = cijoe.run(f"xnvme_tests_znd_zrwa flush-implicit {cli_args}")
     assert not err

--- a/cijoe/tests/logic/test_xnvme_tests_znd_zrwa.py
+++ b/cijoe/tests/logic/test_xnvme_tests_znd_zrwa.py
@@ -1,6 +1,4 @@
-import pytest
-
-from ..conftest import get_osname, xnvme_parametrize
+from ..conftest import xnvme_parametrize
 
 
 # sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same
@@ -25,86 +23,61 @@ def test_support(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
     labels=["zrwa"],
     opts=["be", "admin", "sync"],
     exclude={"sync": ["psync", "block"], "admin": ["block"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_open_with_zrwa(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
     err, _ = cijoe.run(f"xnvme_tests_znd_zrwa open-with-zrwa {cli_args}")
     assert not err
 
 
-# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
     labels=["zrwa"],
     opts=["be", "admin", "sync"],
     exclude={"sync": ["psync", "block"], "admin": ["block"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_open_without_zrwa(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
     err, _ = cijoe.run(f"xnvme_tests_znd_zrwa open-without-zrwa {cli_args}")
     assert not err
 
 
-# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
     labels=["zrwa"],
     opts=["be", "admin", "sync"],
     exclude={"sync": ["psync", "block"], "admin": ["block"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_flush(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
     err, _ = cijoe.run(f"xnvme_tests_znd_zrwa flush {cli_args}")
     assert not err
 
 
-# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
     labels=["zrwa"],
     opts=["be", "admin", "sync"],
     exclude={"sync": ["psync", "block"], "admin": ["block"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_flush_explicit(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
     err, _ = cijoe.run(f"xnvme_tests_znd_zrwa flush-explicit {cli_args}")
     assert not err
 
 
-# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; admin=[block]: same; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
     labels=["zrwa"],
     opts=["be", "admin", "sync"],
     exclude={"sync": ["psync", "block"], "admin": ["block"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_flush_implicit(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
     err, _ = cijoe.run(f"xnvme_tests_znd_zrwa flush-implicit {cli_args}")
     assert not err

--- a/cijoe/tests/tools/test_fdp.py
+++ b/cijoe/tests/tools/test_fdp.py
@@ -1,13 +1,9 @@
-import pytest
-
-from ..conftest import XnvmeDriver, xnvme_parametrize
+from ..conftest import xnvme_parametrize
 
 
-@xnvme_parametrize(labels=["fdp"], opts=["be", "admin"])
+# admin=[block]: block layer does not implement FDP log/feature commands
+@xnvme_parametrize(labels=["fdp"], opts=["be", "admin"], exclude={"admin": ["block"]})
 def test_log_fdp(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not implement fdp log pages")
-
     err, _ = cijoe.run(f"xnvme log-fdp-config {cli_args} --lsi 0x1 --data-nbytes 512")
     assert not err
 
@@ -25,11 +21,9 @@ def test_log_fdp(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["fdp"], opts=["be", "admin"])
+# admin=[block]: block layer does not implement FDP log/feature commands
+@xnvme_parametrize(labels=["fdp"], opts=["be", "admin"], exclude={"admin": ["block"]})
 def test_feature_set_fdp_events(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not implement feature-get")
-
     # Enable all FDP events (0xFF events on placement handle 0)
     err, _ = cijoe.run(
         f"xnvme set-fdp-events {cli_args} --fid 0x1e --feat 0xFF0000 --cdw12 0x1"
@@ -37,11 +31,9 @@ def test_feature_set_fdp_events(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["fdp"], opts=["be", "admin"])
+# admin=[block]: block layer does not implement FDP log/feature commands
+@xnvme_parametrize(labels=["fdp"], opts=["be", "admin"], exclude={"admin": ["block"]})
 def test_feature_get_fdp(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not implement feature-get")
-
     # Get feature FDP (Endurance group id 0x1 on qemu)
     err, _ = cijoe.run(f"xnvme feature-get {cli_args} --fid 0x1d --cdw11 0x1")
     assert not err
@@ -53,20 +45,20 @@ def test_feature_get_fdp(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["fdp"], opts=["be", "admin", "sync"])
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive
+@xnvme_parametrize(
+    labels=["fdp"], opts=["be", "admin", "sync"], exclude={"sync": ["psync", "block"]}
+)
 def test_ruhs(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] in ["psync", "block"]:
-        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do mgmt send/receive")
-
     err, _ = cijoe.run(f"xnvme fdp-ruhs {cli_args} --limit 128")
     assert not err
 
 
-@xnvme_parametrize(labels=["fdp"], opts=["be", "admin", "sync"])
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive
+@xnvme_parametrize(
+    labels=["fdp"], opts=["be", "admin", "sync"], exclude={"sync": ["psync", "block"]}
+)
 def test_write_dir(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] in ["psync", "block"]:
-        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do write with directives")
-
     # Write (DPD) to placement id 0x0
     err, _ = cijoe.run(
         f"lblk write-dir {cli_args} --slba 0x0 --nlb 2 --dtype 0x2 --dspec 0x0"
@@ -74,11 +66,11 @@ def test_write_dir(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["fdp"], opts=["be", "admin", "sync"])
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive
+@xnvme_parametrize(
+    labels=["fdp"], opts=["be", "admin", "sync"], exclude={"sync": ["psync", "block"]}
+)
 def test_ruhu(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] in ["psync", "block"]:
-        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do mgmt send/receive")
-
     # Reclaim unit handle update for Placement id 0x0)
     err, _ = cijoe.run(f"xnvme fdp-ruhu {cli_args} --pid 0x0")
     assert not err

--- a/cijoe/tests/tools/test_lblk.py
+++ b/cijoe/tests/tools/test_lblk.py
@@ -1,6 +1,4 @@
-import pytest
-
-from ..conftest import XnvmeDriver, get_osname, xnvme_parametrize
+from ..conftest import XnvmeDriver, xnvme_parametrize
 
 
 def test_enum(cijoe):
@@ -71,12 +69,14 @@ def test_write_zeroes(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-# admin=[block]: block layer does not support metadata/PI operations
-@xnvme_parametrize(labels=["pi1"], opts=["be", "admin"], exclude={"admin": ["block"]})
+# admin=[block]: block layer does not support metadata/PI operations; os=[freebsd],admin=[nvme]: FreeBSD nvme admin does not support metadata
+@xnvme_parametrize(
+    labels=["pi1"],
+    opts=["be", "admin"],
+    exclude={"admin": ["block"]},
+    os_exclude={"freebsd": {"admin": ["nvme"]}},
+)
 def test_pi_type1(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["admin"] == "nvme":
-        pytest.skip(reason="[admin=nvme] does not support metadata")
-
     err, _ = cijoe.run(
         f"lblk write-read-pi {cli_args} --slba 0x0 --nlb 0 --pract 1 --prchk 0x5"
     )
@@ -88,12 +88,14 @@ def test_pi_type1(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-# admin=[block]: block layer does not support metadata/PI operations
-@xnvme_parametrize(labels=["pi2"], opts=["be", "admin"], exclude={"admin": ["block"]})
+# admin=[block]: block layer does not support metadata/PI operations; os=[freebsd],admin=[nvme]: FreeBSD nvme admin does not support metadata
+@xnvme_parametrize(
+    labels=["pi2"],
+    opts=["be", "admin"],
+    exclude={"admin": ["block"]},
+    os_exclude={"freebsd": {"admin": ["nvme"]}},
+)
 def test_pi_type2(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["admin"] == "nvme":
-        pytest.skip(reason="[admin=nvme] does not support metadata")
-
     err, _ = cijoe.run(
         f"lblk write-read-pi {cli_args} --slba 0x0 --nlb 0 --pract 1 --prchk 0x5"
     )
@@ -105,11 +107,14 @@ def test_pi_type2(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-# admin=[block]: block layer does not support metadata/PI operations
-@xnvme_parametrize(labels=["pi3"], opts=["be", "admin"], exclude={"admin": ["block"]})
+# admin=[block]: block layer does not support metadata/PI operations; os=[freebsd],admin=[nvme]: FreeBSD nvme admin does not support metadata
+@xnvme_parametrize(
+    labels=["pi3"],
+    opts=["be", "admin"],
+    exclude={"admin": ["block"]},
+    os_exclude={"freebsd": {"admin": ["nvme"]}},
+)
 def test_pi_type3(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["admin"] == "nvme":
-        pytest.skip(reason="[admin=nvme] does not support metadata")
 
     # For PI type 3 prchk 0bxx1 is invalid
     # Thus using prchk 0b100
@@ -141,13 +146,14 @@ def test_pi_type1_extended_lba(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-# admin=[block]: block layer does not support metadata/PI operations
+# admin=[block]: block layer does not support metadata/PI operations; os=[freebsd],admin=[nvme]: FreeBSD nvme admin does not support metadata
 @xnvme_parametrize(
-    labels=["pi1_pif2"], opts=["be", "admin"], exclude={"admin": ["block"]}
+    labels=["pi1_pif2"],
+    opts=["be", "admin"],
+    exclude={"admin": ["block"]},
+    os_exclude={"freebsd": {"admin": ["nvme"]}},
 )
 def test_pi1_pif2(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["admin"] == "nvme":
-        pytest.skip(reason="[admin=nvme] does not support metadata")
 
     err, _ = cijoe.run(
         f"lblk write-read-pi {cli_args} --slba 0x0 --nlb 0 --pract 1 --prchk 0x5"

--- a/cijoe/tests/tools/test_lblk.py
+++ b/cijoe/tests/tools/test_lblk.py
@@ -19,10 +19,11 @@ def test_info(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
+# mem=[upcie-cuda]: test does not support CUDA memory
+@xnvme_parametrize(
+    labels=["dev"], opts=["be", "admin"], exclude={"mem": ["upcie-cuda"]}
+)
 def test_idfy(cijoe, device, be_opts, cli_args):
-    if be_opts["mem"] == "upcie-cuda":
-        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
     err, _ = cijoe.run(f"lblk idfy {cli_args}")
     assert not err
 
@@ -39,10 +40,11 @@ def test_write(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
+# mem=[upcie-cuda]: test does not support CUDA memory
+@xnvme_parametrize(
+    labels=["dev"], opts=["be", "admin"], exclude={"mem": ["upcie-cuda"]}
+)
 def test_compare(cijoe, device, be_opts, cli_args):
-    if be_opts["mem"] == "upcie-cuda":
-        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
     src = "/tmp/file.bin"
 
     prep = [
@@ -69,11 +71,9 @@ def test_write_zeroes(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["pi1"], opts=["be", "admin"])
+# admin=[block]: block layer does not support metadata/PI operations
+@xnvme_parametrize(labels=["pi1"], opts=["be", "admin"], exclude={"admin": ["block"]})
 def test_pi_type1(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not support metadata")
-
     if get_osname() == "freebsd" and be_opts["admin"] == "nvme":
         pytest.skip(reason="[admin=nvme] does not support metadata")
 
@@ -88,11 +88,9 @@ def test_pi_type1(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["pi2"], opts=["be", "admin"])
+# admin=[block]: block layer does not support metadata/PI operations
+@xnvme_parametrize(labels=["pi2"], opts=["be", "admin"], exclude={"admin": ["block"]})
 def test_pi_type2(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not support metadata")
-
     if get_osname() == "freebsd" and be_opts["admin"] == "nvme":
         pytest.skip(reason="[admin=nvme] does not support metadata")
 
@@ -107,11 +105,9 @@ def test_pi_type2(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["pi3"], opts=["be", "admin"])
+# admin=[block]: block layer does not support metadata/PI operations
+@xnvme_parametrize(labels=["pi3"], opts=["be", "admin"], exclude={"admin": ["block"]})
 def test_pi_type3(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not support metadata")
-
     if get_osname() == "freebsd" and be_opts["admin"] == "nvme":
         pytest.skip(reason="[admin=nvme] does not support metadata")
 
@@ -129,11 +125,11 @@ def test_pi_type3(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["pi1_ex"], opts=["be", "admin"])
+# admin=[block]: block layer does not support metadata/PI operations
+@xnvme_parametrize(
+    labels=["pi1_ex"], opts=["be", "admin"], exclude={"admin": ["block"]}
+)
 def test_pi_type1_extended_lba(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not support metadata")
-
     err, _ = cijoe.run(
         f"lblk write-read-pi {cli_args} --slba 0x0 --nlb 0 --pract 1 --prchk 0x5"
     )
@@ -145,11 +141,11 @@ def test_pi_type1_extended_lba(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["pi1_pif2"], opts=["be", "admin"])
+# admin=[block]: block layer does not support metadata/PI operations
+@xnvme_parametrize(
+    labels=["pi1_pif2"], opts=["be", "admin"], exclude={"admin": ["block"]}
+)
 def test_pi1_pif2(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not support metadata")
-
     if get_osname() == "freebsd" and be_opts["admin"] == "nvme":
         pytest.skip(reason="[admin=nvme] does not support metadata")
 

--- a/cijoe/tests/tools/test_xnvme.py
+++ b/cijoe/tests/tools/test_xnvme.py
@@ -119,63 +119,66 @@ def test_info(cijoe, device, be_opts, cli_args):
             )
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
+# mem=[upcie-cuda]: idfy does not support CUDA memory
+@xnvme_parametrize(
+    labels=["dev"], opts=["be", "admin"], exclude={"mem": ["upcie-cuda"]}
+)
 def test_idfy(cijoe, device, be_opts, cli_args):
-    if be_opts["mem"] == "upcie-cuda":
-        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
     err, _ = cijoe.run(
         f"xnvme idfy {cli_args} --cns 0x0 --cntid 0x0 --setid 0x0 --uuid 0x0"
     )
     assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
+# mem=[upcie-cuda]: idfy-ns does not support CUDA memory
+@xnvme_parametrize(
+    labels=["dev"], opts=["be", "admin"], exclude={"mem": ["upcie-cuda"]}
+)
 def test_idfy_ns(cijoe, device, be_opts, cli_args):
-    if be_opts["mem"] == "upcie-cuda":
-        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
     err, _ = cijoe.run(f"xnvme idfy-ns {cli_args} --nsid {device['nsid']}")
     assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
+# mem=[upcie-cuda]: idfy-ctrlr does not support CUDA memory
+@xnvme_parametrize(
+    labels=["dev"], opts=["be", "admin"], exclude={"mem": ["upcie-cuda"]}
+)
 def test_idfy_ctrlr(cijoe, device, be_opts, cli_args):
-    if be_opts["mem"] == "upcie-cuda":
-        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
     err, _ = cijoe.run(f"xnvme idfy-ctrlr {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["dev", "idfy_cs"], opts=["be", "admin"])
+# admin=[block,ramdisk]: block/ramdisk backends do not support idfy-cs
+@xnvme_parametrize(
+    labels=["dev", "idfy_cs"],
+    opts=["be", "admin"],
+    exclude={"admin": ["block", "ramdisk"]},
+)
 def test_idfy_cs(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not implement idfy-cs")
-    if be_opts["admin"] == "ramdisk":
-        pytest.skip(reason="[be=ramdisk] does not implement idfy-cs")
 
     err, _ = cijoe.run(f"xnvme idfy-cs {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["nvm"], opts=["be", "admin"])
+# admin=[block,ramdisk]: block/ramdisk backends do not support format
+@xnvme_parametrize(
+    labels=["nvm"], opts=["be", "admin"], exclude={"admin": ["block", "ramdisk"]}
+)
 def test_format(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not implement format")
-    elif be_opts["admin"] == "spdk" and "fabrics" in device["labels"]:
+    if be_opts["admin"] == "spdk" and "fabrics" in device["labels"]:
         pytest.skip(reason="spdk fabrics does not support format")
-
-    if be_opts["admin"] == "ramdisk":
-        pytest.skip(reason="[be=ramdisk] does not implement format")
 
     err, _ = cijoe.run(f"xnvme format {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["nvm", "sanitize"], opts=["be", "admin"])
+# admin=[block,ramdisk]: block/ramdisk backends do not support sanitize
+@xnvme_parametrize(
+    labels=["nvm", "sanitize"],
+    opts=["be", "admin"],
+    exclude={"admin": ["block", "ramdisk"]},
+)
 def test_sanitize(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not implement sanitize")
-    if be_opts["admin"] == "ramdisk":
-        pytest.skip(reason="[be=ramdisk] does not implement sanitize")
 
     err, _ = cijoe.run(f"xnvme sanitize --sanact 0x2 {cli_args}")
 
@@ -187,51 +190,49 @@ def test_sanitize(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
+# mem=[upcie-cuda]: CUDA memory not supported; admin=[block,ramdisk]: block/ramdisk do not expose NVMe log pages
+@xnvme_parametrize(
+    labels=["dev"],
+    opts=["be", "admin"],
+    exclude={"mem": ["upcie-cuda"], "admin": ["block", "ramdisk"]},
+)
 def test_log_erri(cijoe, device, be_opts, cli_args):
-    if be_opts["mem"] == "upcie-cuda":
-        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not implement error-log")
-    if be_opts["admin"] == "ramdisk":
-        pytest.skip(reason="[be=ramdisk] does not implement error-log")
 
     err, _ = cijoe.run(f"xnvme log-erri {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
+# mem=[upcie-cuda]: CUDA memory not supported; admin=[block,ramdisk]: block/ramdisk do not expose NVMe log pages
+@xnvme_parametrize(
+    labels=["dev"],
+    opts=["be", "admin"],
+    exclude={"mem": ["upcie-cuda"], "admin": ["block", "ramdisk"]},
+)
 def test_log_health_controller(cijoe, device, be_opts, cli_args):
-    if be_opts["mem"] == "upcie-cuda":
-        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not implement health-log")
-    if be_opts["admin"] == "ramdisk":
-        pytest.skip(reason="[be=ramdisk] does not implement health-log")
 
     err, _ = cijoe.run(f"xnvme log-health {cli_args} --nsid 0xFFFFFFFF")
     assert not err
 
 
-@xnvme_parametrize(labels=["dev", "log_health_ns"], opts=["be", "admin"])
+# admin=[block,ramdisk]: block/ramdisk do not expose NVMe log pages
+@xnvme_parametrize(
+    labels=["dev", "log_health_ns"],
+    opts=["be", "admin"],
+    exclude={"admin": ["block", "ramdisk"]},
+)
 def test_log_health_namespace(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not implement health-log")
-    if be_opts["admin"] == "ramdisk":
-        pytest.skip(reason="[be=ramdisk] does not implement health-log")
 
     err, _ = cijoe.run(f"xnvme log-health {cli_args} --nsid {device['nsid']}")
     assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
+# mem=[upcie-cuda]: CUDA memory not supported; admin=[block,ramdisk]: block/ramdisk do not expose NVMe log pages
+@xnvme_parametrize(
+    labels=["dev"],
+    opts=["be", "admin"],
+    exclude={"mem": ["upcie-cuda"], "admin": ["block", "ramdisk"]},
+)
 def test_log(cijoe, device, be_opts, cli_args):
-    if be_opts["mem"] == "upcie-cuda":
-        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not implement get-log")
-    if be_opts["admin"] == "ramdisk":
-        pytest.skip(reason="[be=ramdisk] does not implement get-log")
 
     lid, lsp, lpo_nbytes, rae, nbytes, nsid = "0x1", "0x0", 0, 0, 4096, "0xFFFFFFFF"
 
@@ -242,12 +243,11 @@ def test_log(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
+# admin=[block,ramdisk]: block/ramdisk backends do not support NVMe feature get
+@xnvme_parametrize(
+    labels=["dev"], opts=["be", "admin"], exclude={"admin": ["block", "ramdisk"]}
+)
 def test_feature_get(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not implement feature-get")
-    if be_opts["admin"] == "ramdisk":
-        pytest.skip(reason="[be=ramdisk] does not implement feature-get")
 
     for fid, descr in [("0x4", "Temperature threshold"), ("0x5", "Error recovery")]:
         # Get fid without setting select-bit
@@ -260,10 +260,9 @@ def test_feature_get(cijoe, device, be_opts, cli_args):
             assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
+# admin=[ramdisk]: ramdisk backend does not support NVMe feature set (block is excluded at runtime via assert err)
+@xnvme_parametrize(labels=["dev"], opts=["be", "admin"], exclude={"admin": ["ramdisk"]})
 def test_feature_set(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "ramdisk":
-        pytest.skip(reason="[be=ramdisk] does not implement feature-set")
 
     err, _ = cijoe.run(f"xnvme feature-set {cli_args} --fid 0x4 --feat 0x1")
 
@@ -273,14 +272,12 @@ def test_feature_set(cijoe, device, be_opts, cli_args):
         assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
+# admin=[block,ramdisk]: block/ramdisk backends do not support passthrough admin commands
+@xnvme_parametrize(
+    labels=["dev"], opts=["be", "admin"], exclude={"admin": ["block", "ramdisk"]}
+)
 def test_padc(cijoe, device, be_opts, cli_args):
     """Construct and send an admin command (Get Log Page: Error Information)"""
-
-    if be_opts["admin"] == "block":
-        pytest.skip(reason="[admin=block] does not support admin-passthru")
-    if be_opts["admin"] == "ramdisk":
-        pytest.skip(reason="[be=ramdisk] does not implement this admin-opcode")
 
     # Get Log Page
     opcode = "0x02"
@@ -333,10 +330,11 @@ def test_pioc(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["dev"], opts=["be", "admin"])
+# mem=[upcie-cuda]: DSM does not support CUDA memory
+@xnvme_parametrize(
+    labels=["dev"], opts=["be", "admin"], exclude={"mem": ["upcie-cuda"]}
+)
 def test_dsm(cijoe, device, be_opts, cli_args):
-    if be_opts["mem"] == "upcie-cuda":
-        pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
     err, _ = cijoe.run(
         f"xnvme dsm {cli_args} --nsid {device['nsid']} --ad --slba 0 --llb 1"
     )
@@ -359,7 +357,10 @@ def test_dsm(cijoe, device, be_opts, cli_args):
 
 
 # For these four tests we request a device with labels 'ctrlr'
-@xnvme_parametrize(labels=["ctrlr"], opts=["be", "admin"])
+# admin=[libvfn]: libvfn does not support show-regs
+@xnvme_parametrize(
+    labels=["ctrlr"], opts=["be", "admin"], exclude={"admin": ["libvfn"]}
+)
 def test_show_regs(cijoe, device, be_opts, cli_args):
     """
     The 'xnvme show-regs' is expected to fail when the kernel config has
@@ -367,9 +368,6 @@ def test_show_regs(cijoe, device, be_opts, cli_args):
     the state of this kernel config-option is, thus we check for it, and adjust
     the test-expectation accordingly.
     """
-
-    if be_opts["admin"] == "libvfn":
-        pytest.skip(reason="[be=libvfn] does not support pseudo commands")
 
     err, _ = cijoe.run(
         f"xnvme show-regs {device['uri']} --be {be_opts['be']} --admin {be_opts['admin']}"
@@ -388,12 +386,11 @@ def test_show_regs(cijoe, device, be_opts, cli_args):
         assert not err, "Expected it to work, however, it did not"
 
 
-@xnvme_parametrize(labels=["ctrlr"], opts=["be", "admin"])
+# admin=[libvfn,upcie]: these backends do not support subsystem reset
+@xnvme_parametrize(
+    labels=["ctrlr"], opts=["be", "admin"], exclude={"admin": ["libvfn", "upcie"]}
+)
 def test_subsystem_reset(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "libvfn":
-        pytest.skip(reason="[be=libvfn] does not support pseudo commands")
-    if be_opts["admin"] == "upcie":
-        pytest.skip(reason="[be=upcie] does not support subsystem-reset")
 
     err, state = cijoe.run(
         f"xnvme subsystem-reset {device['uri']} --be {be_opts['be']} --admin {be_opts['admin']}"
@@ -417,12 +414,11 @@ def test_subsystem_reset(cijoe, device, be_opts, cli_args):
     XnvmeDriver.kernel_attach(cijoe)
 
 
-@xnvme_parametrize(labels=["ctrlr"], opts=["be", "admin"])
+# admin=[libvfn,upcie]: these backends do not support controller reset
+@xnvme_parametrize(
+    labels=["ctrlr"], opts=["be", "admin"], exclude={"admin": ["libvfn", "upcie"]}
+)
 def test_ctrlr_reset(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "libvfn":
-        pytest.skip(reason="[be=libvfn] does not support pseudo commands")
-    if be_opts["admin"] == "upcie":
-        pytest.skip(reason="[be=upcie] does not support controller-reset")
 
     err, _ = cijoe.run(
         f"xnvme ctrlr-reset {device['uri']} --be {be_opts['be']} --admin {be_opts['admin']}"
@@ -431,12 +427,11 @@ def test_ctrlr_reset(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["ctrlr"], opts=["be", "admin"])
+# admin=[libvfn,spdk]: these backends do not support namespace rescan
+@xnvme_parametrize(
+    labels=["ctrlr"], opts=["be", "admin"], exclude={"admin": ["libvfn", "spdk"]}
+)
 def test_namespace_rescan(cijoe, device, be_opts, cli_args):
-    if be_opts["admin"] == "libvfn":
-        pytest.skip(reason="[be=libvfn] does not support pseudo commands")
-    if be_opts["admin"] == "spdk":
-        pytest.skip(reason="[admin=spdk] does not support namespace rescan")
 
     err, _ = cijoe.run(
         f"xnvme ns-rescan {device['uri']} --be {be_opts['be']} --admin {be_opts['admin']}"

--- a/cijoe/tests/tools/test_zoned.py
+++ b/cijoe/tests/tools/test_zoned.py
@@ -1,6 +1,4 @@
-import pytest
-
-from ..conftest import get_osname, xnvme_cli_args, xnvme_parametrize
+from ..conftest import xnvme_cli_args, xnvme_parametrize
 
 
 def test_enum(cijoe):
@@ -32,18 +30,14 @@ def test_idfy_ns(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
-    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync", "block"]}
+    labels=["zns"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync", "block"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_append(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
-
     admin_opts = {k: be_opts[k] for k in ["be", "admin"]}
     admin_args = xnvme_cli_args(device, admin_opts)
 
@@ -58,91 +52,74 @@ def test_append(cijoe, device, be_opts, cli_args):
         assert not err
 
 
-# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive
+# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
-    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync"]}
+    labels=["zns"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_report_all(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
-
     err, _ = cijoe.run(f"zoned report {cli_args}")
     assert not err
 
 
-# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive
+# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
-    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync"]}
+    labels=["zns"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_report_limit(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
-
     err, _ = cijoe.run(f"zoned report {cli_args} --slba 0x0 --limit 1")
     assert not err
 
 
-# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive
+# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
-    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync"]}
+    labels=["zns"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_report_single(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
-
     err, _ = cijoe.run(f"zoned report {cli_args} --slba 0x26400 --limit 1")
     assert not err
 
 
-# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive
+# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
-    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync"]}
+    labels=["zns"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_report_some(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
-
     err, _ = cijoe.run(f"zoned report {cli_args} --slba 0x1dc00 --limit 10")
     assert not err
 
 
-# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
-    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync", "block"]}
+    labels=["zns"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync", "block"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_read(cijoe, device, be_opts, cli_args):
-
     err, _ = cijoe.run(f"zoned read {cli_args} --slba 0x0 --nlb 0")
     assert not err
 
 
-# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
-    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync", "block"]}
+    labels=["zns"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync", "block"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_reset_report_write_report(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
 
     slba = "0x0"
     nlb = "0"
@@ -161,17 +138,14 @@ def test_reset_report_write_report(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive; os=[freebsd],be=[kqueue,thrpool,emu]: FreeBSD kernel doesn't support ZNS
 @xnvme_parametrize(
-    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync", "block"]}
+    labels=["zns"],
+    opts=["be", "admin", "sync"],
+    exclude={"sync": ["psync", "block"]},
+    os_exclude={"freebsd": {"be": ["kqueue", "thrpool", "emu"]}},
 )
 def test_reset_open_report(cijoe, device, be_opts, cli_args):
-    if get_osname() == "freebsd" and be_opts["be"] not in [
-        "spdk",
-        "ramdisk_emu",
-        "ramdisk_thrpool",
-    ]:
-        pytest.skip(reason="Freebsd kernel doesn't support zns")
 
     slba = "0x0"
     limit = "1"

--- a/cijoe/tests/tools/test_zoned.py
+++ b/cijoe/tests/tools/test_zoned.py
@@ -32,7 +32,10 @@ def test_idfy_ns(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["zns"], opts=["be", "admin", "sync"])
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive
+@xnvme_parametrize(
+    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync", "block"]}
+)
 def test_append(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -40,8 +43,6 @@ def test_append(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["sync"] in ["psync", "block"]:
-        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do mgmt send/receive")
 
     admin_opts = {k: be_opts[k] for k in ["be", "admin"]}
     admin_args = xnvme_cli_args(device, admin_opts)
@@ -57,7 +58,10 @@ def test_append(cijoe, device, be_opts, cli_args):
         assert not err
 
 
-@xnvme_parametrize(labels=["zns"], opts=["be", "admin", "sync"])
+# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive
+@xnvme_parametrize(
+    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync"]}
+)
 def test_report_all(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -65,14 +69,15 @@ def test_report_all(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["sync"] == "psync":
-        pytest.skip(reason="ENOSYS: psync(pwrite/pread) cannot do mgmt send/receive")
 
     err, _ = cijoe.run(f"zoned report {cli_args}")
     assert not err
 
 
-@xnvme_parametrize(labels=["zns"], opts=["be", "admin", "sync"])
+# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive
+@xnvme_parametrize(
+    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync"]}
+)
 def test_report_limit(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -80,14 +85,15 @@ def test_report_limit(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["sync"] == "psync":
-        pytest.skip(reason="ENOSYS: psync(pwrite/pread) cannot do mgmt send/receive")
 
     err, _ = cijoe.run(f"zoned report {cli_args} --slba 0x0 --limit 1")
     assert not err
 
 
-@xnvme_parametrize(labels=["zns"], opts=["be", "admin", "sync"])
+# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive
+@xnvme_parametrize(
+    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync"]}
+)
 def test_report_single(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -95,14 +101,15 @@ def test_report_single(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["sync"] == "psync":
-        pytest.skip(reason="ENOSYS: psync(pwrite/pread) cannot do mgmt send/receive")
 
     err, _ = cijoe.run(f"zoned report {cli_args} --slba 0x26400 --limit 1")
     assert not err
 
 
-@xnvme_parametrize(labels=["zns"], opts=["be", "admin", "sync"])
+# sync=[psync]: ENOSYS, psync cannot do mgmt send/receive
+@xnvme_parametrize(
+    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync"]}
+)
 def test_report_some(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -110,23 +117,25 @@ def test_report_some(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["sync"] == "psync":
-        pytest.skip(reason="ENOSYS: psync(pwrite/pread) cannot do mgmt send/receive")
 
     err, _ = cijoe.run(f"zoned report {cli_args} --slba 0x1dc00 --limit 10")
     assert not err
 
 
-@xnvme_parametrize(labels=["zns"], opts=["be", "admin", "sync"])
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive
+@xnvme_parametrize(
+    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync", "block"]}
+)
 def test_read(cijoe, device, be_opts, cli_args):
-    if be_opts["sync"] in ["psync", "block"]:
-        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do mgmt send/receive")
 
     err, _ = cijoe.run(f"zoned read {cli_args} --slba 0x0 --nlb 0")
     assert not err
 
 
-@xnvme_parametrize(labels=["zns"], opts=["be", "admin", "sync"])
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive
+@xnvme_parametrize(
+    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync", "block"]}
+)
 def test_reset_report_write_report(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -134,8 +143,6 @@ def test_reset_report_write_report(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["sync"] in ["psync", "block"]:
-        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do mgmt send/receive")
 
     slba = "0x0"
     nlb = "0"
@@ -154,7 +161,10 @@ def test_reset_report_write_report(cijoe, device, be_opts, cli_args):
     assert not err
 
 
-@xnvme_parametrize(labels=["zns"], opts=["be", "admin", "sync"])
+# sync=[psync,block]: ENOSYS, cannot do mgmt send/receive
+@xnvme_parametrize(
+    labels=["zns"], opts=["be", "admin", "sync"], exclude={"sync": ["psync", "block"]}
+)
 def test_reset_open_report(cijoe, device, be_opts, cli_args):
     if get_osname() == "freebsd" and be_opts["be"] not in [
         "spdk",
@@ -162,8 +172,6 @@ def test_reset_open_report(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
-    if be_opts["sync"] in ["psync", "block"]:
-        pytest.skip(reason="ENOSYS: sync=[psync,block] cannot do mgmt send/receive")
 
     slba = "0x0"
     limit = "1"


### PR DESCRIPTION
  Each `pytest.skip()` call that fires inside a test body still pays the full
  fixture setup cost: the `device` fixture runs, which calls
  `XnvmeDriver.attach()` and optionally spins up a fabrics target over SSH
  (~0.22 s per invocation). Across hundreds of parametrised combinations this
  adds up to non-trivial overhead on every CI run.

  This PR is an experiment to measure whether moving known-incompatible
  combinations out of the test body and into collection time makes a meaningful
  difference to wall-clock CI duration.

  ## What changed

  Two new parameters are added to `@xnvme_parametrize` (and the underlying
  `xnvme_setup`):

  - `exclude={}` — drop combinations at collection time based on backend option
    values (`sync`, `async`, `admin`, `mem`, `be`). A combination is dropped if
    *any* key/value matches (OR semantics).
  - `os_exclude={}` — same, but only applied when the current OS (resolved from
    the CIJOE config at collection time) matches the key.

  These replace all `pytest.skip()` calls in test bodies that were conditioned
  purely on `be_opts` values or on `(OS, be_opts)` pairs. Three FreeBSD patterns
  are covered by `os_exclude`:

  | `os_exclude` key | Values excluded | Reason |
  |---|---|---|
  | `be` | `kqueue`, `thrpool`, `emu` | FreeBSD kernel doesn't support ZNS |
  | `sync` | `nvme` | FreeBSD nvme sync does not implement iovec |
  | `admin` | `nvme` | FreeBSD nvme admin does not support metadata/PI |

  Runtime skips that depend on device labels or other runtime state (e.g.
  `"cdev" not in device["labels"]`, spdk fabrics format check) are left as-is.

  A comment above each `@xnvme_parametrize` decorator documents the reason for
  each exclusion so the information is not lost.

  ## What is not changed

  - Test correctness — the same combinations that were previously skipped at
    runtime are now simply never scheduled.
  - OS-detection based behaviour that is not a skip (e.g. `test_scan`,
    `test_show_regs`) is untouched.
  - The two `!= libvfn` skips (`test_xnvme_single_async_efd`,
    `test_xnvme_tests_map`) require AND/include semantics not supported by the
    current `exclude` design and are left for a follow-up if the experiment
    proves worthwhile.
