### PR TITLE
be: remove dead enumerate field and fix stale docstrings

### DIFF
--- a/include/libxnvme_dev.h
+++ b/include/libxnvme_dev.h
@@ -44,11 +44,11 @@ int
 xnvme_dev_pr(const struct xnvme_dev *dev, int opts);
 
 /**
- * Signature of callback function used with 'xnvme_enumerate' invoked for each discoved device
+ * Signature of callback function used with 'xnvme_enumerate', invoked for each discovered device
  *
- * The callback function signals whether the device-handle it receives should by closed, that is,
- * backend with invoke 'xnvme_dev_close(), after the callback returns or kept open. In the latter
- * case then it is up to the user to invoke 'xnvme_dev_close()' on the device-handle.
+ * The callback function signals whether the device-handle it receives should be closed, that is,
+ * the platform will invoke 'xnvme_dev_close()' after the callback returns, or kept open. In the
+ * latter case it is up to the user to invoke 'xnvme_dev_close()' on the device-handle.
  *
  * Each signal is represented by the enum #xnvme_enumerate_action, and the values
  * XNVME_ENUMERATE_DEV_KEEP_OPEN or XNVME_ENUMERATE_DEV_CLOSE.

--- a/include/xnvme_be.h
+++ b/include/xnvme_be.h
@@ -14,7 +14,7 @@
 #define XNVME_BE_ASYNC_NBYTES 64
 #define XNVME_BE_SYNC_NBYTES  24
 #define XNVME_BE_ADMIN_NBYTES 24
-#define XNVME_BE_DEV_NBYTES   48
+#define XNVME_BE_DEV_NBYTES   40
 #define XNVME_BE_MEM_NBYTES   56
 #define XNVME_BE_ATTR_NBYTES  24
 #define XNVME_BE_STATE_NBYTES 128
@@ -88,11 +88,6 @@ struct xnvme_be_admin {
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_be_admin) == XNVME_BE_ADMIN_NBYTES, "Incorrect size")
 
 struct xnvme_be_dev {
-	/**
-	 * enumerate devices on/at the given 'sys_uri' when NULL local devices
-	 */
-	int (*enumerate)(const char *, struct xnvme_opts *, xnvme_enumerate_cb, void *);
-
 	/**
 	 * Construct a device from the given identifier
 	 */

--- a/include/xnvme_be_nosys.h
+++ b/include/xnvme_be_nosys.h
@@ -69,10 +69,6 @@ int
 xnvme_be_nosys_mem_unmap(const struct xnvme_dev *dev, void *buf);
 
 int
-xnvme_be_nosys_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enumerate_cb cb_func,
-			 void *cb_args);
-
-int
 xnvme_be_nosys_dev_open(struct xnvme_dev *dev);
 
 void
@@ -113,7 +109,6 @@ xnvme_be_nosys_dev_close(struct xnvme_dev *dev);
 
 #define XNVME_BE_NOSYS_DEV                              \
 	{                                               \
-		.enumerate  = xnvme_be_nosys_enumerate, \
 		.dev_open   = xnvme_be_nosys_dev_open,  \
 		.dev_close  = xnvme_be_nosys_dev_close, \
 		.id         = "nosys",                  \

--- a/include/xnvme_be_spdk.h
+++ b/include/xnvme_be_spdk.h
@@ -39,20 +39,21 @@ XNVME_STATIC_ASSERT(sizeof(struct spdk_nvme_ns_data) == sizeof(struct xnvme_spec
 		    "Incorrect size")
 
 struct xnvme_be_spdk_state {
-	union {
-		pthread_mutex_t qpair_lock; ///< LOCK for SYNC IO commands
-		uint8_t _fill[64];
-	};
-	struct spdk_nvme_qpair *qpair; ///< QPAIR for SYNC IO commands
-
-	struct spdk_nvme_ctrlr *ctrlr; ///< Pointer to attached controller
+	struct spdk_nvme_ctrlr *ctrlr; ///< Pointer to attached controller (must be first: platform
+				       ///< stores ctrlr at state[0])
 	struct spdk_nvme_ns *ns;       ///< Pointer to associated namespace
+	struct spdk_nvme_qpair *qpair; ///< QPAIR for SYNC IO commands
 
 	uint8_t attached;
 
 	uint8_t _rsvd[7];
 
 	struct xnvme_be_spdk_iov_payload payload;
+
+	union {
+		pthread_mutex_t qpair_lock; ///< LOCK for SYNC IO commands
+		uint8_t _fill[64];
+	};
 };
 XNVME_STATIC_ASSERT(sizeof(struct xnvme_be_spdk_state) == XNVME_BE_STATE_NBYTES, "Incorrect size")
 

--- a/include/xnvme_platform.h
+++ b/include/xnvme_platform.h
@@ -28,7 +28,8 @@ typedef int (*xnvme_scan_cb)(const struct xnvme_ident *ident, void *cb_args);
  * @param dev Opened device handle (caller must close with xnvme_dev_close())
  * @param cb_args User-provided callback arguments
  *
- * @return On success, 0 is returned. On error, negative `errno` is returned.
+ * @return XNVME_ENUMERATE_DEV_KEEP_OPEN to retain the device handle, or
+ *         XNVME_ENUMERATE_DEV_CLOSE to close it after the callback returns.
  */
 typedef int (*xnvme_enumerate_cb)(struct xnvme_dev *dev, void *cb_args);
 
@@ -70,8 +71,8 @@ xnvme_platform_dev_open(struct xnvme_dev *dev, struct xnvme_opts *opts);
  * Shared enumerate implementation using scan + dev_open
  *
  * When sys_uri is NULL, uses platform scan to discover local devices, opens each,
- * and invokes the callback. When sys_uri is provided (fabrics), delegates to the
- * first backend that implements enumerate.
+ * and invokes the callback. When sys_uri is provided (fabrics), delegates to
+ * enumerate_controller to iterate namespaces on the target controller.
  *
  * @param sys_uri NULL for local devices, or fabrics URI for discovery
  * @param opts Options for dev_open (may be NULL for defaults)

--- a/lib/upcie/xnvme_be_upcie.h
+++ b/lib/upcie/xnvme_be_upcie.h
@@ -71,9 +71,6 @@ void
 xnvme_be_upcie_dev_close(struct xnvme_dev *dev);
 int
 xnvme_be_upcie_dev_open(struct xnvme_dev *dev);
-int
-xnvme_be_upcie_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enumerate_cb cb_func,
-			 void *cb_args);
 void *
 xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev);
 int

--- a/lib/upcie/xnvme_be_upcie_cuda_dev.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_dev.c
@@ -154,14 +154,12 @@ xnvme_be_upcie_cuda_ctrlr_init(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_upcie_cuda_dev = {
 #ifdef XNVME_BE_UPCIE_CUDA_ENABLED
-	.enumerate = xnvme_be_upcie_enumerate,
 	.dev_open = xnvme_be_upcie_dev_open,
 	.dev_close = xnvme_be_upcie_dev_close,
 	.id = "upcie-cuda",
 	.ctrlr_init = xnvme_be_upcie_cuda_ctrlr_init,
 	.ctrlr_term = xnvme_be_upcie_cuda_ctrlr_term,
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 #endif

--- a/lib/upcie/xnvme_be_upcie_dev.c
+++ b/lib/upcie/xnvme_be_upcie_dev.c
@@ -13,12 +13,6 @@
 
 static _Atomic int g_ctrlr_count;
 
-struct xnvme_be_upcie_enumerate_context {
-	struct xnvme_opts *opts;
-	xnvme_enumerate_cb cb_func;
-	void *cb_args;
-};
-
 int
 xnvme_be_upcie_get_driver_name(const char *bdf, char *driver_name, size_t driver_name_len)
 {
@@ -277,68 +271,16 @@ xnvme_be_upcie_dev_open(struct xnvme_dev *dev)
 	return 0;
 }
 
-static int
-_instantiate(struct pci_func *func, void *callback_arg)
-{
-	struct xnvme_be_upcie_enumerate_context *ectx = callback_arg;
-	struct xnvme_opts opts = *ectx->opts;
-	struct xnvme_dev *dev = NULL;
-
-	if (!(((func->ident.classcode >> 8) & 0xFFFF) == 0x0108)) {
-		return PCI_SCAN_ACTION_RELEASE_FUNC;
-	}
-
-	opts.be = "upcie";
-
-	dev = xnvme_dev_open(func->bdf, &opts);
-	if (!dev) {
-		XNVME_DEBUG("xnvme_dev_open(); errno()")
-		return PCI_SCAN_ACTION_RELEASE_FUNC;
-	}
-
-	if (ectx->cb_func(dev, ectx->cb_args)) {
-		xnvme_dev_close(dev);
-		return PCI_SCAN_ACTION_RELEASE_FUNC;
-	}
-
-	return PCI_SCAN_ACTION_CLAIM_FUNC;
-}
-
-int
-xnvme_be_upcie_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enumerate_cb cb_func,
-			 void *cb_args)
-{
-	struct xnvme_be_upcie_enumerate_context ectx = {0};
-	int err;
-
-	if (sys_uri) {
-		XNVME_DEBUG("FAILED: does not support 'sys_uri'");
-		return -ENOSYS;
-	}
-
-	ectx.opts = opts;
-	ectx.cb_func = cb_func;
-	ectx.cb_args = cb_args;
-
-	err = pci_scan(_instantiate, &ectx);
-	if (err) {
-		perror("pci_scan()");
-	}
-
-	return 0;
-}
 #endif
 
 struct xnvme_be_dev g_xnvme_be_upcie_dev = {
 #ifdef XNVME_BE_UPCIE_ENABLED
-	.enumerate = xnvme_be_upcie_enumerate,
 	.dev_open = xnvme_be_upcie_dev_open,
 	.dev_close = xnvme_be_upcie_dev_close,
 	.id = "upcie",
 	.ctrlr_init = xnvme_be_upcie_ctrlr_init,
 	.ctrlr_term = xnvme_be_upcie_ctrlr_term,
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_be_fbsd_dev.c
+++ b/lib/xnvme_be_fbsd_dev.c
@@ -160,12 +160,10 @@ xnvme_be_fbsd_dev_open(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_fbsd_dev = {
 #ifdef XNVME_PLATFORM_FREEBSD_ENABLED
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_fbsd_dev_open,
 	.dev_close = xnvme_be_fbsd_dev_close,
 	.id = "freebsd",
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_be_linux_dev.c
+++ b/lib/xnvme_be_linux_dev.c
@@ -189,12 +189,10 @@ xnvme_be_linux_dev_close(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_dev_linux = {
 #ifdef XNVME_PLATFORM_LINUX_ENABLED
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_linux_dev_open,
 	.dev_close = xnvme_be_linux_dev_close,
 	.id = "linux",
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_be_macos_dev.c
+++ b/lib/xnvme_be_macos_dev.c
@@ -228,12 +228,10 @@ xnvme_be_macos_dev_open(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_macos_dev = {
 #ifdef XNVME_PLATFORM_MACOS_ENABLED
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_macos_dev_open,
 	.dev_close = xnvme_be_macos_dev_close,
 	.id = "macos",
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_be_macos_driverkit_dev.c
+++ b/lib/xnvme_be_macos_driverkit_dev.c
@@ -202,14 +202,12 @@ xnvme_be_macos_driverkit_dev_open(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_macos_driverkit_dev = {
 #ifdef XNVME_PLATFORM_MACOS_ENABLED
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_macos_driverkit_dev_open,
 	.dev_close = xnvme_be_macos_driverkit_dev_close,
 	.id = "driverkit",
 	.ctrlr_init = xnvme_be_macos_driverkit_ctrlr_init,
 	.ctrlr_term = xnvme_be_macos_driverkit_ctrlr_term,
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_be_nosys.c
+++ b/lib/xnvme_be_nosys.c
@@ -162,14 +162,6 @@ xnvme_be_nosys_mem_unmap(const struct xnvme_dev *XNVME_UNUSED(dev), void *XNVME_
 }
 
 int
-xnvme_be_nosys_enumerate(const char *XNVME_UNUSED(sys_uri), struct xnvme_opts *XNVME_UNUSED(opts),
-			 xnvme_enumerate_cb XNVME_UNUSED(cb_func), void *XNVME_UNUSED(cb_args))
-{
-	XNVME_DEBUG("FAILED: not implemented(possibly intentional)");
-	return -ENOSYS;
-}
-
-int
 xnvme_be_nosys_dev_open(struct xnvme_dev *XNVME_UNUSED(dev))
 {
 	XNVME_DEBUG("FAILED: not implemented(possibly intentional)");

--- a/lib/xnvme_be_ramdisk_dev.c
+++ b/lib/xnvme_be_ramdisk_dev.c
@@ -87,12 +87,10 @@ xnvme_be_ramdisk_dev_open(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_ramdisk_dev = {
 #ifdef XNVME_BE_RAMDISK_ENABLED
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_ramdisk_dev_open,
 	.dev_close = xnvme_be_ramdisk_dev_close,
 	.id = "ramdisk",
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_be_spdk_dev.c
+++ b/lib/xnvme_be_spdk_dev.c
@@ -24,19 +24,6 @@
 #define XNVME_BE_SPDK_MAX_PROBE_ATTEMPTS 1
 #define XNVME_BE_SPDK_AVLB_TRANSPORTS 3
 
-static int
-_spdk_ctrlr_destructor(void *ctrlr)
-{
-	int err;
-
-	err = spdk_nvme_detach((struct spdk_nvme_ctrlr *)ctrlr);
-	if (err) {
-		XNVME_DEBUG("FAILED: spdk_nvme_detach()");
-	}
-
-	return err;
-}
-
 static int g_xnvme_be_spdk_transport[] = {
 #ifdef XNVME_BE_SPDK_TRANSPORT_PCIE_ENABLED
 	SPDK_NVME_TRANSPORT_PCIE,
@@ -361,8 +348,12 @@ timeout_cb_func(void *XNVME_UNUSED(cb_arg), struct spdk_nvme_ctrlr *ctrlr,
 }
 
 /**
- * Sets up the state{ns, ctrlr, attached} given via the cb_ctx
- * detached if dev->nsid is not a match
+ * Records the attached controller in state so ctrlr_init can return it.
+ *
+ * When nsid is set, rejects controllers that do not have the requested namespace active.
+ * This is needed for NVMe-oF auto-discovery, where SPDK may call attach_cb for both
+ * the discovery controller and the actual NVM subsystem controllers; we must skip the
+ * discovery controller (which has no data namespaces) and wait for the right one.
  */
 static void
 attach_cb(void *cb_ctx, const struct spdk_nvme_transport_id *trid, struct spdk_nvme_ctrlr *ctrlr,
@@ -371,78 +362,64 @@ attach_cb(void *cb_ctx, const struct spdk_nvme_transport_id *trid, struct spdk_n
 	struct xnvme_dev *dev = cb_ctx;
 	struct xnvme_opts *opts = &dev->opts;
 	struct xnvme_be_spdk_state *state = (void *)dev->be.state;
-	struct spdk_nvme_ns *ns = NULL;
 
-	XNVME_DEBUG("INFO: nsid: %d", opts->nsid);
+	if (state->attached) {
+		XNVME_DEBUG("SKIP: Already attached");
+		spdk_nvme_detach(ctrlr);
+		return;
+	}
 
 	if (opts->nsid) {
-		ns = spdk_nvme_ctrlr_get_ns(ctrlr, opts->nsid);
-		if (!ns) {
-			XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_get_ns(0x%x)", opts->nsid);
-			spdk_nvme_detach(ctrlr);
-			return;
-		}
-		if (!spdk_nvme_ns_is_active(ns)) {
-			XNVME_DEBUG("FAILED: !spdk_nvme_ns_is_active(opts->nsid:0x%x)",
+		struct spdk_nvme_ns *ns = spdk_nvme_ctrlr_get_ns(ctrlr, opts->nsid);
+		if (!ns || !spdk_nvme_ns_is_active(ns)) {
+			XNVME_DEBUG("SKIP: nsid 0x%x not found or inactive on this controller",
 				    opts->nsid);
 			spdk_nvme_detach(ctrlr);
 			return;
 		}
-		state->ns = ns;
 	}
 
 	state->ctrlr = ctrlr;
 	state->attached = 1;
 	opts->spdk_fabrics = trid->trtype > SPDK_NVME_TRANSPORT_PCIE;
-
-	if (!xnvme_be_cref_ref(dev->ident.uri, g_xnvme_be_spdk.attr.name, state->ctrlr,
-			       _spdk_ctrlr_destructor)) {
-		XNVME_DEBUG("FAILED: xnvme_be_cref_ref()");
-		return;
-	}
-	if (opts->command_timeout > 0 && opts->admin_timeout > 0) {
-		spdk_nvme_ctrlr_register_timeout_callback(ctrlr, opts->command_timeout,
-							  opts->admin_timeout, timeout_cb_func, 0);
-	}
 }
 
-void
-xnvme_be_spdk_state_term(struct xnvme_be_spdk_state *state)
+static int
+xnvme_be_spdk_ctrlr_term(void *ctrlr)
 {
-	int err;
-
-	if (!state) {
-		return;
-	}
-	if (state->qpair) {
-		spdk_nvme_qp_failure_reason reason;
-		reason = spdk_nvme_qpair_get_failure_reason(state->qpair);
-		if (reason) {
-			// the qpair has already disconnected
-			XNVME_DEBUG("WARNING: qpair in failed state, reason: %d", reason);
-		} else {
-			spdk_nvme_ctrlr_free_io_qpair(state->qpair);
-		}
-		err = pthread_mutex_destroy(&state->qpair_lock);
-		if (err) {
-			printf("UNHANDLED: pthread_mutex_destroy(): '%s'\n", strerror(err));
-		}
-	}
-	err = xnvme_be_cref_deref(state->ctrlr, XNVME_BE_CREF_DESTROY_IMMEDIATE);
+	int err = spdk_nvme_detach((struct spdk_nvme_ctrlr *)ctrlr);
 	if (err) {
-		XNVME_DEBUG("FAILED: xnvme_be_cref_deref():, err: %d", err);
+		XNVME_DEBUG("FAILED: spdk_nvme_detach()");
 	}
+	return err;
 }
 
 void
 xnvme_be_spdk_dev_close(struct xnvme_dev *dev)
 {
+	struct xnvme_be_spdk_state *state = (void *)dev->be.state;
+	spdk_nvme_qp_failure_reason reason;
+	int err;
+
 	if (!dev) {
 		return;
 	}
 
-	xnvme_be_spdk_state_term((void *)dev->be.state);
-	memset(&dev->be, 0, sizeof(dev->be));
+	if (!state->qpair) {
+		return;
+	}
+
+	reason = spdk_nvme_qpair_get_failure_reason(state->qpair);
+	if (reason) {
+		XNVME_DEBUG("WARNING: qpair in failed state, reason: %d", reason);
+	} else {
+		spdk_nvme_ctrlr_free_io_qpair(state->qpair);
+	}
+
+	err = pthread_mutex_destroy(&state->qpair_lock);
+	if (err) {
+		printf("UNHANDLED: pthread_mutex_destroy(): '%s'\n", strerror(err));
+	}
 }
 
 struct xnvme_be_spdk_enumerate_ctx {
@@ -528,7 +505,7 @@ enumerate_attach_cb(void *cb_ctx, const struct spdk_nvme_transport_id *trid,
 
 		// Save the reference to ctrlr so it can be reused when we call xnvme_dev_open()
 		if (!xnvme_be_cref_ref(ident.uri, g_xnvme_be_spdk.attr.name, ctrlr,
-				       _spdk_ctrlr_destructor)) {
+				       xnvme_be_spdk_ctrlr_term)) {
 			XNVME_DEBUG("FAILED: xnvme_be_cref_ref()");
 			return;
 		}
@@ -663,21 +640,18 @@ verify_ctrlr_ok(struct spdk_nvme_ctrlr *ctrlr)
 }
 
 /**
- * - Parse options from dev->ident
- * - Initialize SPDK environment
- * - Attach to controller matching dev->ident
- * - create sync-io-qpair
- * - create lock protecting sync-io-qpair
+ * Initialize a new SPDK controller for the device URI.
+ *
+ * Inits the SPDK environment, if needed, and probes for a device matching the URI.
  */
-int
-xnvme_be_spdk_state_init(struct xnvme_dev *dev)
+static void *
+xnvme_be_spdk_ctrlr_init(struct xnvme_dev *dev)
 {
 	struct xnvme_be_spdk_state *state = (void *)dev->be.state;
 	struct spdk_env_opts env_opts = {0};
 	int err;
 
 	spdk_env_opts_init(&env_opts);
-
 	if (dev->opts.core_mask) {
 		XNVME_DEBUG("INFO: multi-process setup");
 		env_opts.shm_id = dev->opts.shm_id;
@@ -688,74 +662,15 @@ xnvme_be_spdk_state_init(struct xnvme_dev *dev)
 	err = _spdk_env_init(&env_opts);
 	if (err) {
 		XNVME_DEBUG("FAILED: _spdk_env_init(), err: %d", err);
-		return err;
+		return NULL;
 	}
 
-	state->ctrlr = xnvme_be_cref_ref(dev->ident.uri, g_xnvme_be_spdk.attr.name, NULL,
-					 _spdk_ctrlr_destructor);
-	if (state->ctrlr) {
-		struct spdk_nvme_ns *ns;
-
-		XNVME_DEBUG("INFO: found dev->ident.uri: '%s' via cref_lookup()", dev->ident.uri);
-
-		int err = verify_ctrlr_ok(state->ctrlr);
-		if (err < 0) {
-			XNVME_DEBUG("FAILED: verify_ctrlr_ok, err: %d", err);
-		}
-		if (err || spdk_nvme_ctrlr_is_failed(state->ctrlr)) {
-			err = reconnect_ctrlr(state->ctrlr);
-			if (err < 0) {
-				if (xnvme_be_cref_deref(state->ctrlr,
-							XNVME_BE_CREF_DESTROY_IMMEDIATE)) {
-					XNVME_DEBUG("FAILED: xnvme_be_cref_deref");
-				}
-				return -EBUSY;
-			}
-		}
-
-		err = spdk_nvme_ctrlr_process_admin_completions(state->ctrlr);
-		if (err < 0) {
-			XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_process_admin_completions, err: %d",
-				    err);
-			if (xnvme_be_cref_deref(state->ctrlr, XNVME_BE_CREF_DESTROY_IMMEDIATE)) {
-				XNVME_DEBUG("FAILED: xnvme_be_cref_deref");
-			}
-			return -EBUSY;
-		}
-
-		if (dev->opts.nsid) {
-			ns = spdk_nvme_ctrlr_get_ns(state->ctrlr, dev->opts.nsid);
-			if (!ns) {
-				XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_get_ns(0x%x)",
-					    dev->opts.nsid);
-				if (xnvme_be_cref_deref(state->ctrlr,
-							XNVME_BE_CREF_DESTROY_IMMEDIATE)) {
-					XNVME_DEBUG("FAILED: xnvme_be_cref_deref");
-				}
-				return -EBUSY;
-			}
-			if (!spdk_nvme_ns_is_active(ns)) {
-				XNVME_DEBUG("FAILED: !spdk_nvme_ns_is_active(nsid:0x%x)",
-					    dev->opts.nsid);
-				if (xnvme_be_cref_deref(state->ctrlr,
-							XNVME_BE_CREF_DESTROY_IMMEDIATE)) {
-					XNVME_DEBUG("FAILED: xnvme_be_cref_deref");
-				}
-				return -EBUSY;
-			}
-			state->ns = ns;
-		}
-		state->attached = 1;
-		XNVME_DEBUG("INFO: re-using previously attached controller");
-	}
-
-	// Probe for device matching dev->ident
 	for (int i = 0; !state->attached; ++i) {
 		if (XNVME_BE_SPDK_MAX_PROBE_ATTEMPTS == i) {
 			XNVME_DEBUG("FAILED: max attempts exceeded");
-			return -ENXIO;
+			errno = ENXIO;
+			return NULL;
 		}
-
 		for (int t = 0; t < g_xnvme_be_spdk_ntransport; ++t) {
 			int trtype = g_xnvme_be_spdk_transport[t];
 			struct spdk_nvme_transport_id trid = {0};
@@ -771,51 +686,83 @@ xnvme_be_spdk_state_init(struct xnvme_dev *dev)
 			}
 
 			err = spdk_nvme_probe(&trid, dev, probe_cb, attach_cb, NULL);
-			if ((err) || (!state->attached)) {
+			if (err || !state->attached) {
 				XNVME_DEBUG("FAILED: probe a:%d, e:%d, i:%d", state->attached, err,
 					    i);
 			}
 		}
 	}
 
+	XNVME_DEBUG("INFO: ctrlr_init() OK");
+	return state->ctrlr;
+}
+
+int
+xnvme_be_spdk_dev_open(struct xnvme_dev *dev)
+{
+	struct xnvme_be_spdk_state *state = (void *)dev->be.state;
+	int err;
+
+	// ctrlr is at state->ctrlr, placed there by platform (cref reuse or ctrlr_init).
+	// On cref reuse, state->attached is 0 (fresh state); verify health before setting up a new
+	// qpair. On fresh ctrlr_init, attach_cb sets state->attached=1 and we skip verification.
+	if (!state->attached) {
+		int check = verify_ctrlr_ok(state->ctrlr);
+		if (check < 0) {
+			XNVME_DEBUG("FAILED: verify_ctrlr_ok, err: %d", check);
+		}
+		if (check < 0 || spdk_nvme_ctrlr_is_failed(state->ctrlr)) {
+			if (reconnect_ctrlr(state->ctrlr) < 0) {
+				return -EBUSY;
+			}
+		}
+		err = spdk_nvme_ctrlr_process_admin_completions(state->ctrlr);
+		if (err < 0) {
+			XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_process_admin_completions, err: %d",
+				    err);
+			return -EBUSY;
+		}
+	}
+
 	dev->ident.dtype =
 		dev->opts.nsid ? XNVME_DEV_TYPE_NVME_NAMESPACE : XNVME_DEV_TYPE_NVME_CONTROLLER;
-	if (state->ns) {
-		dev->ident.csi = spdk_nvme_ns_get_csi(state->ns);
-	}
 	dev->ident.nsid = dev->opts.nsid;
 
-	// Setup IO qpair lock for SYNC commands
+	if (dev->opts.nsid) {
+		struct spdk_nvme_ns *ns = spdk_nvme_ctrlr_get_ns(state->ctrlr, dev->opts.nsid);
+		if (!ns) {
+			XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_get_ns(0x%x)", dev->opts.nsid);
+			return -EBUSY;
+		}
+		if (!spdk_nvme_ns_is_active(ns)) {
+			XNVME_DEBUG("FAILED: !spdk_nvme_ns_is_active(nsid:0x%x)", dev->opts.nsid);
+			return -EBUSY;
+		}
+		state->ns = ns;
+		dev->ident.csi = spdk_nvme_ns_get_csi(ns);
+	}
+
+	if (dev->opts.command_timeout > 0 && dev->opts.admin_timeout > 0) {
+		spdk_nvme_ctrlr_register_timeout_callback(state->ctrlr, dev->opts.command_timeout,
+							  dev->opts.admin_timeout, timeout_cb_func,
+							  0);
+	}
+
 	err = pthread_mutex_init(&state->qpair_lock, NULL);
 	if (err) {
 		XNVME_DEBUG("FAILED: pthread_mutex_init(): '%s'", strerror(err));
 		return -err;
 	}
 
-	// Setup IO qpair for SYNC commands
 	state->qpair = spdk_nvme_ctrlr_alloc_io_qpair(state->ctrlr, NULL, 0);
 	if (!state->qpair) {
 		XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_alloc_io_qpair()");
+		pthread_mutex_destroy(&state->qpair_lock);
 		return -ENOMEM;
 	}
 
-	XNVME_DEBUG("INFO: open() : OK");
-
+	XNVME_DEBUG("INFO: dev_open() OK");
 	return 0;
-}
-
-int
-xnvme_be_spdk_dev_open(struct xnvme_dev *dev)
-{
-	int err;
-
-	err = xnvme_be_spdk_state_init(dev);
-	if (err) {
-		XNVME_DEBUG("FAILED: xnvme_be_spdk_state_init()");
-		return err;
-	}
-
-	return err;
 }
 #endif
 
@@ -825,6 +772,8 @@ struct xnvme_be_dev g_xnvme_be_spdk_dev = {
 	.dev_open = xnvme_be_spdk_dev_open,
 	.dev_close = xnvme_be_spdk_dev_close,
 	.id = "spdk",
+	.ctrlr_init = xnvme_be_spdk_ctrlr_init,
+	.ctrlr_term = xnvme_be_spdk_ctrlr_term,
 #else
 	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,

--- a/lib/xnvme_be_spdk_dev.c
+++ b/lib/xnvme_be_spdk_dev.c
@@ -18,7 +18,6 @@
 #include <xnvme_queue.h>
 #include <xnvme_be_spdk.h>
 #include <xnvme_be_registry.h>
-#include <xnvme_be_cref.h>
 #include <xnvme_dev.h>
 
 #define XNVME_BE_SPDK_MAX_PROBE_ATTEMPTS 1
@@ -422,168 +421,6 @@ xnvme_be_spdk_dev_close(struct xnvme_dev *dev)
 	}
 }
 
-struct xnvme_be_spdk_enumerate_ctx {
-	struct xnvme_opts *opts;
-	xnvme_enumerate_cb enumerate_cb;
-	void *cb_args;
-};
-
-/**
- * Always attach to supported transports such that `enumerate_probe_cb` can
- * grab namespaces
- *
- * And disable CMB sqs / cqs for now due to shared PMR / CMB
- */
-static bool
-enumerate_probe_cb(void *cb_ctx, const struct spdk_nvme_transport_id *trid,
-		   struct spdk_nvme_ctrlr_opts *ctrlr_opts)
-{
-	struct xnvme_be_spdk_enumerate_ctx *ectx = cb_ctx;
-	struct xnvme_opts *opts = ectx->opts;
-
-	return _spdk_setup_controller_opts(opts, trid, ctrlr_opts);
-}
-
-static void
-enumerate_attach_cb(void *cb_ctx, const struct spdk_nvme_transport_id *trid,
-		    struct spdk_nvme_ctrlr *ctrlr, const struct spdk_nvme_ctrlr_opts *ctrlr_opts)
-{
-	struct xnvme_be_spdk_enumerate_ctx *ectx = cb_ctx;
-
-	for (int nsid = spdk_nvme_ctrlr_get_first_active_ns(ctrlr); nsid;
-	     nsid = spdk_nvme_ctrlr_get_next_active_ns(ctrlr, nsid)) {
-		struct xnvme_opts opts = *ectx->opts;
-		struct xnvme_ident ident = {0};
-		struct xnvme_dev *dev = NULL;
-		struct spdk_nvme_ns *ns;
-		int err;
-
-		// Option options based on what the driver ended up using
-		// NOTE: we communicate the css via the dev->ident.csi
-		opts.use_cmb_sqs = ctrlr_opts->use_cmb_sqs;
-		opts.nsid = nsid;
-		opts.spdk_fabrics = trid->trtype > SPDK_NVME_TRANSPORT_PCIE;
-
-		if (!spdk_nvme_ctrlr_get_data(ctrlr)) {
-			XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_get_data");
-			continue;
-		}
-		ns = spdk_nvme_ctrlr_get_ns(ctrlr, nsid);
-		if (!ns) {
-			XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_get_ns(), for nsid: %d", nsid);
-			continue;
-		}
-		if (!spdk_nvme_ns_get_data(ns)) {
-			XNVME_DEBUG("FAILED: spdk_nvme_ns_get_data()");
-			continue;
-		}
-
-		ident.dtype = XNVME_DEV_TYPE_NVME_NAMESPACE;
-		ident.nsid = nsid;
-		ident.csi = spdk_nvme_ns_get_csi(ns);
-
-		// Namespace looks good, construct xNVMe identifier, and ..
-		switch (trid->trtype) {
-		case SPDK_NVME_TRANSPORT_PCIE:
-			snprintf(ident.uri, sizeof(ident.uri), "%s", trid->traddr);
-			break;
-
-		case SPDK_NVME_TRANSPORT_TCP:
-		case SPDK_NVME_TRANSPORT_RDMA:
-			snprintf(ident.uri, sizeof(ident.uri), "%s:%s", trid->traddr,
-				 trid->trsvcid);
-			break;
-
-		case SPDK_NVME_TRANSPORT_FC:
-		case SPDK_NVME_TRANSPORT_CUSTOM:
-		case SPDK_NVME_TRANSPORT_VFIOUSER:
-		case SPDK_NVME_TRANSPORT_CUSTOM_FABRICS:
-			XNVME_DEBUG("SKIP: ENOSYS trtype: %s",
-				    spdk_nvme_transport_id_trtype_str(trid->trtype));
-			continue;
-		}
-
-		// Save the reference to ctrlr so it can be reused when we call xnvme_dev_open()
-		if (!xnvme_be_cref_ref(ident.uri, g_xnvme_be_spdk.attr.name, ctrlr,
-				       xnvme_be_spdk_ctrlr_term)) {
-			XNVME_DEBUG("FAILED: xnvme_be_cref_ref()");
-			return;
-		}
-
-		dev = xnvme_dev_open(ident.uri, &opts);
-		if (!dev) {
-			XNVME_DEBUG("FAILED: xnvme_dev_open(), err: %d", errno);
-			return;
-		}
-		if (ectx->enumerate_cb(dev, ectx->cb_args)) {
-			xnvme_dev_close(dev);
-			err = xnvme_be_cref_deref(ctrlr, XNVME_BE_CREF_NONE);
-			if (err) {
-				XNVME_DEBUG("FAILED: xnvme_be_cref_deref():, err: %d", err);
-			}
-		}
-	}
-
-	xnvme_be_cref_cleanup(g_xnvme_be_spdk.attr.name);
-}
-
-int
-xnvme_be_spdk_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enumerate_cb cb_func,
-			void *cb_args)
-{
-	struct xnvme_be_spdk_enumerate_ctx ectx = {0};
-	char addr[SPDK_NVMF_TRADDR_MAX_LEN + 1] = {0};
-	struct xnvme_ident ident = {0};
-	int port = 0;
-
-	if (_spdk_env_init(NULL)) {
-		XNVME_DEBUG("FAILED: _spdk_env_init()");
-		return -ESRCH;
-	}
-	if (sys_uri) {
-		if (xnvme_ident_from_uri(sys_uri, &ident)) {
-			XNVME_DEBUG("FAILED: ident_from_uri, uri: %s", sys_uri);
-			return -EINVAL;
-		}
-		if (sscanf(ident.uri, "%[^:]:%d", addr, &port) != 2) {
-			XNVME_DEBUG("FAILED: malformed sys_uri: %s", sys_uri);
-			return -EINVAL;
-		}
-	}
-	XNVME_DEBUG("INFO: sys_uri: %s, addr: %s, port: %d", sys_uri ? sys_uri : "(null)", addr,
-		    port);
-
-	struct xnvme_opts tmp_opts = *opts;
-	tmp_opts.be = g_xnvme_be_spdk.attr.name;
-
-	ectx.opts = &tmp_opts;
-	ectx.enumerate_cb = cb_func;
-	ectx.cb_args = cb_args;
-
-	for (int t = 0; t < g_xnvme_be_spdk_ntransport; ++t) {
-		int trtype = g_xnvme_be_spdk_transport[t];
-		struct spdk_nvme_transport_id trid = {0};
-		int err;
-
-		XNVME_DEBUG("INFO: trtype: %s, # %d of %d",
-			    spdk_nvme_transport_id_trtype_str(trtype), t + 1,
-			    g_xnvme_be_spdk_ntransport);
-
-		err = _xnvme_be_spdk_ident_to_trid(&ident, opts, &trid, trtype);
-		if (err) {
-			XNVME_DEBUG("SKIP: !_xnvme_be_spdk_ident_to_trid()");
-			continue;
-		}
-
-		err = spdk_nvme_probe(&trid, &ectx, enumerate_probe_cb, enumerate_attach_cb, NULL);
-		if (err) {
-			XNVME_DEBUG("FAILED: spdk_nvme_probe(), err: %d", err);
-		}
-	}
-
-	return 0;
-}
-
 static void
 identify_cb(void *ctx, const struct spdk_nvme_cpl *cpl)
 {
@@ -757,14 +594,12 @@ xnvme_be_spdk_dev_open(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_spdk_dev = {
 #ifdef XNVME_BE_SPDK_ENABLED
-	.enumerate = xnvme_be_spdk_enumerate,
 	.dev_open = xnvme_be_spdk_dev_open,
 	.dev_close = xnvme_be_spdk_dev_close,
 	.id = "spdk",
 	.ctrlr_init = xnvme_be_spdk_ctrlr_init,
 	.ctrlr_term = xnvme_be_spdk_ctrlr_term,
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_be_spdk_dev.c
+++ b/lib/xnvme_be_spdk_dev.c
@@ -584,59 +584,58 @@ xnvme_be_spdk_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enum
 	return 0;
 }
 
-static int
-reconnect_ctrlr(struct spdk_nvme_ctrlr *ctrlr)
-{
-	int err;
-	XNVME_DEBUG("WARNING: attempting to reconnect controller");
-	err = spdk_nvme_ctrlr_reset(ctrlr);
-	if (err < 0) {
-		XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_reset, err: %d", err);
-		return -EBUSY;
-	}
-	XNVME_DEBUG("INFO: controller reconnected");
-	return 0;
-}
-
-void
-_identify_cb(void *ctx, const struct spdk_nvme_cpl *cpl)
+static void
+identify_cb(void *ctx, const struct spdk_nvme_cpl *cpl)
 {
 	int *result = (int *)ctx;
 	*result = cpl->status.sc;
 	if (*result != 0) {
-		XNVME_DEBUG("WARNING: bad identify, result: %d", *result);
+		XNVME_DEBUG("WARNING: bad identify, sct: %d, sc: %d", cpl->status.sct,
+			    cpl->status.sc);
 	}
 }
 
-/**
- * See if controller is able to handle a simple admin command if not then the ctrlr is in a bad
- * state
- */
 static int
 verify_ctrlr_ok(struct spdk_nvme_ctrlr *ctrlr)
 {
 	struct spdk_nvme_cmd cmd = {0};
-	int cmd_result = -1;
+	int cmd_result = -1, buf_size = 4096;
+	void *buf;
 	int err;
 
-	int buf_size = 4096;
-	void *buf;
+	err = spdk_nvme_ctrlr_is_failed(ctrlr);
+	if (err) {
+		XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_is_failed()");
+		return -EBUSY;
+	}
+
 	buf = spdk_dma_malloc(buf_size, 0, NULL);
+	if (!buf) {
+		XNVME_DEBUG("FAILED: spdk_dma_malloc()");
+		return -ENOMEM;
+	}
 	cmd.opc = SPDK_NVME_OPC_IDENTIFY;
 	cmd.cdw10_bits.identify.cns = SPDK_NVME_IDENTIFY_CTRLR;
-	spdk_nvme_ctrlr_cmd_admin_raw(ctrlr, &cmd, buf, buf_size, _identify_cb, &cmd_result);
+	err = spdk_nvme_ctrlr_cmd_admin_raw(ctrlr, &cmd, buf, buf_size, identify_cb, &cmd_result);
+	if (err) {
+		XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_cmd_admin_raw(), err: %d", err);
+		goto exit;
+	}
 	while (cmd_result == -1) {
 		err = spdk_nvme_ctrlr_process_admin_completions(ctrlr);
 		if (err < 0) {
-			XNVME_DEBUG(
-				"WARNING: spdk_nvme_ctrlr_process_admin_completions failed, %d",
-				err);
-			cmd_result = err;
-			break;
+			XNVME_DEBUG("WARNING: spdk_nvme_ctrlr_process_admin_completions() failed, "
+				    "err: %d",
+				    err);
+			goto exit;
 		}
 	}
+
+	err = cmd_result;
+
+exit:
 	spdk_dma_free(buf);
-	return cmd_result;
+	return err;
 }
 
 /**
@@ -707,19 +706,9 @@ xnvme_be_spdk_dev_open(struct xnvme_dev *dev)
 	// On cref reuse, state->attached is 0 (fresh state); verify health before setting up a new
 	// qpair. On fresh ctrlr_init, attach_cb sets state->attached=1 and we skip verification.
 	if (!state->attached) {
-		int check = verify_ctrlr_ok(state->ctrlr);
-		if (check < 0) {
-			XNVME_DEBUG("FAILED: verify_ctrlr_ok, err: %d", check);
-		}
-		if (check < 0 || spdk_nvme_ctrlr_is_failed(state->ctrlr)) {
-			if (reconnect_ctrlr(state->ctrlr) < 0) {
-				return -EBUSY;
-			}
-		}
-		err = spdk_nvme_ctrlr_process_admin_completions(state->ctrlr);
-		if (err < 0) {
-			XNVME_DEBUG("FAILED: spdk_nvme_ctrlr_process_admin_completions, err: %d",
-				    err);
+		err = verify_ctrlr_ok(state->ctrlr);
+		if (err) {
+			XNVME_DEBUG("FAILED: verify_ctrlr_ok(), err: %d", err);
 			return -EBUSY;
 		}
 	}

--- a/lib/xnvme_be_vfio_dev.c
+++ b/lib/xnvme_be_vfio_dev.c
@@ -172,14 +172,12 @@ xnvme_be_vfio_dev_close(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_vfio_dev = {
 #ifdef XNVME_BE_VFIO_ENABLED
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_vfio_dev_open,
 	.dev_close = xnvme_be_vfio_dev_close,
 	.id = "libvfn",
 	.ctrlr_init = xnvme_be_vfio_ctrlr_init,
 	.ctrlr_term = xnvme_be_vfio_ctrlr_term,
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",

--- a/lib/xnvme_be_windows_dev.c
+++ b/lib/xnvme_be_windows_dev.c
@@ -238,12 +238,10 @@ xnvme_be_windows_dev_close(struct xnvme_dev *dev)
 
 struct xnvme_be_dev g_xnvme_be_dev_windows = {
 #ifdef XNVME_PLATFORM_WINDOWS_ENABLED
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_windows_dev_open,
 	.dev_close = xnvme_be_windows_dev_close,
 	.id = "windows",
 #else
-	.enumerate = xnvme_be_nosys_enumerate,
 	.dev_open = xnvme_be_nosys_dev_open,
 	.dev_close = xnvme_be_nosys_dev_close,
 	.id = "nosys",


### PR DESCRIPTION
  xnvme_enumerate() has routed through the platform's scan +
  enumerate_controller path for some time. The per-backend enumerate
  function pointer in struct xnvme_be_dev is never called through the
  public API, but every backend still carried an assignment and SPDK/uPCIe
  had non-trivial implementations that were dead code.

  Remove the enumerate field from struct xnvme_be_dev, drop
  xnvme_be_nosys_enumerate, and remove the custom enumerate
  implementations from the SPDK and uPCIe backends.

  Also fix two docstring issues that became visible during this cleanup:
  the xnvme_enumerate_cb return value description incorrectly documented
  generic errno convention instead of the KEEP_OPEN/CLOSE values, and
  xnvme_platform_enumerate still referenced per-backend enumerate
  delegation that no longer exists.
