### PR TITLE
be/cref: API cleanup and deferred teardown to fix RTE churn during enumeration

### DIFF
--- a/include/xnvme_be_cref.h
+++ b/include/xnvme_be_cref.h
@@ -17,15 +17,28 @@ enum xnvme_be_cref_flags {
 };
 
 /**
- * Lookup a controller by @uri and @be_name, and increment its refcount
+ * A controller reference entry
+ *
+ * @ctrlr holds the controller handle and @be_name holds the backend name the
+ * entry was inserted with.
+ */
+struct xnvme_be_cref_entry {
+	void *ctrlr;
+	xnvme_be_cref_destructor_fn destructor;
+	const char *be_name;
+	int refcount;
+	char uri[XNVME_IDENT_URI_LEN + 1];
+};
+
+/**
+ * Lookup a controller by @uri and increment its refcount
  *
  * @param uri Device URI to match against
- * @param be_name Backend name to match (pointer equality), or NULL for any
  *
- * @return On success, the controller handle. On error, NULL.
+ * @return On a hit, a const pointer to the matched entry. On a miss, NULL.
  */
-void *
-xnvme_be_cref_lookup(const char *uri, const char *be_name);
+const struct xnvme_be_cref_entry *
+xnvme_be_cref_lookup(const char *uri);
 
 /**
  * Insert a new controller entry with refcount=1

--- a/include/xnvme_be_cref.h
+++ b/include/xnvme_be_cref.h
@@ -11,11 +11,6 @@
 
 typedef int (*xnvme_be_cref_destructor_fn)(void *ctrlr);
 
-enum xnvme_be_cref_flags {
-	XNVME_BE_CREF_NONE              = 0x0,
-	XNVME_BE_CREF_DESTROY_IMMEDIATE = 0x1,
-};
-
 /**
  * A controller reference entry
  *
@@ -47,7 +42,7 @@ xnvme_be_cref_lookup(const char *uri);
  * already present, e.g. by calling xnvme_be_cref_lookup() first.
  *
  * @param uri Device URI to associate with the controller
- * @param be_name Backend name pointer, used for filtering in xnvme_be_cref_cleanup()
+ * @param be_name Backend name pointer, stored for later matching
  * @param ctrlr Controller handle to store, must be non-NULL
  * @param destructor Callback invoked to destroy the controller when refcount reaches zero
  *
@@ -58,49 +53,16 @@ xnvme_be_cref_insert(const char *uri, const char *be_name, void *ctrlr,
 		     xnvme_be_cref_destructor_fn destructor);
 
 /**
- * Combined lookup-or-insert
- *
- * If an entry with matching @uri exists, increment its refcount and return the
- * stored handle. Otherwise, if @ctrlr is non-NULL, insert it with refcount=1
- * and associate it with @be_name and @destructor.
- *
- * @param uri Device URI to match or insert
- * @param be_name Backend name pointer, stored for filtering in xnvme_be_cref_cleanup()
- * @param ctrlr Controller handle to insert if no match is found, may be NULL for lookup-only
- * @param destructor Callback invoked to destroy the controller when refcount reaches zero
- *
- * @return On success, the controller handle. On error, NULL.
- */
-void *
-xnvme_be_cref_ref(const char *uri, const char *be_name, void *ctrlr,
-		  xnvme_be_cref_destructor_fn destructor);
-
-/**
  * Decrement the refcount for the given controller
  *
- * If the refcount reaches zero and XNVME_BE_CREF_DESTROY_IMMEDIATE is set,
- * call the stored destructor and remove the entry. Otherwise the entry remains
- * with refcount=0 until xnvme_be_cref_cleanup() is called.
+ * When the refcount reaches zero, call the stored destructor and remove the
+ * entry.
  *
  * @param ctrlr Controller handle to dereference, must be non-NULL
- * @param flags Bitmask of enum xnvme_be_cref_flags
  *
  * @return 0 on success, negative errno on error.
  */
 int
-xnvme_be_cref_deref(void *ctrlr, enum xnvme_be_cref_flags flags);
-
-/**
- * Destroy all entries with zero refcount matching @be_name
- *
- * Iterates all entries, and for those matching @be_name with refcount=0,
- * calls the stored destructor and removes the entry.
- *
- * @param be_name Backend name pointer to match (compared by pointer equality)
- *
- * @return 0 on success, negative errno of the last failed destructor on error.
- */
-int
-xnvme_be_cref_cleanup(const char *be_name);
+xnvme_be_cref_deref(void *ctrlr);
 
 #endif /* __INTERNAL_XNVME_BE_CREF_H */

--- a/include/xnvme_be_cref.h
+++ b/include/xnvme_be_cref.h
@@ -33,13 +33,13 @@ struct xnvme_be_cref_entry {
  * @return On a hit, a const pointer to the matched entry. On a miss, NULL.
  */
 const struct xnvme_be_cref_entry *
-xnvme_be_cref_lookup(const char *uri);
+xnvme_be_cref_get(const char *uri);
 
 /**
  * Insert a new controller entry with refcount=1
  *
  * Does not check for duplicate URIs. The caller must ensure the URI is not
- * already present, e.g. by calling xnvme_be_cref_lookup() first.
+ * already present, e.g. by calling xnvme_be_cref_get() first.
  *
  * @param uri Device URI to associate with the controller
  * @param be_name Backend name pointer, stored for later matching
@@ -63,6 +63,6 @@ xnvme_be_cref_insert(const char *uri, const char *be_name, void *ctrlr,
  * @return 0 on success, negative errno on error.
  */
 int
-xnvme_be_cref_deref(void *ctrlr);
+xnvme_be_cref_put(void *ctrlr);
 
 #endif /* __INTERNAL_XNVME_BE_CREF_H */

--- a/lib/xnvme_be_cref.c
+++ b/lib/xnvme_be_cref.c
@@ -6,14 +6,6 @@
 #include <errno.h>
 #include <xnvme_be_cref.h>
 
-struct xnvme_be_cref_entry {
-	void *ctrlr;
-	xnvme_be_cref_destructor_fn destructor;
-	const char *be_name;
-	int refcount;
-	char uri[XNVME_IDENT_URI_LEN + 1];
-};
-
 static struct xnvme_be_cref_entry g_cref_table[XNVME_BE_CREF_MAX_ENTRIES];
 
 static int
@@ -29,14 +21,14 @@ _entry_matches(const struct xnvme_be_cref_entry *entry, const char *uri, const c
 	return 1;
 }
 
-void *
-xnvme_be_cref_lookup(const char *uri, const char *be_name)
+const struct xnvme_be_cref_entry *
+xnvme_be_cref_lookup(const char *uri)
 {
 	for (int i = 0; i < XNVME_BE_CREF_MAX_ENTRIES; ++i) {
 		if (!g_cref_table[i].ctrlr) {
 			continue;
 		}
-		if (!_entry_matches(&g_cref_table[i], uri, be_name)) {
+		if (strncmp(g_cref_table[i].uri, uri, XNVME_IDENT_URI_LEN)) {
 			continue;
 		}
 		if (g_cref_table[i].refcount < 1) {
@@ -46,7 +38,7 @@ xnvme_be_cref_lookup(const char *uri, const char *be_name)
 
 		g_cref_table[i].refcount += 1;
 
-		return g_cref_table[i].ctrlr;
+		return &g_cref_table[i];
 	}
 
 	return NULL;

--- a/lib/xnvme_be_cref.c
+++ b/lib/xnvme_be_cref.c
@@ -9,7 +9,7 @@
 static struct xnvme_be_cref_entry g_cref_table[XNVME_BE_CREF_MAX_ENTRIES];
 
 const struct xnvme_be_cref_entry *
-xnvme_be_cref_lookup(const char *uri)
+xnvme_be_cref_get(const char *uri)
 {
 	for (int i = 0; i < XNVME_BE_CREF_MAX_ENTRIES; ++i) {
 		if (!g_cref_table[i].ctrlr) {
@@ -60,7 +60,7 @@ xnvme_be_cref_insert(const char *uri, const char *be_name, void *ctrlr,
 }
 
 int
-xnvme_be_cref_deref(void *ctrlr)
+xnvme_be_cref_put(void *ctrlr)
 {
 	if (!ctrlr) {
 		XNVME_DEBUG("FAILED: !ctrlr");

--- a/lib/xnvme_be_cref.c
+++ b/lib/xnvme_be_cref.c
@@ -8,19 +8,6 @@
 
 static struct xnvme_be_cref_entry g_cref_table[XNVME_BE_CREF_MAX_ENTRIES];
 
-static int
-_entry_matches(const struct xnvme_be_cref_entry *entry, const char *uri, const char *be_name)
-{
-	if (strncmp(entry->uri, uri, XNVME_IDENT_URI_LEN)) {
-		return 0;
-	}
-	if (be_name && (!entry->be_name || strcmp(entry->be_name, be_name))) {
-		return 0;
-	}
-
-	return 1;
-}
-
 const struct xnvme_be_cref_entry *
 xnvme_be_cref_lookup(const char *uri)
 {
@@ -72,58 +59,8 @@ xnvme_be_cref_insert(const char *uri, const char *be_name, void *ctrlr,
 	return -ENOMEM;
 }
 
-void *
-xnvme_be_cref_ref(const char *uri, const char *be_name, void *ctrlr,
-		  xnvme_be_cref_destructor_fn destructor)
-{
-	int free_pos = -1;
-
-	for (int i = 0; i < XNVME_BE_CREF_MAX_ENTRIES; ++i) {
-		if (!g_cref_table[i].ctrlr) {
-			if (free_pos < 0) {
-				free_pos = i;
-			}
-			continue;
-		}
-		if (!_entry_matches(&g_cref_table[i], uri, be_name)) {
-			continue;
-		}
-		if (g_cref_table[i].refcount < 0) {
-			XNVME_DEBUG("FAILED: corrupted refcount");
-			return NULL;
-		}
-		if (ctrlr != NULL && ctrlr != g_cref_table[i].ctrlr) {
-			XNVME_DEBUG("FAILED: multiple ctrlr with same ident");
-			return NULL;
-		}
-
-		g_cref_table[i].refcount += 1;
-
-		return g_cref_table[i].ctrlr;
-	}
-
-	if (!ctrlr) {
-		XNVME_DEBUG("FAILED: no matching ctrlr and no ctrlr provided");
-		return NULL;
-	}
-
-	if (free_pos < 0) {
-		XNVME_DEBUG("FAILED: out of slots");
-		return NULL;
-	}
-
-	g_cref_table[free_pos].ctrlr = ctrlr;
-	g_cref_table[free_pos].destructor = destructor;
-	g_cref_table[free_pos].be_name = be_name;
-	g_cref_table[free_pos].refcount = 1;
-	strncpy(g_cref_table[free_pos].uri, uri, XNVME_IDENT_URI_LEN);
-	g_cref_table[free_pos].uri[XNVME_IDENT_URI_LEN] = '\0';
-
-	return g_cref_table[free_pos].ctrlr;
-}
-
 int
-xnvme_be_cref_deref(void *ctrlr, enum xnvme_be_cref_flags flags)
+xnvme_be_cref_deref(void *ctrlr)
 {
 	if (!ctrlr) {
 		XNVME_DEBUG("FAILED: !ctrlr");
@@ -142,7 +79,7 @@ xnvme_be_cref_deref(void *ctrlr, enum xnvme_be_cref_flags flags)
 
 		g_cref_table[i].refcount -= 1;
 
-		if (g_cref_table[i].refcount == 0 && (flags & XNVME_BE_CREF_DESTROY_IMMEDIATE)) {
+		if (g_cref_table[i].refcount == 0) {
 			int err = 0;
 
 			XNVME_DEBUG("INFO: refcount: %d => detaching", g_cref_table[i].refcount);
@@ -161,40 +98,4 @@ xnvme_be_cref_deref(void *ctrlr, enum xnvme_be_cref_flags flags)
 
 	XNVME_DEBUG("FAILED: no tracking for %p", ctrlr);
 	return -EINVAL;
-}
-
-int
-xnvme_be_cref_cleanup(const char *be_name)
-{
-	int ret = 0;
-
-	for (int i = 0; i < XNVME_BE_CREF_MAX_ENTRIES; ++i) {
-		if (!g_cref_table[i].ctrlr) {
-			continue;
-		}
-
-		if (!be_name != !g_cref_table[i].be_name ||
-		    (be_name && strcmp(g_cref_table[i].be_name, be_name))) {
-			continue;
-		}
-
-		if (g_cref_table[i].refcount < 0) {
-			XNVME_DEBUG("FAILED: invalid refcount: %d", g_cref_table[i].refcount);
-			continue;
-		}
-
-		if (g_cref_table[i].refcount == 0) {
-			XNVME_DEBUG("INFO: refcount: %d => detaching", g_cref_table[i].refcount);
-			if (g_cref_table[i].destructor) {
-				int err = g_cref_table[i].destructor(g_cref_table[i].ctrlr);
-				if (err) {
-					XNVME_DEBUG("FAILED: destructor(): %d", err);
-					ret = err;
-				}
-			}
-			memset(&g_cref_table[i], 0, sizeof(g_cref_table[i]));
-		}
-	}
-
-	return ret;
 }

--- a/lib/xnvme_dev.c
+++ b/lib/xnvme_dev.c
@@ -791,7 +791,7 @@ xnvme_dev_close(struct xnvme_dev *dev)
 		dev->be.dev.dev_close(dev);
 
 		if (dev->be.dev.ctrlr_term && ctrlr) {
-			xnvme_be_cref_deref(ctrlr, XNVME_BE_CREF_DESTROY_IMMEDIATE);
+			xnvme_be_cref_deref(ctrlr);
 		}
 	}
 

--- a/lib/xnvme_dev.c
+++ b/lib/xnvme_dev.c
@@ -791,7 +791,7 @@ xnvme_dev_close(struct xnvme_dev *dev)
 		dev->be.dev.dev_close(dev);
 
 		if (dev->be.dev.ctrlr_term && ctrlr) {
-			xnvme_be_cref_deref(ctrlr);
+			xnvme_be_cref_put(ctrlr);
 		}
 	}
 

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -251,11 +251,20 @@ struct enumerate_scan_ctx {
 	struct xnvme_opts *opts;
 	xnvme_enumerate_cb cb_func;
 	void *cb_args;
+	void *anchor;
 };
 
 /**
  * Open controller with nsid=0, send Identify Active Namespace List,
  * then open each namespace and invoke ctx->cb_func.
+ *
+ * On the first enumerated controller (ctx->anchor still NULL), take one extra
+ * reference and store the controller handle in ctx->anchor. The runtime
+ * environment is shared and reference-counted across controllers, so holding
+ * one extra reference keeps it initialized while the remaining controllers are
+ * opened and closed — avoiding a teardown and re-init per controller. The
+ * caller releases the reference with xnvme_be_cref_put() once enumeration
+ * completes.
  */
 static int
 enumerate_controller(const char *uri, struct enumerate_scan_ctx *ctx)
@@ -325,6 +334,14 @@ enumerate_controller(const char *uri, struct enumerate_scan_ctx *ctx)
 
 exit:
 	xnvme_buf_free(ctrlr_dev, idfy_buf);
+
+	if (!ctx->anchor) {
+		const struct xnvme_be_cref_entry *cref = xnvme_be_cref_get(uri);
+
+		if (cref) {
+			ctx->anchor = cref->ctrlr;
+		}
+	}
 	xnvme_dev_close(ctrlr_dev);
 	return 0;
 }
@@ -400,6 +417,7 @@ xnvme_platform_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enu
 			 void *cb_args)
 {
 	struct xnvme_opts opts_default = xnvme_opts_default();
+	int err;
 
 	if (!opts) {
 		opts = &opts_default;
@@ -412,11 +430,18 @@ xnvme_platform_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enu
 	};
 
 	if (!sys_uri) {
-		return g_xnvme_platform->scan(NULL, opts, enumerate_scan_cb, &ctx);
+		err = g_xnvme_platform->scan(NULL, opts, enumerate_scan_cb, &ctx);
+	} else {
+		/** Fabrics / explicit sys_uri: delegate directly to enumerate_controller */
+		err = enumerate_controller(sys_uri, &ctx);
 	}
 
-	/** Fabrics / explicit sys_uri: delegate directly to enumerate_controller */
-	return enumerate_controller(sys_uri, &ctx);
+	/** Release the controller pinned open across enumeration, if any */
+	if (ctx.anchor) {
+		xnvme_be_cref_put(ctx.anchor);
+	}
+
+	return err;
 }
 
 int

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -255,16 +255,15 @@ struct enumerate_scan_ctx {
 
 /**
  * Open controller with nsid=0, send Identify Active Namespace List,
- * then open each namespace and invoke cb_func.
+ * then open each namespace and invoke ctx->cb_func.
  */
 static int
-enumerate_controller(const char *uri, struct xnvme_opts *opts, xnvme_enumerate_cb cb_func,
-		     void *cb_args)
+enumerate_controller(const char *uri, struct enumerate_scan_ctx *ctx)
 {
-	struct xnvme_opts ctrlr_opts = *opts;
+	struct xnvme_opts ctrlr_opts = *ctx->opts;
 	struct xnvme_dev *ctrlr_dev;
 	struct xnvme_spec_idfy *idfy_buf;
-	struct xnvme_cmd_ctx ctx;
+	struct xnvme_cmd_ctx cmd_ctx;
 	uint32_t nslist[XNVME_MAX_NS_LIST_SIZE];
 	size_t buf_size;
 	int err;
@@ -292,9 +291,9 @@ enumerate_controller(const char *uri, struct xnvme_opts *opts, xnvme_enumerate_c
 		return err;
 	}
 
-	ctx = xnvme_cmd_ctx_from_dev(ctrlr_dev);
-	err = xnvme_adm_idfy(&ctx, XNVME_SPEC_IDFY_NSLIST, 0, 0, 0, 0, idfy_buf);
-	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+	cmd_ctx = xnvme_cmd_ctx_from_dev(ctrlr_dev);
+	err = xnvme_adm_idfy(&cmd_ctx, XNVME_SPEC_IDFY_NSLIST, 0, 0, 0, 0, idfy_buf);
+	if (err || xnvme_cmd_ctx_cpl_status(&cmd_ctx)) {
 		XNVME_DEBUG("FAILED: Identify Active NS List, err: %d", err);
 		xnvme_buf_free(ctrlr_dev, idfy_buf);
 		xnvme_dev_close(ctrlr_dev);
@@ -308,7 +307,7 @@ enumerate_controller(const char *uri, struct xnvme_opts *opts, xnvme_enumerate_c
 		goto exit;
 	}
 	for (int i = 0; i < XNVME_MAX_NS_LIST_SIZE && nslist[i]; ++i) {
-		struct xnvme_opts ns_opts = *opts;
+		struct xnvme_opts ns_opts = *ctx->opts;
 		struct xnvme_dev *ns_dev;
 
 		ns_opts.nsid = nslist[i];
@@ -319,7 +318,7 @@ enumerate_controller(const char *uri, struct xnvme_opts *opts, xnvme_enumerate_c
 			continue;
 		}
 
-		if (cb_func(ns_dev, cb_args)) {
+		if (ctx->cb_func(ns_dev, ctx->cb_args)) {
 			xnvme_dev_close(ns_dev);
 		}
 	}
@@ -355,7 +354,7 @@ enumerate_scan_cb(const struct xnvme_ident *ident, void *cb_args)
 	 */
 	if (ident->dtype == XNVME_DEV_TYPE_NVME_CONTROLLER) {
 		if (!is_kernel_nvme_driver(ident->kernel_driver)) {
-			enumerate_controller(ident->uri, ctx->opts, ctx->cb_func, ctx->cb_args);
+			enumerate_controller(ident->uri, ctx);
 		}
 		return 0;
 	}
@@ -406,18 +405,18 @@ xnvme_platform_enumerate(const char *sys_uri, struct xnvme_opts *opts, xnvme_enu
 		opts = &opts_default;
 	}
 
-	if (!sys_uri) {
-		struct enumerate_scan_ctx ctx = {
-			.opts = opts,
-			.cb_func = cb_func,
-			.cb_args = cb_args,
-		};
+	struct enumerate_scan_ctx ctx = {
+		.opts = opts,
+		.cb_func = cb_func,
+		.cb_args = cb_args,
+	};
 
+	if (!sys_uri) {
 		return g_xnvme_platform->scan(NULL, opts, enumerate_scan_cb, &ctx);
 	}
 
 	/** Fabrics / explicit sys_uri: delegate directly to enumerate_controller */
-	return enumerate_controller(sys_uri, opts, cb_func, cb_args);
+	return enumerate_controller(sys_uri, &ctx);
 }
 
 int

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -85,10 +85,10 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 		return be->dev.dev_open(dev);
 	}
 
-	cref = xnvme_be_cref_lookup(dev->ident.uri);
+	cref = xnvme_be_cref_get(dev->ident.uri);
 	if (cref) {
 		if (strcmp(cref->be_name, cfg->attr.name)) {
-			xnvme_be_cref_deref(cref->ctrlr);
+			xnvme_be_cref_put(cref->ctrlr);
 			XNVME_DEBUG("FAILED: uri '%s' claimed by another backend config",
 				    dev->ident.uri);
 			return -EBUSY;
@@ -116,7 +116,7 @@ ctrlr_ready:
 
 	err = be->dev.dev_open(dev);
 	if (err) {
-		xnvme_be_cref_deref(ctrlr);
+		xnvme_be_cref_put(ctrlr);
 	}
 
 	return err;

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -88,7 +88,7 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 	cref = xnvme_be_cref_lookup(dev->ident.uri);
 	if (cref) {
 		if (strcmp(cref->be_name, cfg->attr.name)) {
-			xnvme_be_cref_deref(cref->ctrlr, XNVME_BE_CREF_NONE);
+			xnvme_be_cref_deref(cref->ctrlr);
 			XNVME_DEBUG("FAILED: uri '%s' claimed by another backend config",
 				    dev->ident.uri);
 			return -EBUSY;
@@ -116,7 +116,7 @@ ctrlr_ready:
 
 	err = be->dev.dev_open(dev);
 	if (err) {
-		xnvme_be_cref_deref(ctrlr, XNVME_BE_CREF_DESTROY_IMMEDIATE);
+		xnvme_be_cref_deref(ctrlr);
 	}
 
 	return err;

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -77,27 +77,25 @@ _dev_open_resolve_mem(struct xnvme_be *be, const struct xnvme_be_config *cfg,
 static int
 _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnvme_be_config *cfg)
 {
-	void *ctrlr = NULL;
+	const struct xnvme_be_cref_entry *cref;
+	void *ctrlr;
 	int err;
 
 	if (!be->dev.ctrlr_init) {
 		return be->dev.dev_open(dev);
 	}
 
-	ctrlr = xnvme_be_cref_lookup(dev->ident.uri, cfg->attr.name);
-	if (ctrlr) {
-		goto ctrlr_ready;
-	}
-
-	{
-		void *conflict = xnvme_be_cref_lookup(dev->ident.uri, NULL);
-
-		if (conflict) {
-			xnvme_be_cref_deref(conflict, XNVME_BE_CREF_NONE);
+	cref = xnvme_be_cref_lookup(dev->ident.uri);
+	if (cref) {
+		if (strcmp(cref->be_name, cfg->attr.name)) {
+			xnvme_be_cref_deref(cref->ctrlr, XNVME_BE_CREF_NONE);
 			XNVME_DEBUG("FAILED: uri '%s' claimed by another backend config",
 				    dev->ident.uri);
 			return -EBUSY;
 		}
+
+		ctrlr = cref->ctrlr;
+		goto ctrlr_ready;
 	}
 
 	ctrlr = be->dev.ctrlr_init(dev);


### PR DESCRIPTION
  **Single-lookup conflict detection** (`refactor(be/cref): change lookup
  be_name from filter to out-parameter`)
  `xnvme_be_cref_lookup()` previously took `be_name` as a filter, requiring
  callers to call it twice to distinguish a same-name hit from a
  conflict with a different backend. Change `be_name` to a `const char**`
  out-parameter so a single call covers both cases.

  **Remove `xnvme_be_cref_ref()`** (`cleanup(be/cref)`)
  `xnvme_be_cref_ref()` was a combined lookup-or-insert helper used only by
  the old SPDK enumerate path (removed in #680). Dead code.

  **Deferred teardown** (`refactor + fix`)
  During enumeration, each `ctrlr_dev` close triggers the `ctrlr` destructor
  immediately when refcount hits 0. For SPDK and uPCIe this tears down the RTE
  between controllers, forcing re-initialisation for every subsequent
  controller in the scan.

  Introduce `xnvme_be_cref_defer()`: callers mark an entry as deferred
  before releasing it. `xnvme_be_cref_put()` then leaves `refcount==0` entries
  alive rather than destroying them. `xnvme_be_cref_cleanup()` destroys all
  pending entries in one pass and is called after the full scan completes.

  For devices that stay open across an enumeration boundary, `cleanup()`
  clears the deferred flag so they are destroyed normally on the caller's
  eventual close.

  Fix `xnvme_be_cref_insert()` to scan for a free slot using `ctrlr == NULL` rather than
  `refcount == 0`, with deferred entries the two are no longer equivalent.

  **Rename** (`rename(be/cref)`)
  `lookup()` -> `get()`, `deref()` -> `put()`. get/put is a natural acquire/release pair
  that makes the refcounting semantics clear.
