### PR TITLE
platform: fix three bugs in the dev-open and enumerate paths

### DIFF
--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -78,7 +78,6 @@ static int
 _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnvme_be_config *cfg)
 {
 	void *ctrlr = NULL;
-	int cref_inserted = 0;
 	int err;
 
 	if (!be->dev.ctrlr_init) {
@@ -87,8 +86,7 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 
 	ctrlr = xnvme_be_cref_lookup(dev->ident.uri, cfg->attr.name);
 	if (ctrlr) {
-		((void **)be->state)[0] = ctrlr;
-		return 0;
+		goto ctrlr_ready;
 	}
 
 	{
@@ -114,12 +112,12 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 		be->dev.ctrlr_term(ctrlr);
 		return err;
 	}
-	cref_inserted = 1;
 
+ctrlr_ready:
 	((void **)be->state)[0] = ctrlr;
 
 	err = be->dev.dev_open(dev);
-	if (err && cref_inserted) {
+	if (err) {
 		xnvme_be_cref_deref(ctrlr, XNVME_BE_CREF_DESTROY_IMMEDIATE);
 	}
 

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -81,7 +81,7 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 	int err;
 
 	if (!be->dev.ctrlr_init) {
-		return 0;
+		return be->dev.dev_open(dev);
 	}
 
 	ctrlr = xnvme_be_cref_lookup(dev->ident.uri, cfg->attr.name);
@@ -164,13 +164,6 @@ _dev_open_try_config(struct xnvme_dev *dev, const struct xnvme_be_config *cfg,
 	err = _dev_open_init_cref(dev, &dev->be, cfg);
 	if (err) {
 		return err;
-	}
-
-	if (!dev->be.dev.ctrlr_init) {
-		err = dev->be.dev.dev_open(dev);
-		if (err) {
-			return err;
-		}
 	}
 
 	XNVME_DEBUG("INFO: obtained device handle");

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -290,6 +290,7 @@ enumerate_controller(const char *uri, struct xnvme_opts *opts, xnvme_enumerate_c
 	if (err) {
 		XNVME_DEBUG("FAILED: xnvme_buf_clear(), err: %d", err);
 		xnvme_buf_free(ctrlr_dev, idfy_buf);
+		xnvme_dev_close(ctrlr_dev);
 		return err;
 	}
 


### PR DESCRIPTION
Three independent correctness fixes to _dev_open_init_cref and
  enumerate_controller:

  1. Same-name cref hit skipped dev_open. When _dev_open_init_cref found
     an existing cref entry for the same URI and backend, it stored the
     ctrlr pointer and returned 0 without calling dev_open. Per-handle
     resources initialised in dev_open (e.g. atomic counters) were left
     uninitialised for every open after the first.

  2. _dev_open_init_cref duplicated the ctrlr_init check. The early
     return for backends without ctrlr_init was also present in the
     caller, making _dev_open_init_cref dead for those backends. Removing
     the duplicate caller check makes the function the single owner of
     ctrlr_init logic.

  3. ctrlr_dev leaked on xnvme_buf_clear failure in enumerate_controller.
     The error path freed the identify buffer but returned without closing
     ctrlr_dev, leaving the controller reference open.
     
This should fix the failure we're seeing in #672 