### PR TITLE
KV via vfu_kvssd over vfio-user and switch to nosi images

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -745,6 +745,10 @@ jobs:
       run: bash toolbox/build_vfu_kvssd.sh
 
     - name: CIJOE, provision and test guest
+      # DIAGNOSTIC (revert): drop the vfio-user-kvssd device to test whether the
+      # guest/QEMU death is caused by the vfio-user mechanism. docgen keeps KV.
+      env:
+        XNVME_GUEST_NO_VFU: "1"
       run: |
         make verify-guest \
           CIJOE_OUTPUT="${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -749,14 +749,22 @@ jobs:
         make verify-guest \
           CIJOE_OUTPUT="${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
 
-    - name: Collect vfu_kvssd device log
+    - name: Collect vfu_kvssd device log + guest serial console
       if: always() && matrix.guest.os == 'debian'
       run: |
+        dst="cijoe/${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
         echo "::group::vfu_kvssd device log"
         cat /tmp/vfu_kvssd.log 2>/dev/null || echo "no vfu_kvssd device log"
         echo "::endgroup::"
-        cp /tmp/vfu_kvssd.log \
-          "cijoe/${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-vfu_kvssd.log" \
+        cp /tmp/vfu_kvssd.log "${dst}-vfu_kvssd.log" 2>/dev/null || true
+        # Guest serial console: shows a guest kernel panic/OOM, and is silent if
+        # QEMU itself died -- which distinguishes a guest crash from a host
+        # vfio-user-pci client crash. Path from configs/debian-trixie*.toml.
+        echo "::group::guest serial console (tail)"
+        tail -c 20000 "$HOME/guests/debian-trixie-amd64/serial.output" 2>/dev/null \
+          || echo "no guest serial output"
+        echo "::endgroup::"
+        cp "$HOME/guests/debian-trixie-amd64/serial.output" "${dst}-serial.output" \
           2>/dev/null || true
 
     - name: CIJOE, result-log-dump on error

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -690,13 +690,16 @@ jobs:
       fail-fast: false
       matrix:
         guest:
-        - {os: 'freebsd', ver: '14'}
-        #- {os: 'freebsd', ver: '15'}
-        - {os: 'debian', ver: 'trixie'}
-        - {os: 'debian', ver: 'trixie-noiommu'}
+        - {os: 'freebsd', ver: '14', container: 'ghcr.io/xnvme/xnvme-qemu:latest'}
+        #- {os: 'freebsd', ver: '15', container: 'ghcr.io/xnvme/xnvme-qemu:latest'}
+        - {os: 'debian', ver: 'trixie', container: 'ghcr.io/safl/nosi/ubuntu-2604-docker:latest'}
+        - {os: 'debian', ver: 'trixie-noiommu', container: 'ghcr.io/safl/nosi/ubuntu-2604-docker:latest'}
 
+    # Debian guests run on the nosi image (upstream QEMU >= 10.1 + cijoe), where
+    # KV is provided by vfu_kvssd over vfio-user. FreeBSD stays on the fork
+    # container until it is migrated separately.
     container:
-      image: ghcr.io/xnvme/xnvme-qemu:latest
+      image: ${{ matrix.guest.container }}
       options: --privileged
 
     steps:
@@ -727,6 +730,13 @@ jobs:
     - name: CIJOE, check that it is available
       run: |
         cijoe -r
+
+    - name: Stage nosi guest image
+      if: matrix.guest.os == 'debian'
+      run: |
+        python3 toolbox/stage_nosi_guest.py \
+          cijoe/configs/${{ matrix.guest.os }}-${{ matrix.guest.ver }}.toml \
+          cijoe/configs/system_imaging.toml
 
     - name: CIJOE, provision and test guest
       run: |
@@ -1154,8 +1164,10 @@ jobs:
         guest:
         - {os: 'debian', ver: 'trixie'}
 
+    # docgen needs the KV emulation; run on the nosi image (upstream QEMU + cijoe)
+    # with KV provided by vfu_kvssd over vfio-user.
     container:
-      image: ghcr.io/xnvme/xnvme-qemu:latest
+      image: ghcr.io/safl/nosi/ubuntu-2604-docker:latest
       options: --privileged
 
     steps:
@@ -1193,6 +1205,12 @@ jobs:
     - name: CIJOE, check that it is available
       run: |
         cijoe -r
+
+    - name: Stage nosi guest image
+      run: |
+        python3 toolbox/stage_nosi_guest.py \
+          cijoe/configs/${{ matrix.guest.os }}-${{ matrix.guest.ver }}.toml \
+          cijoe/configs/system_imaging.toml
 
     # cd'ing into 'cijoe' to auto-collect the non-packaged github-specific configs and
     # workflows.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -738,10 +738,26 @@ jobs:
           cijoe/configs/${{ matrix.guest.os }}-${{ matrix.guest.ver }}.toml \
           cijoe/configs/system_imaging.toml
 
+    # TEMPORARY: build the vfu_kvssd device from a pinned commit so CI runs the
+    # latest device (FLR/reset handling, tracing) instead of the lagging release.
+    - name: Build vfu_kvssd from source (debug)
+      if: matrix.guest.os == 'debian'
+      run: bash toolbox/build_vfu_kvssd.sh
+
     - name: CIJOE, provision and test guest
       run: |
         make verify-guest \
           CIJOE_OUTPUT="${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
+
+    - name: Collect vfu_kvssd device log
+      if: always() && matrix.guest.os == 'debian'
+      run: |
+        echo "::group::vfu_kvssd device log"
+        cat /tmp/vfu_kvssd.log 2>/dev/null || echo "no vfu_kvssd device log"
+        echo "::endgroup::"
+        cp /tmp/vfu_kvssd.log \
+          "cijoe/${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-vfu_kvssd.log" \
+          2>/dev/null || true
 
     - name: CIJOE, result-log-dump on error
       if: failure()
@@ -1212,12 +1228,35 @@ jobs:
           cijoe/configs/${{ matrix.guest.os }}-${{ matrix.guest.ver }}.toml \
           cijoe/configs/system_imaging.toml
 
+    # TEMPORARY: build the vfu_kvssd device from a pinned commit so CI runs the
+    # latest device (FLR/reset handling, tracing) instead of the lagging release.
+    - name: Build vfu_kvssd from source (debug)
+      run: bash toolbox/build_vfu_kvssd.sh
+
+    # The nosi container is the host toolchain (qemu+cijoe); it does not carry
+    # xNVMe's doc toolchain that 'make docs' runs locally. Install the system doc
+    # tools (doxygen, universal-ctags, graphviz) and the xnvme-docs-* commands.
+    - name: Install doc toolchain
+      run: |
+        bash toolbox/pkgs/docgen.sh
+        pipx install ./docs/tooling
+
     # cd'ing into 'cijoe' to auto-collect the non-packaged github-specific configs and
     # workflows.
     - name: CIJOE, provision and generate documentation
       run: |
         make docgen-guest \
           CIJOE_OUTPUT="${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
+
+    - name: Collect vfu_kvssd device log
+      if: always()
+      run: |
+        echo "::group::vfu_kvssd device log"
+        cat /tmp/vfu_kvssd.log 2>/dev/null || echo "no vfu_kvssd device log"
+        echo "::endgroup::"
+        cp /tmp/vfu_kvssd.log \
+          "cijoe/${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-vfu_kvssd.log" \
+          2>/dev/null || true
 
     - name: CIJOE, upload report-docgen
       uses: actions/upload-artifact@v4.3.0

--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,7 @@ guest-start:
 		guest_kill \
 		guest_initialize \
 		guest_start \
+		root_unlock \
 		guest_check
 	@echo "## xNVMe: guest-start [DONE]"
 

--- a/cijoe/configs/debian-trixie-noiommu.toml
+++ b/cijoe/configs/debian-trixie-noiommu.toml
@@ -5,6 +5,16 @@ password = "root"
 hostname = "localhost"
 port = 4200
 
+# Operator account on nosi images (passwordless sudo, SSH password auth on first
+# boot; root is LOCKED by default). Used ONLY by the 'root_unlock' step to open
+# root SSH; every other step uses the default 'ssh' (root) transport unchanged.
+# Inert on the fork-based guest where root SSH already works.
+[cijoe.transport.odus]
+username = "odus"
+password = "odus.321"
+hostname = "localhost"
+port = 4200
+
 [os]
 name = "debian"
 version = "trixie"
@@ -47,6 +57,25 @@ system_args.raw = """\
 # Managed arguments: expands into longer incantations
 system_args.tcp_forward = {host = 4200, guest = 22}
 #system_args.host_share = "{{ local.env.HOME }}/git"
+
+# vfu_kvssd: external NVMe KV device attached over vfio-user. Engaged by
+# xnvme_guest_start_nvme.py only when the QEMU binary lacks native
+# 'nvme-ns,kv=on' (upstream QEMU, not the SamsungDS fork); inert on the fork.
+# vfio-user is host-side, so it works without a guest IOMMU. The prebuilt static
+# binary is fetched from the release when not present at 'binary'.
+[kvssd]
+binary = "{{ local.env.HOME }}/guests/vfu_kvssd"
+url = "https://github.com/safl/vfio-user-kvssd/releases/download/v0.1.0/vfu_kvssd-x86_64-linux"
+socket = "/tmp/vfu_kvssd.sock"
+
+# nosi guest disk-image (OCI artifact on ghcr): a debian-trixie headless image
+# with qemu+cijoe+devbind/iommu/hugepages preinstalled. toolbox/stage_nosi_guest.py
+# pulls + converts it into the system-imaging disk.path that guest_initialize
+# copies to boot.img. Pin 'digest' for reproducibility; 'tag' is used otherwise.
+[guest_image]
+registry = "ghcr.io"
+repository = "safl/nosi/debian-13-headless"
+tag = "latest"
 
 # =============================================================================
 # Devices - One namespace per controller to avoid Linux kernel ordering issues

--- a/cijoe/configs/debian-trixie.toml
+++ b/cijoe/configs/debian-trixie.toml
@@ -68,6 +68,15 @@ binary = "{{ local.env.HOME }}/guests/vfu_kvssd"
 url = "https://github.com/safl/vfio-user-kvssd/releases/download/v0.1.0/vfu_kvssd-x86_64-linux"
 socket = "/tmp/vfu_kvssd.sock"
 
+# nosi guest disk-image (OCI artifact on ghcr): a debian-trixie headless image
+# with qemu+cijoe+devbind/iommu/hugepages preinstalled. toolbox/stage_nosi_guest.py
+# pulls + converts it into the system-imaging disk.path that guest_initialize
+# copies to boot.img. Pin 'digest' for reproducibility; 'tag' is used otherwise.
+[guest_image]
+registry = "ghcr.io"
+repository = "safl/nosi/debian-13-headless"
+tag = "latest"
+
 # =============================================================================
 # Devices - One namespace per controller to avoid Linux kernel ordering issues
 # =============================================================================

--- a/cijoe/configs/debian-trixie.toml
+++ b/cijoe/configs/debian-trixie.toml
@@ -5,6 +5,16 @@ password = "root"
 hostname = "localhost"
 port = 4200
 
+# Operator account on nosi images (passwordless sudo, SSH password auth on first
+# boot; root is LOCKED by default). Used ONLY by the 'root_unlock' step to open
+# root SSH; every other step uses the default 'ssh' (root) transport unchanged.
+# Inert on the fork-based guest where root SSH already works.
+[cijoe.transport.odus]
+username = "odus"
+password = "odus.321"
+hostname = "localhost"
+port = 4200
+
 [os]
 name = "debian"
 version = "trixie"
@@ -47,6 +57,16 @@ system_args.raw = """\
 # Managed arguments: expands into longer incantations
 system_args.tcp_forward = {host = 4200, guest = 22}
 #system_args.host_share = "{{ local.env.HOME }}/git"
+
+# vfu_kvssd: external NVMe KV device attached over vfio-user. Engaged by
+# xnvme_guest_start_nvme.py only when the QEMU binary lacks native
+# 'nvme-ns,kv=on' (upstream QEMU, not the SamsungDS fork); inert on the fork.
+# The prebuilt static binary is fetched from the release when not present at
+# 'binary'.
+[kvssd]
+binary = "{{ local.env.HOME }}/guests/vfu_kvssd"
+url = "https://github.com/safl/vfio-user-kvssd/releases/download/v0.1.0/vfu_kvssd-x86_64-linux"
+socket = "/tmp/vfu_kvssd.sock"
 
 # =============================================================================
 # Devices - One namespace per controller to avoid Linux kernel ordering issues

--- a/cijoe/scripts/root_unlock.py
+++ b/cijoe/scripts/root_unlock.py
@@ -54,6 +54,13 @@ def wait_for_transport(cijoe, transport_name, timeout):
 def main(args, cijoe):
     """Open root SSH over the operator account, then wait for root to be up."""
 
+    # No-op when no operator transport is configured (e.g. the freebsd guest or
+    # the fork-based guest where root SSH already works).
+    transports = cijoe.config.options.get("cijoe", {}).get("transport", {})
+    if args.operator not in transports:
+        log.info(f"no '{args.operator}' transport configured; skipping root unlock")
+        return 0
+
     if not wait_for_transport(cijoe, args.operator, args.timeout):
         log.error(f"operator transport '{args.operator}' did not come up")
         return 1

--- a/cijoe/scripts/root_unlock.py
+++ b/cijoe/scripts/root_unlock.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Unlock root SSH on a nosi guest
+===============================
+
+nosi images ship safe-by-default: the root account is LOCKED; you log in as the
+operator 'odus' (passwordless sudo, SSH password auth on first boot). xNVMe's
+cijoe workflows assume a root SSH transport, so this step -- run over the 'odus'
+transport -- sets a root password and enables 'PermitRootLogin', then waits for
+the root transport to come up. After it runs, the rest of the workflow uses the
+default (root) transport unchanged.
+
+Config: requires an operator transport (default name 'odus') and the default
+transport to be root. The sshd drop-in is named to sort before any hardening
+drop-ins so its 'PermitRootLogin yes' wins.
+
+Retargetable: True (uses the 'odus' and the default transports).
+"""
+import logging as log
+import time
+from argparse import ArgumentParser
+
+ROOT_PASSWORD = "root"
+SSHD_DROPIN = "/etc/ssh/sshd_config.d/00-ci-root.conf"
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--operator",
+        type=str,
+        default="odus",
+        help="Transport name of the passwordless-sudo operator account.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=300,
+        help="Seconds to wait for the operator and the root transport.",
+    )
+
+
+def wait_for_transport(cijoe, transport_name, timeout):
+    """Return True once 'transport_name' accepts SSH within 'timeout' seconds."""
+
+    began = time.time()
+    while time.time() - began < timeout:
+        err, _ = cijoe.run("true", transport_name=transport_name)
+        if not err:
+            return True
+        time.sleep(5)
+    return False
+
+
+def main(args, cijoe):
+    """Open root SSH over the operator account, then wait for root to be up."""
+
+    if not wait_for_transport(cijoe, args.operator, args.timeout):
+        log.error(f"operator transport '{args.operator}' did not come up")
+        return 1
+
+    commands = [
+        f"echo 'root:{ROOT_PASSWORD}' | sudo chpasswd",
+        f"echo 'PermitRootLogin yes' | sudo tee {SSHD_DROPIN}",
+        f"echo 'PasswordAuthentication yes' | sudo tee -a {SSHD_DROPIN}",
+        "sudo systemctl restart ssh || sudo systemctl restart sshd",
+    ]
+    for command in commands:
+        err, _ = cijoe.run(command, transport_name=args.operator)
+        if err:
+            log.error(f"root-unlock command failed: {command}")
+            return err
+
+    if not wait_for_transport(cijoe, None, args.timeout):
+        log.error("root transport did not come up after unlock")
+        return 1
+
+    log.info("root SSH unlocked")
+    return 0

--- a/cijoe/scripts/xnvme_guest_start_nvme.py
+++ b/cijoe/scripts/xnvme_guest_start_nvme.py
@@ -26,6 +26,7 @@ Retargetable: false
 """
 import errno
 import logging as log
+import os
 import subprocess
 from argparse import ArgumentParser
 from pathlib import Path
@@ -75,7 +76,7 @@ def add_args(parser: ArgumentParser):
     parser.add_argument("--guest_name", type=str, default=None)
 
 
-def qemu_nvme_args(nvme_img_root, features=None, vfu_socket=None):
+def qemu_nvme_args(nvme_img_root, features=None, vfu_socket=None, no_vfu=False):
     """
     Returns list of drive-args and a string of qemu-arguments
 
@@ -83,6 +84,8 @@ def qemu_nvme_args(nvme_img_root, features=None, vfu_socket=None):
     @param features: Dict of detected QEMU features {kv, zns, fdp, pi}
     @param vfu_socket: When set (and native KV is absent), emit an external
         vfu_kvssd KV device attached over vfio-user, listening on this socket.
+    @param no_vfu: Diagnostic; when set, fill the KV slot with a plain NVM
+        controller instead of the vfio-user device (keeps downstream BDFs fixed).
     @returns drives, args
     """
     if features is None:
@@ -214,6 +217,10 @@ def qemu_nvme_args(nvme_img_root, features=None, vfu_socket=None):
         slot += 1
     elif vfu_socket:
         nvme_config.append(("vfu_kvssd", vfu_socket, None, slot, None, None))
+        slot += 1
+    elif no_vfu:
+        # Diagnostic: plain NVM controller in the KV slot (no vfio-user device).
+        nvme_config.append(("nvme2", "beef0002", 7, slot, None, [(1, {})]))
         slot += 1
 
     # nvme3: NVM (fabrics testing)
@@ -392,9 +399,15 @@ def main(args, cijoe):
     # (the SamsungDS fork), otherwise an external vfu_kvssd device over vfio-user
     # (upstream QEMU >= 10.1), which needs a launched server and a shareable
     # guest-RAM backend.
+    #
+    # Diagnostic: XNVME_GUEST_NO_VFU drops the vfio-user device + memfd backend
+    # entirely (a plain NVM controller fills the KV slot to keep other BDFs
+    # fixed). Used to test whether the guest/QEMU death is caused by the
+    # vfio-user mechanism or by something else in the nosi/upstream-QEMU setup.
+    no_vfu = bool(os.environ.get("XNVME_GUEST_NO_VFU"))
     extra_args = []
     vfu_socket = None
-    if not features.get("kv"):
+    if not features.get("kv") and not no_vfu:
         vfu_socket = setup_vfu_kvssd(cijoe)
     if vfu_socket:
         mem = guest.guest_config.get("system_args", {}).get("kwa", {}).get("m", "6G")
@@ -405,7 +418,7 @@ def main(args, cijoe):
             f"memory-backend-memfd,id=mem0,size={mem},share=on",
         ]
 
-    drives, nvme_args = qemu_nvme_args(nvme_img_root, features, vfu_socket)
+    drives, nvme_args = qemu_nvme_args(nvme_img_root, features, vfu_socket, no_vfu)
     extra_args += nvme_args
 
     # Check that the backing-storage exists, create them if they do not

--- a/cijoe/scripts/xnvme_guest_start_nvme.py
+++ b/cijoe/scripts/xnvme_guest_start_nvme.py
@@ -75,12 +75,14 @@ def add_args(parser: ArgumentParser):
     parser.add_argument("--guest_name", type=str, default=None)
 
 
-def qemu_nvme_args(nvme_img_root, features=None):
+def qemu_nvme_args(nvme_img_root, features=None, vfu_socket=None):
     """
     Returns list of drive-args and a string of qemu-arguments
 
     @param nvme_img_root: Path to store NVMe backing images
     @param features: Dict of detected QEMU features {kv, zns, fdp, pi}
+    @param vfu_socket: When set (and native KV is absent), emit an external
+        vfu_kvssd KV device attached over vfio-user, listening on this socket.
     @returns drives, args
     """
     if features is None:
@@ -203,17 +205,26 @@ def qemu_nvme_args(nvme_img_root, features=None):
         nvme_config.append(("nvme1", "beef0001", 7, slot, None, [(1, zns_attrs)]))
         slot += 1
 
-    # nvme2: KV
+    # nvme2: KV -- native nvme-ns kv=on (the SamsungDS QEMU fork) or, on upstream
+    # QEMU lacking native KV, an external vfu_kvssd device attached over
+    # vfio-user. Either source occupies this slot so the downstream controller
+    # BDFs (fabrics, large_mdts, fdp, pi...) stay fixed.
     if ENABLE_KV:
         nvme_config.append(("nvme2", "beef0002", 7, slot, None, [(1, {"kv": "on"})]))
+        slot += 1
+    elif vfu_socket:
+        nvme_config.append(("vfu_kvssd", vfu_socket, None, slot, None, None))
         slot += 1
 
     # nvme3: NVM (fabrics testing)
     nvme_config.append(("nvme3", "beef0003", 7, slot, None, [(1, {})]))
     slot += 1
 
-    # nvme4: NVM (large MDTS)
-    nvme_config.append(("nvme4", "beef0004", 0, slot, None, [(1, {})]))
+    # nvme4: NVM (large MDTS). The fork accepts mdts=0 (NVMe "no limit"); upstream
+    # QEMU rejects mdts=0, so advertise a large finite mdts there instead. ENABLE_KV
+    # distinguishes the two (the fork has native KV; upstream does not).
+    large_mdts = 0 if ENABLE_KV else 9
+    nvme_config.append(("nvme4", "beef0004", large_mdts, slot, None, [(1, {})]))
     slot += 1
 
     # nvme5: FDP
@@ -255,6 +266,26 @@ def qemu_nvme_args(nvme_img_root, features=None):
 
     created_subsys = set()
     for ctrl_id, serial, mdts, slot, subsys, namespaces in nvme_config:
+        # vfu_kvssd: external KV device attached via vfio-user on its own root
+        # port ('serial' carries the UNIX socket path). Upstream QEMU's
+        # vfio-user-pci takes the device spec in JSON form; cijoe runs qemu via a
+        # shell, so the (space-free) JSON is single-quoted to keep its quotes.
+        if ctrl_id == "vfu_kvssd":
+            root_port = f"pcie_root_port{slot}"
+            nvme += [
+                "-device",
+                f"pcie-root-port,id={root_port},chassis={slot},slot={slot}",
+            ]
+            vfio_dev = (
+                '{"driver":"vfio-user-pci","socket":{"type":"unix","path":"'
+                + serial
+                + '"},"bus":"'
+                + root_port
+                + '"}'
+            )
+            nvme += ["-device", "'" + vfio_dev + "'"]
+            continue
+
         # Create subsystem if needed
         subsys_id = None
         if subsys:
@@ -274,6 +305,63 @@ def qemu_nvme_args(nvme_img_root, features=None):
             drives.append(drv)
 
     return drives, nvme
+
+
+def setup_vfu_kvssd(cijoe):
+    """
+    Ensure the vfu_kvssd device server is running; return its socket path.
+
+    Reads the '[kvssd]' config table (binary, url, socket). Returns None when no
+    vfu_kvssd is configured -- the caller then simply omits the KV device. The
+    binary is fetched from 'url' when it is not already present at 'binary'. The
+    server is launched detached so it outlives this invocation; the guest
+    connects to its socket after boot.
+    """
+    binary = cijoe.getconf("kvssd.binary", None)
+    url = cijoe.getconf("kvssd.url", None)
+    if not (binary or url):
+        return None
+
+    socket = cijoe.getconf("kvssd.socket", "/tmp/vfu_kvssd.sock")
+    log_path = str(Path(socket).with_suffix(".log"))
+
+    need_fetch = True
+    if binary:
+        err, _ = cijoe.run_local(f"[ -x {binary} ]")
+        need_fetch = bool(err)
+    if need_fetch:
+        if not binary:
+            binary = str(Path(socket).with_name("vfu_kvssd"))
+        if not url:
+            log.error("vfu_kvssd binary missing and no 'kvssd.url' to fetch it")
+            return None
+        err, _ = cijoe.run_local(
+            f"curl -fL --retry 3 -o {binary} {url} && chmod +x {binary}"
+        )
+        if err:
+            log.error(f"failed to fetch vfu_kvssd from {url}")
+            return None
+
+    # Replace any stale server bound to this socket, then launch detached.
+    cijoe.run_local(f"pkill -f '{binary} -s {socket}' || true")
+    cijoe.run_local(f"rm -f {socket}")
+    err, _ = cijoe.run_local(
+        f"setsid {binary} -s {socket} > {log_path} 2>&1 < /dev/null & echo started"
+    )
+    if err:
+        log.error(f"failed to start vfu_kvssd: err({err})")
+        return None
+
+    err, _ = cijoe.run_local(
+        f"for _ in $(seq 1 100); do [ -S {socket} ] && break; sleep 0.1; done; "
+        f"[ -S {socket} ]"
+    )
+    if err:
+        log.error(f"vfu_kvssd did not create socket {socket}; see {log_path}")
+        return None
+
+    log.info(f"vfu_kvssd listening on {socket}")
+    return socket
 
 
 def main(args, cijoe):
@@ -297,7 +385,25 @@ def main(args, cijoe):
     features = detect_qemu_nvme_features(qemu_bin)
     log.info(f"Detected QEMU NVMe features ({qemu_bin}): {features}")
 
-    drives, nvme_args = qemu_nvme_args(nvme_img_root, features)
+    # KV device source: native nvme-ns kv=on when the QEMU binary supports it
+    # (the SamsungDS fork), otherwise an external vfu_kvssd device over vfio-user
+    # (upstream QEMU >= 10.1), which needs a launched server and a shareable
+    # guest-RAM backend.
+    extra_args = []
+    vfu_socket = None
+    if not features.get("kv"):
+        vfu_socket = setup_vfu_kvssd(cijoe)
+    if vfu_socket:
+        mem = guest.guest_config.get("system_args", {}).get("kwa", {}).get("m", "6G")
+        extra_args += [
+            "-machine",
+            "memory-backend=mem0",
+            "-object",
+            f"memory-backend-memfd,id=mem0,size={mem},share=on",
+        ]
+
+    drives, nvme_args = qemu_nvme_args(nvme_img_root, features, vfu_socket)
+    extra_args += nvme_args
 
     # Check that the backing-storage exists, create them if they do not
     for drive in drives:
@@ -306,7 +412,7 @@ def main(args, cijoe):
             guest.image_create(drive["file"], drive["format"], drive_size)
         err, _ = cijoe.run_local(f"[ -f {drive['file']} ]")
 
-    err = guest.start(extra_args=nvme_args)
+    err = guest.start(extra_args=extra_args)
     if err:
         log.error(f"guest.start() : err({err})")
         return err

--- a/cijoe/scripts/xnvme_guest_start_nvme.py
+++ b/cijoe/scripts/xnvme_guest_start_nvme.py
@@ -343,10 +343,13 @@ def setup_vfu_kvssd(cijoe):
             return None
 
     # Replace any stale server bound to this socket, then launch detached.
+    # VFU_KVSSD_TRACE makes the device log its control/admin/IO path to log_path,
+    # which CI bundles, so a host driver's probe sequence can be inspected.
     cijoe.run_local(f"pkill -f '{binary} -s {socket}' || true")
     cijoe.run_local(f"rm -f {socket}")
     err, _ = cijoe.run_local(
-        f"setsid {binary} -s {socket} > {log_path} 2>&1 < /dev/null & echo started"
+        f"setsid env VFU_KVSSD_TRACE=1 {binary} -s {socket} > {log_path} 2>&1 "
+        "< /dev/null & echo started"
     )
     if err:
         log.error(f"failed to start vfu_kvssd: err({err})")

--- a/cijoe/workflows/provision-using-tgz.yaml
+++ b/cijoe/workflows/provision-using-tgz.yaml
@@ -32,6 +32,12 @@ steps:
   with:
     guest_name: "{{ config.qemu.default_guest }}"
 
+# Open root SSH on nosi guests (root is locked by default; uses the 'odus'
+# operator transport). No-op when no operator transport is configured, e.g. the
+# freebsd guest or the fork-based guest where root SSH already works.
+- name: root_unlock
+  uses: root_unlock
+
 - name: guest_check
   run: |
     hostname

--- a/toolbox/build_vfu_kvssd.sh
+++ b/toolbox/build_vfu_kvssd.sh
@@ -17,7 +17,10 @@ set -euo pipefail
 
 DEST="${1:-$HOME/guests/vfu_kvssd}"
 REPO="${VFU_KVSSD_REPO:-https://github.com/safl/vfio-user-kvssd}"
-REF="${VFU_KVSSD_REF:-52cb0e1c578252c704bcc84eb1d05483578acb67}"
+# Track main while the device is being stabilised so pushes to the device repo
+# flow into the next xNVMe CI run without bumping a hash here. Pin a commit/tag
+# (or switch to a release via [kvssd].url) once it is stable.
+REF="${VFU_KVSSD_REF:-main}"
 ZIG_VERSION="${ZIG_VERSION:-0.16.0}"
 
 # The nosi image ships an older zig; build.zig needs the 0.16 module API.

--- a/toolbox/build_vfu_kvssd.sh
+++ b/toolbox/build_vfu_kvssd.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# TEMPORARY: build the vfu_kvssd vfio-user KV device from source for CI.
+#
+# The released binary lags the device source while the NVMe emulation is being
+# stabilised (FLR/reset handling, tracing, SPDK-probe fixes). Building from a
+# pinned commit lets xNVMe CI iterate on the device without cutting a release
+# each time. Once the device is stable, drop this and pin [kvssd].url to a
+# release instead.
+#
+# Usage: build_vfu_kvssd.sh [dest-binary-path]
+#   dest defaults to $HOME/guests/vfu_kvssd, matching the [kvssd].binary path in
+#   the debian-trixie cijoe configs, so xnvme_guest_start_nvme.py finds it and
+#   skips the release download.
+#
+set -euo pipefail
+
+DEST="${1:-$HOME/guests/vfu_kvssd}"
+REPO="${VFU_KVSSD_REPO:-https://github.com/safl/vfio-user-kvssd}"
+REF="${VFU_KVSSD_REF:-52cb0e1c578252c704bcc84eb1d05483578acb67}"
+ZIG_VERSION="${ZIG_VERSION:-0.16.0}"
+
+# The nosi image ships an older zig; build.zig needs the 0.16 module API.
+# Install 0.16 to /opt/zig when the available zig is missing or wrong-series.
+zig_bin="$(command -v zig || true)"
+if [ -z "$zig_bin" ] || ! zig version 2>/dev/null | grep -q "^${ZIG_VERSION%.*}\."; then
+	curl -fsSL \
+		"https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" \
+		-o /tmp/zig.tar.xz
+	mkdir -p /opt/zig
+	tar -C /opt/zig --strip-components=1 -xf /tmp/zig.tar.xz
+	zig_bin=/opt/zig/zig
+fi
+
+# Fetch the pinned commit (shallow) with its submodules (libvfio-user, json-c).
+src=/tmp/vfio-user-kvssd
+rm -rf "$src"
+git init -q "$src"
+git -C "$src" remote add origin "$REPO"
+git -C "$src" fetch -q --depth 1 origin "$REF"
+git -C "$src" checkout -q FETCH_HEAD
+git -C "$src" submodule update --init --recursive
+
+# Native build (runs in the CI container alongside qemu); ReleaseSafe keeps
+# assertions on for the debug phase.
+(cd "$src" && "$zig_bin" build -Doptimize=ReleaseSafe)
+
+mkdir -p "$(dirname "$DEST")"
+cp "$src/zig-out/bin/vfu_kvssd" "$DEST"
+chmod +x "$DEST"
+"$DEST" --version || true
+echo "built vfu_kvssd ($REF) -> $DEST"

--- a/toolbox/dev_setup_check.py
+++ b/toolbox/dev_setup_check.py
@@ -4,6 +4,9 @@ Check QEMU development environment readiness for xNVMe guest workflows.
 
 Checks:
 - qemu-system-x86_64 binary available
+- it can provide the NVMe KV command set: either natively (the SamsungDS fork,
+  'nvme-ns,kv=on') or via an external vfu_kvssd device over vfio-user (upstream
+  QEMU >= 10.1, 'vfio-user-pci')
 - /dev/kvm accessible
 """
 import os
@@ -12,17 +15,17 @@ import subprocess
 import sys
 
 
-def is_custom_qemu(qemu_bin):
-    """Check if the QEMU binary is the custom xNVMe fork (supports KVS, mdts=0)."""
+def qemu_has(qemu_bin, args, needle):
+    """Return True when 'needle' appears in the output of 'qemu_bin args'."""
 
     try:
         result = subprocess.run(
-            [qemu_bin, "-device", "nvme-ns,help"],
+            [qemu_bin, *args],
             capture_output=True,
             text=True,
             timeout=5,
         )
-        return "kv=" in (result.stdout + result.stderr)
+        return needle in (result.stdout + result.stderr)
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         return False
 
@@ -35,15 +38,18 @@ def main():
     # Check qemu-system-x86_64
     qemu = shutil.which("qemu-system-x86_64")
     if qemu:
-        if is_custom_qemu(qemu):
-            print(f"  qemu-system-x86_64: OK (xNVMe fork at {qemu})")
+        if qemu_has(qemu, ["-device", "nvme-ns,help"], "kv="):
+            print(f"  qemu-system-x86_64: OK (native KV, xNVMe fork at {qemu})")
+        elif qemu_has(qemu, ["-device", "help"], "vfio-user-pci"):
+            print(f"  qemu-system-x86_64: OK (upstream + vfio-user at {qemu})")
         else:
-            print(f"  qemu-system-x86_64: WRONG BUILD ({qemu})")
+            print(f"  qemu-system-x86_64: NO KV SUPPORT ({qemu})")
             errors.append(
-                "  Found qemu-system-x86_64 but it is upstream QEMU, not the xNVMe fork.\n"
-                "  The xNVMe fork is required for KVS emulation and mdts=0 support.\n"
+                "  Found qemu-system-x86_64 but it can neither emulate NVMe KV\n"
+                "  natively (no 'nvme-ns,kv=on') nor attach an external vfu_kvssd\n"
+                "  device (no 'vfio-user-pci'; needs upstream QEMU >= 10.1).\n"
                 "  Either:\n"
-                "    a) Run inside the xNVMe Docker environment: make docker\n"
+                "    a) Run inside the nosi Docker environment (QEMU >= 10.1)\n"
                 "    b) Build the xNVMe QEMU fork: https://github.com/SamsungDS/qemu.git (branch: for-xnvme)"
             )
     else:
@@ -51,7 +57,7 @@ def main():
         errors.append(
             "  qemu-system-x86_64 not found.\n"
             "  Either:\n"
-            "    a) Run inside the xNVMe Docker environment: make docker\n"
+            "    a) Run inside the nosi Docker environment (QEMU >= 10.1)\n"
             "    b) Build the xNVMe QEMU fork: https://github.com/SamsungDS/qemu.git (branch: for-xnvme)"
         )
 

--- a/toolbox/stage_nosi_guest.py
+++ b/toolbox/stage_nosi_guest.py
@@ -29,6 +29,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import tomllib
 from pathlib import Path
 
@@ -76,7 +77,20 @@ def main():
     print(f"staging {image_ref} -> {dst}")
 
     with tempfile.TemporaryDirectory() as workdir:
-        subprocess.run(["oras", "pull", image_ref, "-o", workdir], check=True)
+        # Retry: parallel verify/docgen jobs pull this multi-GB blob anonymously
+        # at the same time and ghcr intermittently throttles/resets the transfer.
+        last = None
+        for attempt in range(1, 6):
+            try:
+                subprocess.run(["oras", "pull", image_ref, "-o", workdir], check=True)
+                last = None
+                break
+            except subprocess.CalledProcessError as exc:
+                last = exc
+                print(f"oras pull attempt {attempt}/5 failed; retrying")
+                time.sleep(5 * attempt)
+        if last is not None:
+            raise last
 
         files = [path for path in Path(workdir).rglob("*") if path.is_file()]
         if not files:

--- a/toolbox/stage_nosi_guest.py
+++ b/toolbox/stage_nosi_guest.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Stage a nosi guest disk-image for the xNVMe guest workflows.
+
+nosi publishes its headless guest disk-images as OCI artifacts on ghcr. The nosi
+container ships 'oras', so this just pulls the artifact with it, decompresses the
+disk blob, and converts it to the qcow2 file that cijoe's 'qemu.guest_initialize'
+expects at 'system-imaging.images.<image>.disk.path' -- guest_initialize then
+copies it to the guest boot.img unchanged.
+
+Usage:
+    stage_nosi_guest.py <guest-config.toml> <system_imaging.toml>
+
+The guest config provides a [guest_image] table:
+
+    [guest_image]
+    registry = "ghcr.io"            # optional, default ghcr.io
+    repository = "safl/nosi/debian-13-headless"
+    tag = "latest"                  # used when 'digest' is absent
+    # digest = "sha256:..."         # optional pin (preferred over 'tag')
+
+and either 'qemu.guests.<default_guest>.system_image_name' or
+'qemu.default_systemimage' names the system-imaging entry whose 'disk.path' is
+the destination.
+"""
+import gzip
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+
+
+def expand_home(value):
+    """Expand the cijoe '{{ local.env.HOME }}' template in a config string."""
+
+    return value.replace("{{ local.env.HOME }}", os.environ["HOME"])
+
+
+def disk_path(cfg, imaging):
+    """Resolve the system-imaging disk.path destination for the guest."""
+
+    qemu = cfg.get("qemu", {})
+    default_guest = qemu.get("default_guest")
+    image_name = qemu.get("guests", {}).get(default_guest, {}).get("system_image_name")
+    image_name = image_name or qemu.get("default_systemimage")
+    disk = imaging["system-imaging"]["images"][image_name]["disk"]
+    return Path(expand_home(disk["path"]))
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <guest-config.toml> <system_imaging.toml>")
+        return 1
+
+    with open(sys.argv[1], "rb") as cfg_file:
+        cfg = tomllib.load(cfg_file)
+    with open(sys.argv[2], "rb") as imaging_file:
+        imaging = tomllib.load(imaging_file)
+
+    guest_image = cfg.get("guest_image")
+    if not guest_image:
+        print("config has no [guest_image] table; nothing to stage")
+        return 0
+
+    registry = guest_image.get("registry", "ghcr.io")
+    repository = guest_image["repository"]
+    digest = guest_image.get("digest")
+    ref = f"@{digest}" if digest else f":{guest_image.get('tag', 'latest')}"
+    image_ref = f"{registry}/{repository}{ref}"
+
+    dst = disk_path(cfg, imaging)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    print(f"staging {image_ref} -> {dst}")
+
+    with tempfile.TemporaryDirectory() as workdir:
+        subprocess.run(["oras", "pull", image_ref, "-o", workdir], check=True)
+
+        files = [path for path in Path(workdir).rglob("*") if path.is_file()]
+        if not files:
+            raise RuntimeError(f"oras pull produced no files for {image_ref}")
+        blob = max(files, key=lambda path: path.stat().st_size)
+        print(f"  pulled {blob.name} ({blob.stat().st_size} bytes)")
+
+        # nosi disk blobs are gzip-compressed raw images; decompress then convert.
+        if blob.suffix == ".gz":
+            raw = Path(workdir) / blob.stem
+            with gzip.open(blob, "rb") as src, open(raw, "wb") as out:
+                shutil.copyfileobj(src, out, length=1 << 20)
+            convert_in = ["-f", "raw", str(raw)]
+        else:
+            convert_in = [str(blob)]
+
+        subprocess.run(
+            ["qemu-img", "convert", *convert_in, "-O", "qcow2", str(dst)],
+            check=True,
+        )
+
+    # Headroom for the in-guest xNVMe build; cloud-init growpart grows the rootfs.
+    subprocess.run(["qemu-img", "resize", str(dst), "+8G"], check=True)
+    subprocess.run(["qemu-img", "info", str(dst)], check=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Use vfu_kvssd (vfio-user) for KV when QEMU lacks native kv=on; add [kvssd] config, odus transport and root_unlock for nosi guests. Inert on the fork