### PR TITLE
ci(freebsd): use patched nosi image and collect serial console

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -743,13 +743,14 @@ jobs:
           CIJOE_OUTPUT="${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
 
     - name: Collect guest serial console
-      if: always() && matrix.guest.os == 'debian'
+      if: always() && (matrix.guest.os == 'debian' || matrix.guest.os == 'freebsd')
       run: |
         dst="cijoe/${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}"
+        serial="$HOME/guests/${{ matrix.guest.os }}-${{ matrix.guest.ver }}-amd64/serial.output"
         echo "::group::guest serial console (tail)"
-        tail -c 20000 "$HOME/guests/debian-trixie-amd64/serial.output" 2>/dev/null || echo "no guest serial output"
+        tail -c 20000 "$serial" 2>/dev/null || echo "no guest serial output"
         echo "::endgroup::"
-        cp "$HOME/guests/debian-trixie-amd64/serial.output" "${dst}-serial.output" 2>/dev/null || true
+        cp "$serial" "${dst}-serial.output" 2>/dev/null || true
 
     - name: Collect vfu_kvssd device log
       if: always()

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -90,7 +90,7 @@ jobs:
   #
   source-format-check:
     runs-on: ubuntu-latest
-    container: ghcr.io/xnvme/xnvme-deps-fedora-citools:main
+    container: ghcr.io/xnvme/xnvme-citools-debian-latest:main
 
     steps:
     - name: Grab source
@@ -114,7 +114,7 @@ jobs:
   test-gen-targets:
     needs: source-archive
     runs-on: ubuntu-latest
-    container: ghcr.io/xnvme/xnvme-deps-citools-latest:main
+    container: ghcr.io/xnvme/xnvme-citools-debian-latest:main
 
     steps:
     - name: Retrieve and unpack the xNVMe source archive
@@ -1302,7 +1302,7 @@ jobs:
   packaging-debian:
     needs: source-archive
     runs-on: ubuntu-latest
-    container: ghcr.io/xnvme/xnvme-deps-debian-packaging:main
+    container: ghcr.io/xnvme/xnvme-citools-debian-latest:main
     if: github.event_name == 'pull_request'
 
     steps:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -77,7 +77,7 @@ jobs:
         mv builddir/meson-dist/xnvme-0.7.5.tar.gz.sha256sum builddir/meson-dist/xnvme-src.tar.gz.sha256sum
 
     - name: Upload source archive
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: xnvme-src-archive${{ matrix.variant == 'with-subprojects' && '-with-subprojects' || '' }}
         path: |
@@ -215,7 +215,7 @@ jobs:
         mv python/bindings/dist/xnvme-*.*.*.tar.gz python/bindings/dist/xnvme-py-sdist.tar.gz
 
     - name: Python sdist-packages, upload bindings
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: xnvme-py-sdist
         path: |
@@ -333,7 +333,7 @@ jobs:
         echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: Retrieve the xNVMe Python sdist package
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7.0.0
       with:
         name: xnvme-py-sdist
         path: ${{ steps.source.outputs.directory }}
@@ -366,7 +366,7 @@ jobs:
 
     - name: CIJOE, upload report.html
       if: always() && (!contains('focal', matrix.container.ver))
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ github.job }}-${{ matrix.container.os }}-${{ matrix.container.ver }}-report-html
         path: cijoe/${{ github.job }}-${{ matrix.container.os }}-${{ matrix.container.ver }}-*/report.html
@@ -380,7 +380,7 @@ jobs:
 
     - name: CIJOE, upload build-${{ matrix.container.os }}-${{ matrix.container.ver }}-reports
       if: always() && (!contains('focal', matrix.container.ver))
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ github.job }}-${{ matrix.container.os }}-${{ matrix.container.ver }}-reports
         path: ${{ github.job }}-${{ matrix.container.os }}-${{ matrix.container.ver }}-reports.tar.gz
@@ -458,7 +458,7 @@ jobs:
         python3 -c 'import sysconfig; print(sysconfig.get_config_var("SHLIB_SUFFIX"))'
 
     - name: Retrieve the xNVMe Python sdist package
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7.0.0
       with:
         name: xnvme-py-sdist
         path: ${{ steps.source.outputs.directory }}
@@ -498,7 +498,7 @@ jobs:
 
     - name: CIJOE, upload report.html
       if: always()
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-report-html
         path: cijoe/${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-*/report.html
@@ -511,7 +511,7 @@ jobs:
           cijoe/${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-*
 
     - name: CIJOE, upload build-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-reports
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       if: always()
       with:
         name: ${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-reports
@@ -619,7 +619,7 @@ jobs:
         python3 -c 'import sysconfig; print(sysconfig.get_config_var("SHLIB_SUFFIX"))'
 
     - name: Retrieve the xNVMe Python sdist package
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7.0.0
       with:
         name: xnvme-py-sdist
         path: ${{ steps.source.outputs.directory }}
@@ -657,7 +657,7 @@ jobs:
 
     - name: CIJOE, upload report.html
       if: always()
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-report-html
         path: cijoe/${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-*/report.html
@@ -670,7 +670,7 @@ jobs:
           cijoe/${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-*
 
     - name: CIJOE, upload build-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-reports
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       if: always()
       with:
         name: ${{ github.job }}-${{ matrix.runner.os }}-${{ matrix.runner.ver }}-reports
@@ -711,7 +711,7 @@ jobs:
         name: xnvme-src-archive-with-subprojects
 
     - name: Retrieve the xNVMe Python sdist package
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7.0.0
       with:
         name: xnvme-py-sdist
         path: ${{ steps.source.outputs.directory }}
@@ -766,7 +766,7 @@ jobs:
 
     - name: CIJOE, upload report.html
       if: always()
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-report-html
         path: cijoe/${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-*/report.html
@@ -779,7 +779,7 @@ jobs:
           cijoe/${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-*
 
     - name: CIJOE, upload verify-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-reports
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       if: always()
       with:
         name: ${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-reports
@@ -815,7 +815,7 @@ jobs:
         name: xnvme-src-archive-with-subprojects
 
     - name: Retrieve the xNVMe Python sdist package
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7.0.0
       with:
         name: xnvme-py-sdist
         path: ${{ steps.source.outputs.directory }}
@@ -870,7 +870,7 @@ jobs:
 
     - name: CIJOE, upload report.html
       if: always()
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ github.job }}-${{ matrix.guest.hostname }}-report-html
         path: cijoe/${{ github.job }}-${{ matrix.guest.hostname }}-*/report.html
@@ -883,7 +883,7 @@ jobs:
           cijoe/${{ github.job }}-${{ matrix.guest.hostname }}-*
 
     - name: CIJOE, upload verify-${{ matrix.guest.hostname }}-reports
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       if: always()
       with:
         name: ${{ github.job }}-${{ matrix.guest.hostname }}-reports
@@ -915,7 +915,7 @@ jobs:
         name: xnvme-src-archive-with-subprojects
 
     - name: Retrieve the xNVMe Python sdist package
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7.0.0
       with:
         name: xnvme-py-sdist
         path: ${{ steps.source.outputs.directory }}
@@ -956,7 +956,7 @@ jobs:
 
     - name: CIJOE, upload report.html
       if: always()
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ github.job }}-${{ matrix.guest.hostname }}-report-html
         path: cijoe/${{ github.job }}-${{ matrix.guest.hostname }}-*/report.html
@@ -969,7 +969,7 @@ jobs:
           cijoe/${{ github.job }}-${{ matrix.guest.hostname }}-*
 
     - name: CIJOE, upload verify-${{ matrix.guest.hostname }}-reports
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       if: always()
       with:
         name: ${{ github.job }}-${{ matrix.guest.hostname }}-reports
@@ -996,7 +996,7 @@ jobs:
         name: xnvme-src-archive-with-subprojects
 
     - name: Retrieve the xNVMe Python sdist package
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7.0.0
       with:
         name: xnvme-py-sdist
         path: ${{ steps.source.outputs.directory }}
@@ -1041,7 +1041,7 @@ jobs:
 
     - name: CIJOE, upload report.html
       if: always()
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ github.job }}-report-html
         path: cijoe/${{ github.job }}-*/report.html
@@ -1054,7 +1054,7 @@ jobs:
           cijoe/${{ github.job }}-*
 
     - name: CIJOE, upload benchmark-bdev_xnvme-reports
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       if: always()
       with:
         name: ${{ github.job }}-reports
@@ -1089,7 +1089,7 @@ jobs:
         name: xnvme-src-archive-with-subprojects
 
     - name: Retrieve the xNVMe Python sdist package
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7.0.0
       with:
         name: xnvme-py-sdist
         path: ${{ steps.source.outputs.directory }}
@@ -1125,7 +1125,7 @@ jobs:
 
     - name: CIJOE, upload report.html
       if: always()
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: ${{ github.job }}-${{ matrix.guest.os }}-report-html
         path: cijoe/${{ github.job }}-${{ matrix.guest.os }}-*/report.html
@@ -1138,7 +1138,7 @@ jobs:
           cijoe/${{ github.job }}-${{ matrix.guest.os }}-*
 
     - name: CIJOE, upload latency-${{ matrix.guest.os }}-reports
-      uses: actions/upload-artifact@v4.6.2
+      uses: actions/upload-artifact@v6.0.0
       if: always()
       with:
         name: ${{ github.job }}-${{ matrix.guest.os }}-reports
@@ -1201,7 +1201,7 @@ jobs:
         echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: Retrieve the xNVMe Python sdist package
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7.0.0
       with:
         name: xnvme-py-sdist
         path: ${{ steps.source.outputs.directory }}
@@ -1258,7 +1258,7 @@ jobs:
           2>/dev/null || true
 
     - name: CIJOE, upload report-docgen
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       if: always()
       with:
         name: ${{ github.job }}-${{ matrix.guest.os }}-${{ matrix.guest.ver }}-reports
@@ -1331,7 +1331,7 @@ jobs:
         cd debpkg && make || true
 
     - name: Upload debian packages
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: packages-debian
         path: |

--- a/cijoe/configs/freebsd-14.toml
+++ b/cijoe/configs/freebsd-14.toml
@@ -39,7 +39,7 @@ default_guest = "freebsd_14"
 default_systemimage = "freebsd-14-x86_64"
 
 [guest_image]
-url = "https://ghcr.io/v2/safl/nosi/freebsd-14-headless/blobs/sha256:3a834389b4f1d4dddf4cddc2adb3e7a5ad71994d9851bd0c281f185031ed6878"
+url = "https://ghcr.io/v2/safl/nosi/freebsd-14-headless/blobs/sha256:e1e9816add8c8587007c1149048c78495e1b98f2bd53cb1cbe8dda165473ade3"
 
 [qemu.systems.x86_64]
 bin = "qemu-system-x86_64"

--- a/cijoe/configs/freebsd-14.toml
+++ b/cijoe/configs/freebsd-14.toml
@@ -39,7 +39,7 @@ default_guest = "freebsd_14"
 default_systemimage = "freebsd-14-x86_64"
 
 [guest_image]
-url = "https://ghcr.io/v2/safl/nosi/freebsd-14-headless/blobs/sha256:ecb5855545c20a47c2829d63e8a6758ff19804b2694a7edfc1c5cb1ad4c8af41"
+url = "https://ghcr.io/v2/safl/nosi/freebsd-14-headless/blobs/sha256:3a834389b4f1d4dddf4cddc2adb3e7a5ad71994d9851bd0c281f185031ed6878"
 
 [qemu.systems.x86_64]
 bin = "qemu-system-x86_64"

--- a/subprojects/packagefiles/spdk/meson.build
+++ b/subprojects/packagefiles/spdk/meson.build
@@ -1,7 +1,7 @@
 project(
   'spdk',
   'c',
-  version: '24.09',
+  version: '25.05.1',
 )
 fs = import('fs')
 

--- a/subprojects/packagefiles/spdk/patches/spdk-0002-queue-provide-TAILQ_REMOVE_CLEAR-on-FreeBSD.patch
+++ b/subprojects/packagefiles/spdk/patches/spdk-0002-queue-provide-TAILQ_REMOVE_CLEAR-on-FreeBSD.patch
@@ -1,0 +1,65 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Simon A. F. Lund" <os@safl.dk>
+Date: Thu, 11 Jun 2026 13:00:00 +0200
+Subject: [PATCH] queue: provide TAILQ_REMOVE_CLEAR on FreeBSD
+
+include/spdk/queue.h pulls in include/spdk/queue_extras.h only under
+__linux__, on the premise that FreeBSD's <sys/queue.h> already supplies
+the macros SPDK needs. That stopped being true when lib/nvme/nvme_tcp.c
+started using TAILQ_REMOVE_CLEAR and the new TAILQ_ENTRY *_poll /
+*_timeout entries in upstream commit f108a1f1 ("nvme/tcp: use
+TAILQ_ENTRY_*() instead of needs_poll", May 2025). Those macros are
+SPDK-internal, not in any FreeBSD release, so every FreeBSD build since
+then fails with "undeclared identifier".
+
+We cannot just include queue_extras.h on FreeBSD too -- it redefines
+~50 macros (STAILQ_HEAD, LIST_*, TAILQ_FOREACH_SAFE, QMD_*, ...) that
+FreeBSD's <sys/queue.h> already provides, and the redefinitions
+cascade-conflict. Provide just the missing helpers in queue.h directly,
+under an __FreeBSD__ branch, until SPDK upstream fixes the conditional
+include or moves these helpers into a separate header.
+
+Signed-off-by: Simon A. F. Lund <os@safl.dk>
+---
+ include/spdk/queue.h | 26 ++++++++++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+
+diff --git a/include/spdk/queue.h b/include/spdk/queue.h
+--- a/include/spdk/queue.h
++++ b/include/spdk/queue.h
+@@ -20,6 +20,32 @@
+  */
+ #ifdef __linux__
+ #include "spdk/queue_extras.h"
++#elif defined(__FreeBSD__)
++/*
++ * FreeBSD's <sys/queue.h> provides most of the BSD queue macros natively
++ * but lacks the SPDK-introduced helpers (TAILQ_REMOVE_CLEAR et al.) used
++ * by lib/nvme/nvme_tcp.c since upstream f108a1f1 (May 2025). Including
++ * spdk/queue_extras.h wholesale on FreeBSD would cascade-conflict with
++ * ~50 macros (STAILQ_HEAD, LIST_*, QMD_*, ...) that the system header
++ * already provides. Define just the missing helpers here.
++ */
++#include <assert.h>
++
++#define TAILQ_ENTRY_ENQUEUED(elm, field) \
++	((elm)->field.tqe_prev != NULL)
++
++#define TAILQ_ENTRY_NOT_ENQUEUED(elm, field) \
++	(!TAILQ_ENTRY_ENQUEUED(elm, field))
++
++#define TAILQ_ENTRY_CLEAR(elm, field) do { \
++	assert(TAILQ_ENTRY_ENQUEUED(elm, field)); \
++	(elm)->field.tqe_prev = NULL; \
++} while (0)
++
++#define TAILQ_REMOVE_CLEAR(head, elm, field) do { \
++	TAILQ_REMOVE(head, elm, field); \
++	TAILQ_ENTRY_CLEAR(elm, field); \
++} while (0)
+ #endif
+ 
+ /*
+-- 
+2.34.1
+

--- a/subprojects/spdk.wrap
+++ b/subprojects/spdk.wrap
@@ -4,6 +4,6 @@
 
 [wrap-git]
 url = https://github.com/spdk/spdk.git
-revision = v24.09
+revision = v25.05.1
 patch_directory = spdk
 clone-recursive = true

--- a/toolbox/pkgs/alpine-latest.sh
+++ b/toolbox/pkgs/alpine-latest.sh
@@ -32,6 +32,8 @@ apk add \
  perl \
  pkgconf \
  py3-pip \
+ py3-jinja2 \
+ py3-tabulate \
  python3 \
  python3-dev \
  util-linux-dev

--- a/toolbox/pkgs/archlinux-latest.sh
+++ b/toolbox/pkgs/archlinux-latest.sh
@@ -28,7 +28,9 @@ pacman -S --noconfirm \
  pkg-config \
  python-pip \
  python-pipx \
+ python-jinja \
  python-pyelftools \
+ python-tabulate \
  python-setuptools \
  python3 \
  util-linux-libs

--- a/toolbox/pkgs/centos-stream10.sh
+++ b/toolbox/pkgs/centos-stream10.sh
@@ -40,7 +40,9 @@ dnf install -y \
  procps \
  python3-devel \
  python3-pip \
+ python3-jinja2 \
  python3-pyelftools \
+ python3-tabulate \
  unzip \
  wget \
  zlib-devel

--- a/toolbox/pkgs/centos-stream9.sh
+++ b/toolbox/pkgs/centos-stream9.sh
@@ -40,7 +40,9 @@ dnf install -y \
  procps \
  python3-devel \
  python3-pip \
+ python3-jinja2 \
  python3-pyelftools \
+ python3-tabulate \
  unzip \
  wget \
  zlib-devel

--- a/toolbox/pkgs/debian-bookworm.sh
+++ b/toolbox/pkgs/debian-bookworm.sh
@@ -41,7 +41,9 @@ apt-get -qy install \
  pkg-config \
  python3 \
  python3-pip \
+ python3-jinja2 \
  python3-pyelftools \
+ python3-tabulate \
  python3-venv \
  uuid-dev
 

--- a/toolbox/pkgs/debian-forky.sh
+++ b/toolbox/pkgs/debian-forky.sh
@@ -41,7 +41,9 @@ apt-get -qy install \
  pkg-config \
  python3 \
  python3-pip \
+ python3-jinja2 \
  python3-pyelftools \
+ python3-tabulate \
  python3-venv \
  uuid-dev
 

--- a/toolbox/pkgs/debian-trixie.sh
+++ b/toolbox/pkgs/debian-trixie.sh
@@ -42,7 +42,9 @@ apt-get -qy install \
  pkg-config \
  python3 \
  python3-pip \
+ python3-jinja2 \
  python3-pyelftools \
+ python3-tabulate \
  python3-venv \
  uuid-dev
 

--- a/toolbox/pkgs/fedora-42.sh
+++ b/toolbox/pkgs/fedora-42.sh
@@ -35,7 +35,9 @@ dnf install -y \
  procps \
  python3-devel \
  python3-pip \
+ python3-jinja2 \
  python3-pyelftools \
+ python3-tabulate \
  zlib-devel
 
 #

--- a/toolbox/pkgs/fedora-43.sh
+++ b/toolbox/pkgs/fedora-43.sh
@@ -35,7 +35,9 @@ dnf install -y \
  procps \
  python3-devel \
  python3-pip \
+ python3-jinja2 \
  python3-pyelftools \
+ python3-tabulate \
  zlib-devel
 
 #

--- a/toolbox/pkgs/freebsd-14.sh
+++ b/toolbox/pkgs/freebsd-14.sh
@@ -15,7 +15,9 @@ pkg install -qy \
  bash \
  cunit \
  devel/py-pipx \
+ devel/py-Jinja2 \
  devel/py-pyelftools \
+ devel/py-tabulate \
  findutils \
  git \
  gmake \

--- a/toolbox/pkgs/freebsd-15.sh
+++ b/toolbox/pkgs/freebsd-15.sh
@@ -15,7 +15,9 @@ pkg install -qy \
  bash \
  cunit \
  devel/py-pipx \
+ devel/py-Jinja2 \
  devel/py-pyelftools \
+ devel/py-tabulate \
  findutils \
  git \
  gmake \

--- a/toolbox/pkgs/gentoo-latest.sh
+++ b/toolbox/pkgs/gentoo-latest.sh
@@ -19,7 +19,9 @@ emerge \
  dev-libs/libaio \
  dev-libs/openssl \
  dev-python/pip \
+ dev-python/jinja \
  dev-python/pyelftools \
+ dev-python/tabulate \
  dev-util/cunit \
  dev-util/pkgconf \
  dev-vcs/git \

--- a/toolbox/pkgs/opensuse-tumbleweed-latest.sh
+++ b/toolbox/pkgs/opensuse-tumbleweed-latest.sh
@@ -36,7 +36,9 @@ zypper --non-interactive install -y --allow-downgrade \
  python3-devel \
  python3-pip \
  python3-pipx \
+ python3-Jinja2 \
  python3-pyelftools \
+ python3-tabulate \
  python3-setuptools \
  tar
 

--- a/toolbox/pkgs/oraclelinux-10.sh
+++ b/toolbox/pkgs/oraclelinux-10.sh
@@ -41,7 +41,9 @@ dnf install -y \
  procps \
  python3-devel \
  python3-pip \
+ python3-jinja2 \
  python3-pyelftools \
+ python3-tabulate \
  unzip \
  wget \
  zlib-devel

--- a/toolbox/pkgs/oraclelinux-9.sh
+++ b/toolbox/pkgs/oraclelinux-9.sh
@@ -41,7 +41,9 @@ dnf install -y \
  procps \
  python3-devel \
  python3-pip \
+ python3-jinja2 \
  python3-pyelftools \
+ python3-tabulate \
  unzip \
  wget \
  zlib-devel

--- a/toolbox/pkgs/rockylinux-10.1.sh
+++ b/toolbox/pkgs/rockylinux-10.1.sh
@@ -41,7 +41,9 @@ dnf install -y \
  procps \
  python3-devel \
  python3-pip \
+ python3-jinja2 \
  python3-pyelftools \
+ python3-tabulate \
  unzip \
  wget \
  zlib-devel

--- a/toolbox/pkgs/rockylinux-9.7.sh
+++ b/toolbox/pkgs/rockylinux-9.7.sh
@@ -41,7 +41,9 @@ dnf install -y \
  procps \
  python3-devel \
  python3-pip \
+ python3-jinja2 \
  python3-pyelftools \
+ python3-tabulate \
  unzip \
  wget \
  zlib-devel

--- a/toolbox/pkgs/ubuntu-jammy.sh
+++ b/toolbox/pkgs/ubuntu-jammy.sh
@@ -39,7 +39,9 @@ apt-get -qy install \
  pkg-config \
  python3 \
  python3-pip \
+ python3-jinja2 \
  python3-pyelftools \
+ python3-tabulate \
  python3-venv \
  uuid-dev
 

--- a/toolbox/pkgs/ubuntu-noble.sh
+++ b/toolbox/pkgs/ubuntu-noble.sh
@@ -41,7 +41,9 @@ apt-get -qy install \
  pkg-config \
  python3 \
  python3-pip \
+ python3-jinja2 \
  python3-pyelftools \
+ python3-tabulate \
  python3-venv \
  uuid-dev
 

--- a/toolbox/pkgs/ubuntu-questing.sh
+++ b/toolbox/pkgs/ubuntu-questing.sh
@@ -41,7 +41,9 @@ apt-get -qy install \
  pkg-config \
  python3 \
  python3-pip \
+ python3-jinja2 \
  python3-pyelftools \
+ python3-tabulate \
  python3-venv \
  uuid-dev
 


### PR DESCRIPTION
Bump [guest_image] sha to the freebsd-14-headless build cut from safl/nosi#15: firstboot_freebsd_update is disabled in rc.conf, so the consumer first boot no longer pulls thousands of patches before LOGIN (125s+ -> 38s locally).

Extend 'Collect guest serial console' to freebsd and template the serial.output path on ${os}-${ver}-amd64. No behavioural change for debian; freebsd failures now ship a serial console artifact.