### PR TITLE
fix(be): respect config-selected backends in dev_open across platforms

### DIFF
--- a/cijoe/auxiliary/plot-latency-legends.yaml
+++ b/cijoe/auxiliary/plot-latency-legends.yaml
@@ -42,7 +42,7 @@ xnvme_null:
   legend: 'null'
 
 # Windows
-xnvme_io_ring:
+xnvme_ioring:
   legend: 'xnvme(ioring)'
 
 xnvme_iocp:

--- a/cijoe/configs/ax42-freebsd.toml
+++ b/cijoe/configs/ax42-freebsd.toml
@@ -114,10 +114,10 @@ null = {type = "builtin", group = "null", device = "bdev"}
 spdk_nvme = {type = "external_preload", group = "spdk", path = "/tmp/spdk/build/fio/spdk_nvme", device = "pcie"} # Userspace
 spdk_bdev = {type = "external_preload", group = "spdk", path = "/tmp/spdk/build/fio/spdk_bdev", device = "pcie"} # Userspace
 
-xnvme_kqueue = {type = "builtin", group = "posixaio", be = "freebsd", async = "kqueue", device = "bdev"} # Kernel
-xnvme_posixaio = {type = "builtin", group = "posixaio", be = "freebsd", async = "posix", device = "bdev"} # Kernel
-xnvme_spdk = {type = "builtin", group = "spdk", be = "spdk", async = "spdk", device = "pcie"} # Userspace
-xnvme_null = {type = "builtin", group = "null", be = "freebsd", async = "nil", device = "bdev"} # Kernel
+xnvme_kqueue = {type = "builtin", group = "posixaio", be = "kqueue", device = "bdev"} # Kernel
+xnvme_posixaio = {type = "builtin", group = "posixaio", be = "posix", device = "bdev"} # Kernel
+xnvme_spdk = {type = "builtin", group = "spdk", be = "spdk", device = "pcie"} # Userspace
+xnvme_null = {type = "builtin", group = "null", be = "nil", device = "bdev"} # Kernel
 
 [[devices]] # OS Managed
 key = "bdev"

--- a/cijoe/configs/ax42-linux.toml
+++ b/cijoe/configs/ax42-linux.toml
@@ -146,9 +146,9 @@ null = {type = "builtin", group = "null", device = "bdev"}
 spdk_nvme = {type = "external_preload", group = "spdk", path = "/tmp/spdk/build/fio/spdk_nvme", device = "pcie"} # Userspace
 spdk_bdev = {type = "external_preload", group = "spdk", path = "/tmp/spdk/build/fio/spdk_bdev", device = "pcie"} # Userspace
 
-xnvme_libaio = {type = "builtin", group = "libaio", be = "linux", async = "libaio", device = "bdev"} # Kernel
-xnvme_posixaio = {type = "builtin", group = "posixaio", be = "linux", async = "posix", device = "bdev"} # Kernel
-xnvme_io_uring = {type = "builtin", group = "io_uring", be = "linux", async = "io_uring", device = "bdev"} # Kernel
-xnvme_io_uring_cmd = {type = "builtin", group = "io_uring_cmd", be = "linux", async = "io_uring_cmd", device = "cdev"} # Kernel
-xnvme_spdk = {type = "builtin", group = "spdk", be = "spdk", async = "spdk", device = "pcie"} # Userspace
-xnvme_null = {type = "builtin", group = "null", be = "linux", async = "nil", device = "bdev"} # Kernel
+xnvme_libaio = {type = "builtin", group = "libaio", be = "libaio", device = "bdev"} # Kernel
+xnvme_posixaio = {type = "builtin", group = "posixaio", be = "posix", device = "bdev"} # Kernel
+xnvme_io_uring = {type = "builtin", group = "io_uring", be = "io_uring", device = "bdev"} # Kernel
+xnvme_io_uring_cmd = {type = "builtin", group = "io_uring_cmd", be = "io_uring_cmd", device = "cdev"} # Kernel
+xnvme_spdk = {type = "builtin", group = "spdk", be = "spdk", device = "pcie"} # Userspace
+xnvme_null = {type = "builtin", group = "null", be = "nil", device = "bdev"} # Kernel

--- a/cijoe/configs/ax42-windows.toml
+++ b/cijoe/configs/ax42-windows.toml
@@ -65,7 +65,7 @@ system_args.tcp_forward = {host = 4200, guest = 22}
 
 [[devices]]
 key = "bdev"
-uri = "\\\\.\\PhysicalDrive1" # backslashes need to be escaped
+uri = "//./PhysicalDrive1" # forward slashes survive shell evaluation; \\.\ loses its backslashes
 nsid = 1
 labels = [ "dev", "bdev", "nvm" ]
 driver_attachment = "kernel"

--- a/cijoe/configs/ax42-windows.toml
+++ b/cijoe/configs/ax42-windows.toml
@@ -101,7 +101,7 @@ tag = "fio-3.41"
 null = {type = "builtin", group = "null", device = "bdev"}
 windowsaio = {type = "builtin", group = "windowsaio", device = "bdev"}
 
-xnvme_null = {type = "builtin", group = "null", be = "windows", async = "nil", device = "bdev"}
-xnvme_ioring = {type = "builtin", group = "windowsaio", be = "windows", async = "io_ring", device = "bdev"}
-xnvme_iocp = {type = "builtin", group = "windowsaio", be = "windows", async = "iocp", device = "bdev"}
-xnvme_iocpth = {type = "builtin", group = "windowsaio", be = "windows", async = "iocp_th", device = "bdev"}
+xnvme_null = {type = "builtin", group = "null", be = "nil", device = "bdev"}
+xnvme_ioring = {type = "builtin", group = "windowsaio", be = "ioring", device = "bdev"}
+xnvme_iocp = {type = "builtin", group = "windowsaio", be = "iocp", device = "bdev"}
+xnvme_iocpth = {type = "builtin", group = "windowsaio", be = "iocp_th", device = "bdev"}

--- a/cijoe/scripts/fio_latency.py
+++ b/cijoe/scripts/fio_latency.py
@@ -184,14 +184,13 @@ class XnvmeKernelEngine(KernelEngine):
     device: Device
     cijoe: Cijoe
     be: str
-    async_: str
 
     @property
     def name_id(self) -> str:
-        return f"{self.name}_{self.async_}"
+        return f"{self.name}_{self.be}"
 
     def extra_args(self) -> Dict[str, str]:
-        return {"--xnvme_be": f"{self.be}", "--xnvme_async": f"{self.async_}"}
+        return {"--xnvme_be": f"{self.be}"}
 
 
 @dataclass
@@ -201,7 +200,6 @@ class XnvmeUserSpaceEngine(UserSpaceEngine):
     device: Device
     cijoe: Cijoe
     be: str
-    async_: str
 
 
 @dataclass
@@ -232,7 +230,6 @@ class XnvmeSPDK(XnvmeUserSpaceEngine):
     def extra_args(self) -> Dict[str, str]:
         return {
             "--xnvme_be": f"{self.be}",
-            "--xnvme_async": f"{self.async_}",
             "--xnvme_dev_nsid": str(self.device.nsid),
         }
 
@@ -283,8 +280,7 @@ def determine_engine(
     if "xnvme" in engine_identifier:
         name = "xnvme"
         be = definition["be"]
-        async_ = definition["async"]
-        engine_args = [name, group, device, cijoe, be, async_]
+        engine_args = [name, group, device, cijoe, be]
     elif "spdk" in engine_identifier:
         path = Path(definition["path"])
         if "spdk_nvme" == engine_identifier:

--- a/cijoe/tests/logic/test_xnvme_tests_znd_append.py
+++ b/cijoe/tests/logic/test_xnvme_tests_znd_append.py
@@ -11,5 +11,7 @@ def test_verify(cijoe, device, be_opts, cli_args):
         "ramdisk_thrpool",
     ]:
         pytest.skip(reason="Freebsd kernel doesn't support zns")
+    if be_opts["admin"] == "block":
+        pytest.skip(reason="[admin=block] does not implement zone-append")
     err, _ = cijoe.run(f"xnvme_tests_znd_append verify {cli_args}")
     assert not err

--- a/cijoe/tests/tools/test_lblk.py
+++ b/cijoe/tests/tools/test_lblk.py
@@ -43,6 +43,8 @@ def test_write(cijoe, device, be_opts, cli_args):
 def test_compare(cijoe, device, be_opts, cli_args):
     if be_opts["mem"] == "upcie-cuda":
         pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
+    if be_opts["admin"] == "block":
+        pytest.skip(reason="[admin=block] does not implement compare")
     src = "/tmp/file.bin"
 
     prep = [
@@ -65,6 +67,8 @@ def test_write_uncor(cijoe, device, be_opts, cli_args):
 
 @xnvme_parametrize(labels=["write_zeroes"], opts=["be", "admin"])
 def test_write_zeroes(cijoe, device, be_opts, cli_args):
+    if be_opts["admin"] == "block":
+        pytest.skip(reason="[admin=block] does not implement write-zeroes")
     err, _ = cijoe.run(f"lblk write-zeros {cli_args} --slba 0x0 --nlb 0")
     assert not err
 

--- a/cijoe/tests/tools/test_xnvme.py
+++ b/cijoe/tests/tools/test_xnvme.py
@@ -337,6 +337,8 @@ def test_pioc(cijoe, device, be_opts, cli_args):
 def test_dsm(cijoe, device, be_opts, cli_args):
     if be_opts["mem"] == "upcie-cuda":
         pytest.skip(reason="[mem=upcie-cuda] This test does not support CUDA memory")
+    if be_opts["admin"] == "block":
+        pytest.skip(reason="[admin=block] does not implement dsm")
     err, _ = cijoe.run(
         f"xnvme dsm {cli_args} --nsid {device['nsid']} --ad --slba 0 --llb 1"
     )

--- a/include/xnvme_be_registry.h
+++ b/include/xnvme_be_registry.h
@@ -65,6 +65,7 @@ extern const struct xnvme_be_config g_xnvme_be_linux_aio_file;
 /* FreeBSD */
 #ifdef XNVME_PLATFORM_FREEBSD_ENABLED
 extern const struct xnvme_be_config g_xnvme_be_fbsd_kqueue_nvme;
+extern const struct xnvme_be_config g_xnvme_be_fbsd_emu_file;
 extern const struct xnvme_be_config g_xnvme_be_fbsd_kqueue_psync;
 extern const struct xnvme_be_config g_xnvme_be_fbsd_posix_nvme;
 extern const struct xnvme_be_config g_xnvme_be_fbsd_thrpool_nvme;

--- a/lib/xnvme_be_fbsd.c
+++ b/lib/xnvme_be_fbsd.c
@@ -24,6 +24,20 @@ const struct xnvme_be_config g_xnvme_be_fbsd_kqueue_nvme = {
 		},
 };
 
+const struct xnvme_be_config g_xnvme_be_fbsd_emu_file = {
+	.async = &g_xnvme_be_cbi_async_emu,
+	.sync = &g_xnvme_be_cbi_sync_psync,
+	.admin = &g_xnvme_be_cbi_admin_shim,
+	.dev = &g_xnvme_be_fbsd_dev,
+	.mem = &g_xnvme_be_cbi_mem_posix,
+	.attr =
+		{
+			.name = "emu_file",
+			.descr = "Emulated async with file I/O",
+			.caps = XNVME_BE_CAP_FILE,
+		},
+};
+
 const struct xnvme_be_config g_xnvme_be_fbsd_kqueue_psync = {
 	.async = &g_xnvme_be_fbsd_async,
 	.sync = &g_xnvme_be_cbi_sync_psync,

--- a/lib/xnvme_be_fbsd.c
+++ b/lib/xnvme_be_fbsd.c
@@ -27,14 +27,14 @@ const struct xnvme_be_config g_xnvme_be_fbsd_kqueue_nvme = {
 const struct xnvme_be_config g_xnvme_be_fbsd_kqueue_psync = {
 	.async = &g_xnvme_be_fbsd_async,
 	.sync = &g_xnvme_be_cbi_sync_psync,
-	.admin = &g_xnvme_be_fbsd_admin_nvme,
+	.admin = &g_xnvme_be_cbi_admin_shim,
 	.dev = &g_xnvme_be_fbsd_dev,
 	.mem = &g_xnvme_be_cbi_mem_posix,
 	.attr =
 		{
 			.name = "kqueue_file",
 			.descr = "kqueue with POSIX sync",
-			.caps = XNVME_BE_CAP_NVME_CDEV | XNVME_BE_CAP_FILE,
+			.caps = XNVME_BE_CAP_FILE,
 		},
 };
 

--- a/lib/xnvme_be_fbsd_dev.c
+++ b/lib/xnvme_be_fbsd_dev.c
@@ -88,15 +88,6 @@ xnvme_be_fbsd_dev_open(struct xnvme_dev *dev)
 		dev->ident.dtype = XNVME_DEV_TYPE_FS_FILE;
 		dev->ident.csi = XNVME_SPEC_CSI_FS;
 		dev->ident.nsid = 1;
-		if (!opts->admin) {
-			dev->be.admin = g_xnvme_be_cbi_admin_shim;
-		}
-		if (!opts->sync) {
-			dev->be.sync = g_xnvme_be_cbi_sync_psync;
-		}
-		if (!opts->async) {
-			dev->be.async = g_xnvme_be_cbi_async_emu;
-		}
 		state->fd.ctrlr = state->fd.ns;
 		break;
 
@@ -105,30 +96,11 @@ xnvme_be_fbsd_dev_open(struct xnvme_dev *dev)
 		dev->ident.dtype = XNVME_DEV_TYPE_BLOCK_DEVICE;
 		dev->ident.csi = XNVME_SPEC_CSI_FS;
 		dev->ident.nsid = 1;
-		if (!opts->admin) {
-			dev->be.admin = g_xnvme_be_cbi_admin_shim;
-		}
-		if (!opts->sync) {
-			dev->be.sync = g_xnvme_be_cbi_sync_psync;
-		}
-		if (!opts->async) {
-			dev->be.async = g_xnvme_be_cbi_async_emu;
-		}
 		state->fd.ctrlr = state->fd.ns;
 		break;
 
 	case S_IFCHR:
 		XNVME_DEBUG("INFO: open() : char-device-file assuming NVMe ctrlr. or ns.");
-
-		if (!opts->admin) {
-			dev->be.admin = g_xnvme_be_fbsd_admin_nvme;
-		}
-		if (!opts->sync) {
-			dev->be.sync = g_xnvme_be_fbsd_sync_nvme;
-		}
-		if (!opts->async) {
-			dev->be.async = g_xnvme_be_cbi_async_emu;
-		}
 
 		if (xnvme_be_fbsd_nvme_get_nsid_and_ctrlr_fd(state->fd.ns, &dev->ident.nsid,
 							     &state->fd.ctrlr)) {

--- a/lib/xnvme_be_linux_dev.c
+++ b/lib/xnvme_be_linux_dev.c
@@ -71,37 +71,19 @@ xnvme_be_linux_dev_open(struct xnvme_dev *dev)
 		return -errno;
 	}
 
-	// Change {async,sync,admin} based on file unless one was explicitly requested
+	// Refine identifier fields based on the underlying file type
 	switch (dev_stat.st_mode & S_IFMT) {
 	case S_IFREG:
 		XNVME_DEBUG("INFO: open() : regular file");
 		dev->ident.dtype = XNVME_DEV_TYPE_FS_FILE;
 		dev->ident.csi = XNVME_SPEC_CSI_FS;
 		dev->ident.nsid = 1;
-		if (!opts->admin) {
-			dev->be.admin = g_xnvme_be_cbi_admin_shim;
-		}
-		if (!opts->sync) {
-			dev->be.sync = g_xnvme_be_cbi_sync_psync;
-		}
-		if (!opts->async) {
-			dev->be.async = g_xnvme_be_cbi_async_emu;
-		}
 		break;
 
 	case S_IFBLK:
 		dev->ident.dtype = XNVME_DEV_TYPE_BLOCK_DEVICE;
 		dev->ident.csi = XNVME_SPEC_CSI_FS;
 		dev->ident.nsid = 1;
-		if (!opts->admin) {
-			dev->be.admin = g_xnvme_be_linux_admin_block;
-		}
-		if (!opts->sync) {
-			dev->be.sync = g_xnvme_be_linux_sync_block;
-		}
-		if (!opts->async) {
-			dev->be.async = g_xnvme_be_cbi_async_emu;
-		}
 		XNVME_DEBUG("INFO: open() : block-device file");
 
 		err = xnvme_be_linux_nvme_dev_nsid(dev);
@@ -113,15 +95,6 @@ xnvme_be_linux_dev_open(struct xnvme_dev *dev)
 		dev->ident.dtype = XNVME_DEV_TYPE_NVME_NAMESPACE;
 		dev->ident.csi = XNVME_SPEC_CSI_NVM;
 		dev->ident.nsid = err;
-		if (!opts->admin) {
-			dev->be.admin = g_xnvme_be_linux_admin_nvme;
-		}
-		if (!opts->sync) {
-			dev->be.sync = g_xnvme_be_linux_sync_nvme;
-		}
-		if (!opts->async) {
-			dev->be.async = g_xnvme_be_cbi_async_emu;
-		}
 		XNVME_DEBUG("INFO: open() : block-device file (is a NVMe namespace)");
 
 		break;
@@ -143,18 +116,6 @@ xnvme_be_linux_dev_open(struct xnvme_dev *dev)
 			dev->ident.csi = XNVME_SPEC_CSI_NVM;
 			dev->ident.nsid = err;
 		}
-
-		if (!opts->admin) {
-			dev->be.admin = g_xnvme_be_linux_admin_nvme;
-		}
-		if (!opts->sync) {
-			dev->be.sync = g_xnvme_be_linux_sync_nvme;
-		}
-		if (!opts->async) {
-			dev->be.async = g_xnvme_be_cbi_async_emu;
-		}
-
-		XNVME_DEBUG("INFO: open() : char-device-file: NVMe ioctl() with async. emulation");
 
 		break;
 

--- a/lib/xnvme_be_macos_dev.c
+++ b/lib/xnvme_be_macos_dev.c
@@ -200,16 +200,6 @@ xnvme_be_macos_dev_open(struct xnvme_dev *dev)
 		dev->ident.nsid = _get_nvme_ns(ioservice_device);
 		dev->ident.dtype = XNVME_DEV_TYPE_BLOCK_DEVICE;
 		dev->ident.csi = XNVME_SPEC_CSI_NVM;
-
-		if (!opts->admin) {
-			dev->be.admin = g_xnvme_be_macos_admin;
-		}
-		if (!opts->sync) {
-			dev->be.sync = g_xnvme_be_macos_sync_psync;
-		}
-		if (!opts->async) {
-			dev->be.async = g_xnvme_be_cbi_async_emu;
-		}
 	} else {
 		XNVME_DEBUG("non-nvme disks are currently unsupported.");
 		return -ENOTSUP;

--- a/lib/xnvme_be_ramdisk_dev.c
+++ b/lib/xnvme_be_ramdisk_dev.c
@@ -52,7 +52,6 @@ int
 xnvme_be_ramdisk_dev_open(struct xnvme_dev *dev)
 {
 	struct xnvme_be_ramdisk_state *state = (void *)dev->be.state;
-	struct xnvme_opts *opts = &dev->opts;
 
 	size_t ramdisk_size = xnvme_be_ramdisk_dev_get_size(dev);
 	if (!ramdisk_size) {
@@ -64,16 +63,6 @@ xnvme_be_ramdisk_dev_open(struct xnvme_dev *dev)
 		XNVME_DEBUG("FAILED: Unable to allocate ramdisk: uri=%s, state->ramdisk=%p",
 			    dev->ident.uri, state->ramdisk);
 		return -errno;
-	}
-
-	if (!opts->admin) {
-		dev->be.admin = g_xnvme_be_ramdisk_admin;
-	}
-	if (!opts->sync) {
-		dev->be.sync = g_xnvme_be_ramdisk_sync;
-	}
-	if (!opts->async) {
-		dev->be.async = g_xnvme_be_cbi_async_thrpool;
 	}
 
 	dev->ident.dtype = XNVME_DEV_TYPE_RAMDISK;

--- a/lib/xnvme_be_windows_dev.c
+++ b/lib/xnvme_be_windows_dev.c
@@ -126,7 +126,6 @@ xnvme_be_windows_dev_open(struct xnvme_dev *dev)
 	dw_creation_mode = xnvme_file_creation_opts_to_windows(opts);
 	access_mode = xnvme_file_access_opts_to_windows(opts);
 	file_attributes |= xnvme_file_attributes_opts_to_windows(opts);
-	// Change {async,sync,admin} based on file unless one was explicitly requested
 	switch (dev_stat.st_mode & S_IFMT) {
 	case S_IFREG:
 		state->sync_handle = CreateFile((LPCSTR)ident->uri, access_mode, share_mode, NULL,
@@ -154,15 +153,6 @@ xnvme_be_windows_dev_open(struct xnvme_dev *dev)
 		dev->ident.dtype = XNVME_DEV_TYPE_FS_FILE;
 		dev->ident.csi = XNVME_SPEC_CSI_FS;
 		dev->ident.nsid = 1;
-		if (!opts->admin) {
-			dev->be.admin = g_xnvme_be_windows_admin_fs;
-		}
-		if (!opts->sync) {
-			dev->be.sync = g_xnvme_be_windows_sync_fs;
-		}
-		if (!opts->async) {
-			dev->be.async = g_xnvme_be_windows_async_iocp;
-		}
 		break;
 
 	case S_IFCHR:
@@ -192,19 +182,12 @@ xnvme_be_windows_dev_open(struct xnvme_dev *dev)
 		dev->ident.csi = XNVME_SPEC_CSI_NVM;
 		// Making the nsid 1 by default
 		dev->ident.nsid = 1;
+		// SCSI/SATA backend configs aren't defined, so route admin to the block
+		// implementation here when the bus type is not NVMe. Remove once/if the
+		// platform exposes dedicated configs for these bus types.
 		dev_type = xnvme_be_windows_get_device_type(state->async_handle);
-		if (!opts->admin) {
-			if (dev_type == BusTypeNvme) {
-				dev->be.admin = g_xnvme_be_windows_admin_nvme;
-			} else if (dev_type == BusTypeScsi || dev_type == BusTypeSata) {
-				dev->be.admin = g_xnvme_be_windows_admin_block;
-			}
-		}
-		if (!opts->sync) {
-			dev->be.sync = g_xnvme_be_windows_sync_nvme;
-		}
-		if (!opts->async) {
-			dev->be.async = g_xnvme_be_windows_async_iocp;
+		if (dev_type == BusTypeScsi || dev_type == BusTypeSata) {
+			dev->be.admin = g_xnvme_be_windows_admin_block;
 		}
 		break;
 

--- a/lib/xnvme_be_windows_dev.c
+++ b/lib/xnvme_be_windows_dev.c
@@ -117,7 +117,8 @@ xnvme_be_windows_dev_open(struct xnvme_dev *dev)
 			_close(state->fd);
 			return -errno;
 		}
-		if (strstr(ident->uri, "\\\\.\\PhysicalDrive")) {
+		if (strstr(ident->uri, "\\\\.\\PhysicalDrive") ||
+		    strstr(ident->uri, "//./PhysicalDrive")) {
 			dev_stat.st_mode = 0x21B6;
 		}
 	}

--- a/lib/xnvme_platform_freebsd.c
+++ b/lib/xnvme_platform_freebsd.c
@@ -265,6 +265,7 @@ struct xnvme_platform g_xnvme_platform_freebsd = {
 			&g_xnvme_be_spdk,
 #endif
 			&g_xnvme_be_fbsd_kqueue_nvme,
+			&g_xnvme_be_fbsd_emu_file,
 			&g_xnvme_be_fbsd_kqueue_psync,
 			&g_xnvme_be_fbsd_posix_nvme,
 			&g_xnvme_be_fbsd_thrpool_nvme,

--- a/lib/xnvme_platform_freebsd.c
+++ b/lib/xnvme_platform_freebsd.c
@@ -63,7 +63,9 @@ xnvme_platform_fbsd_classify(const char *uri)
 		return XNVME_BE_CAP_NVME_TCP;
 	}
 
-	return 0;
+	/* A path we could not stat() and which matched nothing else is assumed
+	 * to be a not-yet-created file, e.g. the destination of a copy. */
+	return XNVME_BE_CAP_FILE;
 }
 
 struct xnvme_fbsd_scan_args {

--- a/lib/xnvme_platform_linux.c
+++ b/lib/xnvme_platform_linux.c
@@ -69,7 +69,9 @@ xnvme_platform_linux_classify(const char *uri)
 		return XNVME_BE_CAP_NVME_TCP;
 	}
 
-	return 0;
+	/* A path we could not stat() and which matched nothing else is assumed
+	 * to be a not-yet-created file, e.g. the destination of a copy. */
+	return XNVME_BE_CAP_FILE;
 }
 
 struct xnvme_linux_scan_args {

--- a/lib/xnvme_platform_windows.c
+++ b/lib/xnvme_platform_windows.c
@@ -21,8 +21,10 @@ xnvme_platform_windows_classify(const char *uri)
 {
 	size_t len;
 
-	/* Windows device handles: \\.\PhysicalDriveN, \\.\ScsiN: */
-	if (!strncmp(uri, "\\\\.\\", 4)) {
+	/* Windows device handles: \\.\PhysicalDriveN, \\.\ScsiN:. CreateFile()
+	 * resolves the forward-slash form //./ identically, and it survives
+	 * shell evaluation without escaping, so accept both. */
+	if (!strncmp(uri, "\\\\.\\", 4) || !strncmp(uri, "//./", 4)) {
 		return XNVME_BE_CAP_BDEV;
 	}
 

--- a/tools/xdd.c
+++ b/tools/xdd.c
@@ -18,6 +18,7 @@ struct cb_args {
 
 	struct xnvme_cmd_ctx dst_ctx;
 	char *buf;
+	int in_use;
 };
 
 static void
@@ -43,6 +44,7 @@ cb_func(struct xnvme_cmd_ctx *ctx, void *cb_arg)
 		}
 	}
 
+	work->in_use = 0;
 	xnvme_queue_put_cmd_ctx(ctx->async.queue, ctx);
 }
 
@@ -129,11 +131,26 @@ copy_async(struct xnvme_cli *cli)
 		work->start_offset = start_offset;
 	}
 	for (size_t ofz = start_offset; (ofz - start_offset < tbytes) && !nerrors;) {
-		struct cb_args *work = &cb_args[((ofz - start_offset) / iosize) % qdepth];
 		struct xnvme_cmd_ctx *src_ctx = xnvme_cmd_ctx_from_queue(queue);
 		size_t nbytes = XNVME_MIN_U64(iosize, tbytes - (ofz - start_offset));
+		struct cb_args *work = NULL;
 		ssize_t res;
 
+		/* Reuse a buffer slot only once its previous read+write has
+		 * completed. Completions may arrive out of order, so select a
+		 * free slot rather than indexing by block number. */
+		while (!work) {
+			for (uint32_t i = 0; i < qdepth; ++i) {
+				if (!cb_args[i].in_use) {
+					work = &cb_args[i];
+					break;
+				}
+			}
+			if (!work) {
+				xnvme_queue_poke(queue, 0);
+			}
+		}
+		work->in_use = 1;
 		src_ctx->async.cb_arg = work;
 
 submit:


### PR DESCRIPTION
Closes #678.

Every platform's `dev_open` implementation wrote `dev->be.{async,sync,admin}`
inside `if (!opts->{async,sync,admin}) { ... }` guards, defaulting to specific
backend implementations. These defaults predate the flat-config refactor:
`_dev_open_try_config()` in `lib/xnvme_platform.c` now populates
`dev->be.{async,sync,admin}` directly from the matched `xnvme_be_config`
before invoking `dev_open`. The overrides therefore silently clobber the
config's choice whenever the caller did not pass `opts->{async,sync,admin}`
explicitly — the common case for the CLI tools and any consumer that selects a
backend via `opts->be`.

The visible bug (Linux): `xnvme_dev_open(uri, { .be = "io_uring" })` selected
the `io_uring` config (async impl `g_xnvme_be_linux_async_liburing`), then
`xnvme_be_linux_dev_open` overwrote `dev->be.async` with
`g_xnvme_be_cbi_async_emu`. Every "async" submission ran through emu's
threadpool into the sync NVMe ioctl backend — producing hundreds of thousands
of ioctls/sec where io_uring SQEs were expected.

The core change removes these stale overrides on Linux, FreeBSD, macOS,
ramdisk, and Windows, so the matched config is the single source of truth for
backend selection.

Dropping the overrides removed a layer that had been silently papering over
several latent bugs: backends were being swapped out from under callers, which
masked misconfigured configs, an unsafe assumption in the async copy, and
Windows path-classification gaps. With the override gone, the test suite goes
red until each of these is fixed, so they are bundled here to keep CI green. 
They are split into self-contained commits, grouped below.

### Core fix — remove the overrides

- `fix(be/linux)`: stop overriding config-selected backends in `dev_open`
  (the bug above).
- `fix(be/fbsd)`, `fix(be/macos)`, `fix(be/ramdisk)`, `fix(be/windows)`:
  the same removal on the remaining platforms.
- `style(be/linux)`: unify the per-file-type debug prints in
  `xnvme_be_linux_dev_open` (cosmetic, touched while in the area).

On Windows, one deliberate exception remains: the S_IFCHR admin override for
the `BusTypeScsi` / `BusTypeSata` case is kept, because no Windows config
exposes `g_xnvme_be_windows_admin_block` and the configs all set `admin_nvme`,
so a SCSI/SATA disk opened by URI would otherwise land on NVMe admin commands.


### Latent bugs exposed by the removal

- `fix(be): classify non-stattable URIs as files` — a not-yet-created URI
  (e.g. a copy destination) matched no ramdisk/PCI/fabrics pattern and fell
  through to the first (NVMe) config, whose sync backend cannot service file
  I/O. Default such URIs to `XNVME_BE_CAP_FILE`, mirroring Windows `classify()`.
- `fix(be): use CBI shim admin for FreeBSD file backend` — `kqueue_file` was
  wired to the NVMe-ioctl admin, which cannot identify a regular file, so
  geometry derivation failed with `EIO`. Route it to the CBI shim admin and
  make it `CAP_FILE`-only, mirroring the Linux `*_file` configs.
- `fix(be): default FreeBSD file I/O to emulated async` — `kqueue_file`
  (kqueue/POSIX-aio) was the only `CAP_FILE` backend on FreeBSD; POSIX aio
  completes out of order, which the xdd async copy did not tolerate. Add an
  `emu_file` config and list it ahead of `kqueue_file` so file URIs select it
  by default (`kqueue_file` stays available by explicit name).
- `fix(xdd): don't assume in-order completion in async copy` — `copy_async`
  picked a buffer slot by `block % qdepth`, only safe under in-order
  completion. Track a per-slot `in_use` flag and pick a free slot per
  submission, making the copy correct regardless of completion ordering. This
  is an independent correctness bug; the FreeBSD POSIX-aio backend just made it
  observable.

### Windows device-path handling

- `fix(platform): classify forward-slash device paths on Windows as bdev` and
  `fix(be/windows): match forward-slash PhysicalDrive URIs in fstat fallback` —
  `//./PhysicalDriveN` resolves identically to `\\.\PhysicalDriveN` in
  `CreateFile()`, but `classify()` and the fstat fallback only matched the
  backslash form. The backslash form does not survive shell evaluation over
  SSH, so fio received `.PhysicalDrive1` and silently benchmarked a regular
  file in its cwd. Recognise the forward-slash form, which needs no escaping.
- `fix(cijoe/configs): use forward-slash device path for the Windows DUT` —
  switch the DUT URI to `//./PhysicalDrive1` for the same reason.

### Test and benchmark config plumbing

- `test(cijoe): skip NVMe-only commands on [admin=block]` — the block-layer
  sync/admin backends only service read/write/flush and zone-management;
  compare, write-zeroes, dsm and zone-append return `-ENOSYS`. These previously
  passed only because `dev_open` swapped block backends for NVMe-ioctl ones.
- `fix(cijoe/configs): select fio xnvme backend by config name` — the fio
  engines selected `be = "<platform>"`, which is not a config name and no
  longer resolves. Point `be` at the real config name and drop the redundant
  `async` field.
- `refactor(cijoe/scripts): drop redundant async from fio latency engines` —
  config name now fully determines the async backend, so remove the `async_`
  field / `--xnvme_async` flag and derive `name_id` from `be` (renames the
  Windows engine label `xnvme_io_ring` → `xnvme_ioring`).
