### PR TITLE
feat(be): allow upcie and upcie-cuda to share an NVMe controller simultaneously

### DIFF
--- a/cijoe/tests/logic/test_xnvme_tests_dual_be.py
+++ b/cijoe/tests/logic/test_xnvme_tests_dual_be.py
@@ -1,0 +1,44 @@
+import pytest
+
+from ..conftest import xnvme_parametrize
+
+
+def get_alt_be(be: str):
+    if be == "upcie":
+        return "upcie-cuda"
+    elif be == "upcie-cuda":
+        return "upcie"
+    else:
+        return None
+
+
+@xnvme_parametrize(labels=["dev"], opts=["be"])
+def test_open_dev_twice(cijoe, device, be_opts, cli_args):
+    # We are repurposing "xnvme_tests_dual_be idfy-cmp" to verify that opening the same
+    # device twice with the same backend works.
+    err, _ = cijoe.run(
+        f"xnvme_tests_dual_be idfy-cmp {device['uri']} --be {be_opts['be']} --alt-be {be_opts['be']} --dev-nsid {device['nsid']}"
+    )
+    assert not err
+
+
+@xnvme_parametrize(labels=["dev", "cuda"], opts=["be"])
+def test_io_cmp(cijoe, device, be_opts, cli_args):
+    alt_be = get_alt_be(be_opts["be"])
+    if not alt_be:
+        pytest.skip(reason=f"[be={be_opts['be']}] does not have an alternate backend")
+    err, _ = cijoe.run(
+        f"xnvme_tests_dual_be io-cmp {device['uri']} --be {be_opts['be']} --alt-be {alt_be} --dev-nsid {device['nsid']}"
+    )
+    assert not err
+
+
+@xnvme_parametrize(labels=["dev", "cuda"], opts=["be"])
+def test_idfy_cmp(cijoe, device, be_opts, cli_args):
+    alt_be = get_alt_be(be_opts["be"])
+    if not alt_be:
+        pytest.skip(reason=f"[be={be_opts['be']}] does not have an alternate backend")
+    err, _ = cijoe.run(
+        f"xnvme_tests_dual_be idfy-cmp {device['uri']} --be {be_opts['be']} --alt-be {alt_be} --dev-nsid {device['nsid']}"
+    )
+    assert not err

--- a/docs/background/backends/upcie/index.md
+++ b/docs/background/backends/upcie/index.md
@@ -40,9 +40,8 @@ devices to uio_pci_generic or vfio-pci:
 xnvme-driver
 ```
 
-For the host-memory backend, bind devices to `uio_pci_generic` for the legacy
-path or `vfio-pci` for the IOMMU-backed path. The `upcie-cuda` backend still
-requires the non-VFIO path.
+**upcie** supports both `uio_pci_generic` (no-IOMMU path) and `vfio-pci`
+(IOMMU-backed path). **upcie-cuda** requires the non-VFIO path.
 
 ### Privileges
 
@@ -53,6 +52,32 @@ requires the non-VFIO path.
 2. Accessing VFIO device nodes and writing PCI config space via sysfs to
    enable Bus Master when needed.
 
+(sec-backends-upcie-dual)=
+
+## Dual-Backend Operation
+
+The same PCIe device can be opened simultaneously with both **upcie** and
+**upcie-cuda**. This lets one handle send I/O through host-memory buffers while
+another sends I/O through GPU device-memory buffers, both going to the same NVMe
+controller. Opening order does not matter; the controller is torn down only when
+the last handle across both backends is closed. Attempting to open the same URI
+with an unrelated backend while either uPCIe backend holds it returns `-EBUSY`.
+
+Before opening both handles, complete the system configuration for each backend:
+hugepages for {ref}`sec-backends-upcie-host` and the additional CUDA and kernel
+requirements for {ref}`sec-backends-upcie-cuda`.
+
+### Example
+
+```c
+struct xnvme_opts host_opts = xnvme_opts_default();
+struct xnvme_opts cuda_opts = xnvme_opts_default();
+host_opts.be = "upcie";
+cuda_opts.be = "upcie-cuda";
+
+struct xnvme_dev *host_dev = xnvme_dev_open("0000:03:00.0", &host_opts);
+struct xnvme_dev *cuda_dev = xnvme_dev_open("0000:03:00.0", &cuda_opts);
+```
 
 ```{toctree}
 :maxdepth: 1

--- a/include/libxnvme_cli.h
+++ b/include/libxnvme_cli.h
@@ -111,6 +111,7 @@ struct xnvme_cli_args {
 	uint32_t help;
 
 	const char *be;
+	const char *alt_be;
 	const char *mem;
 	const char *sync;
 	const char *async;
@@ -351,7 +352,9 @@ enum xnvme_cli_opt {
 
 	XNVME_CLI_OPT_IOVA_MODE = 129, ///< XNVME_CLI_OPT_IOVA_MODE
 
-	XNVME_CLI_OPT_END = 130, ///< XNVME_CLI_OPT_END
+	XNVME_CLI_OPT_ALT_BE = 130, ///< XNVME_CLI_OPT_ALT_BE
+
+	XNVME_CLI_OPT_END = 131, ///< XNVME_CLI_OPT_END
 };
 
 /**

--- a/lib/upcie/xnvme_be_upcie_cuda_dev.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_dev.c
@@ -72,20 +72,59 @@ _cuda_rte_init(void)
 	return 0;
 }
 
-int
-xnvme_be_upcie_cuda_ctrlr_term(void *handle)
+static int
+_check_driver(struct xnvme_dev *dev)
 {
-	xnvme_be_upcie_ctrlr_term(handle);
+	char driver_name[sizeof(dev->ident.kernel_driver)] = {0};
+	int err;
 
-	if (--g_cuda_ctrlr_count == 0) {
-		_cuda_rte_term();
+	err = xnvme_be_upcie_get_driver_name(dev->ident.uri, driver_name, sizeof(driver_name));
+	if (err) {
+		XNVME_DEBUG("FAILED: xnvme_be_upcie_get_driver_name(%s); err(%d)", dev->ident.uri,
+			    err);
+		return err;
+	}
+	snprintf(dev->ident.kernel_driver, sizeof(dev->ident.kernel_driver), "%s", driver_name);
+
+	if (strcmp(driver_name, "uio_pci_generic")) {
+		XNVME_DEBUG(
+			"FAILED: unsupported driver '%s', upcie-cuda requires 'uio_pci_generic'",
+			driver_name);
+		return -ENOTSUP;
 	}
 
 	return 0;
 }
 
 /**
- * Initialize a uPCIe CUDA controller.
+ * Initialize the NVMe controller for a uPCIe CUDA device.
+ *
+ * Validates that the device is bound to uio_pci_generic (vfio-pci is not
+ * supported for CUDA P2P DMA) and delegates to xnvme_be_upcie_ctrlr_init,
+ * which opens the NVMe controller and allocates the host hugepage runtime.
+ * CUDA runtime initialization is done in dev_open.
+ */
+void *
+xnvme_be_upcie_cuda_ctrlr_init(struct xnvme_dev *dev)
+{
+	int err;
+	err = _check_driver(dev);
+	if (err) {
+		errno = -err;
+		return NULL;
+	}
+
+	return xnvme_be_upcie_ctrlr_init(dev);
+}
+
+int
+xnvme_be_upcie_cuda_ctrlr_term(void *handle)
+{
+	return xnvme_be_upcie_ctrlr_term(handle);
+}
+
+/**
+ * Open a uPCIe CUDA device handle.
  *
  * Memory layout
  * -------------
@@ -103,59 +142,46 @@ xnvme_be_upcie_cuda_ctrlr_term(void *handle)
  * Consequently, both the host hugepage runtime (256 MiB) and the CUDA heap
  * (1 GiB) are initialized when the first upcie-cuda device is opened.
  */
-void *
-xnvme_be_upcie_cuda_ctrlr_init(struct xnvme_dev *dev)
+static int
+xnvme_be_upcie_cuda_dev_open(struct xnvme_dev *dev)
 {
-	struct xnvme_be_upcie_ctrlr *ctrlr;
-	char driver_name[sizeof(dev->ident.kernel_driver)] = {0};
 	int err;
 
-	err = xnvme_be_upcie_get_driver_name(dev->ident.uri, driver_name, sizeof(driver_name));
+	err = _check_driver(dev);
 	if (err) {
-		XNVME_DEBUG("FAILED: xnvme_be_upcie_get_driver_name(%s); err(%d)", dev->ident.uri,
-			    err);
-		errno = -err;
-		return NULL;
+		return err;
 	}
-	snprintf(dev->ident.kernel_driver, sizeof(dev->ident.kernel_driver), "%s", driver_name);
 
-	if (!strcmp(driver_name, "vfio-pci")) {
-		XNVME_DEBUG("FAILED: upcie-cuda does not support vfio-pci");
-		errno = ENOTSUP;
-		return NULL;
-	} else if (strcmp(driver_name, "uio_pci_generic")) {
-		XNVME_DEBUG("FAILED: unsupported driver '%s'", driver_name);
-		errno = ENOTSUP;
-		return NULL;
+	err = xnvme_be_upcie_dev_open(dev);
+	if (err) {
+		return err;
 	}
 
 	err = _cuda_rte_init();
 	if (err) {
 		XNVME_DEBUG("FAILED: _cuda_rte_init(); err(%d)", err);
-		errno = -err;
-		return NULL;
+		return err;
 	}
 
-	ctrlr = xnvme_be_upcie_ctrlr_init(dev);
-	if (!ctrlr) {
-		XNVME_DEBUG("FAILED: xnvme_be_upcie_ctrlr_init(); err(%d)", errno);
-		if (g_cuda_ctrlr_count == 0) {
-			_cuda_rte_term();
-		}
-		return NULL;
+	atomic_fetch_add(&g_cuda_ctrlr_count, 1);
+	return 0;
+}
+
+static void
+xnvme_be_upcie_cuda_dev_close(struct xnvme_dev *dev)
+{
+	if (atomic_fetch_sub(&g_cuda_ctrlr_count, 1) == 1) {
+		_cuda_rte_term();
 	}
-
-	g_cuda_ctrlr_count++;
-
-	return ctrlr;
+	xnvme_be_upcie_dev_close(dev);
 }
 
 #endif
 
 struct xnvme_be_dev g_xnvme_be_upcie_cuda_dev = {
 #ifdef XNVME_BE_UPCIE_CUDA_ENABLED
-	.dev_open = xnvme_be_upcie_dev_open,
-	.dev_close = xnvme_be_upcie_dev_close,
+	.dev_open = xnvme_be_upcie_cuda_dev_open,
+	.dev_close = xnvme_be_upcie_cuda_dev_close,
 	.id = "upcie-cuda",
 	.ctrlr_init = xnvme_be_upcie_cuda_ctrlr_init,
 	.ctrlr_term = xnvme_be_upcie_cuda_ctrlr_term,

--- a/lib/xnvme_cli.c
+++ b/lib/xnvme_cli.c
@@ -895,6 +895,12 @@ static struct xnvme_cli_opt_attr xnvme_cli_opts[] = {
 		.descr = "Number of queues per device",
 	},
 	{
+		.opt = XNVME_CLI_OPT_ALT_BE,
+		.vtype = XNVME_CLI_OPT_VTYPE_STR,
+		.name = "alt-be",
+		.descr = "Alternate xNVMe backend for dual-backend operations",
+	},
+	{
 		.opt = XNVME_CLI_OPT_END,
 		.vtype = XNVME_CLI_OPT_VTYPE_NUM,
 		.name = "",
@@ -1411,6 +1417,9 @@ xnvme_cli_assign_arg(struct xnvme_cli *cli, struct xnvme_cli_opt_attr *opt_attr,
 
 	case XNVME_CLI_OPT_BE:
 		args->be = arg ? arg : "INVALID_INPUT";
+		break;
+	case XNVME_CLI_OPT_ALT_BE:
+		args->alt_be = arg ? arg : "INVALID_INPUT";
 		break;
 	case XNVME_CLI_OPT_MEM:
 		args->mem = arg ? arg : "INVALID_INPUT";

--- a/lib/xnvme_platform.c
+++ b/lib/xnvme_platform.c
@@ -87,7 +87,11 @@ _dev_open_init_cref(struct xnvme_dev *dev, struct xnvme_be *be, const struct xnv
 
 	cref = xnvme_be_cref_get(dev->ident.uri);
 	if (cref) {
-		if (strcmp(cref->be_name, cfg->attr.name)) {
+		// Controller state is keyed by backend name, except that upcie variants
+		// share controller state and accept each other's crefs despite the
+		// inexact name match.
+		if (strcmp(cref->be_name, cfg->attr.name) != 0 &&
+		    !(strstr(cref->be_name, "upcie") && strstr(cfg->attr.name, "upcie"))) {
 			xnvme_be_cref_put(cref->ctrlr);
 			XNVME_DEBUG("FAILED: uri '%s' claimed by another backend config",
 				    dev->ident.uri);

--- a/tests/dual_be.c
+++ b/tests/dual_be.c
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <errno.h>
+#include <stdlib.h>
+
+#include <libxnvme.h>
+
+static int
+open_alt(struct xnvme_cli *cli, struct xnvme_dev **alt_dev)
+{
+	struct xnvme_opts opts = xnvme_opts_default();
+	const char *uri = cli->args.uri;
+	int err;
+
+	opts.be = cli->args.alt_be;
+	opts.nsid = cli->args.dev_nsid;
+
+	*alt_dev = xnvme_dev_open(uri, &opts);
+	if (!(*alt_dev)) {
+		err = -errno;
+		xnvme_cli_perr("xnvme_dev_open(alt_dev)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static int
+sub_io_cmp(struct xnvme_cli *cli)
+{
+	struct xnvme_dev *alt_dev, *dev = cli->args.dev;
+	const struct xnvme_geo *geo;
+	struct xnvme_cmd_ctx ctx;
+	void *write_buf = NULL, *read_buf = NULL;
+	uint32_t iosize, nsid;
+	uint16_t nlb;
+	size_t diff = 0;
+	int err;
+
+	nsid = cli->args.dev_nsid;
+
+	err = open_alt(cli, &alt_dev);
+	if (err) {
+		return err;
+	}
+
+	geo = xnvme_dev_get_geo(dev);
+	if (!geo->lba_nbytes) {
+		err = -EINVAL;
+		xnvme_cli_perr("Error: LBA size == 0", err);
+		goto exit;
+	}
+
+	iosize = geo->lba_nbytes;
+	nlb = 0;
+
+	write_buf = xnvme_buf_alloc(dev, iosize);
+	if (!write_buf) {
+		err = -errno;
+		xnvme_cli_perr("xnvme_buf_alloc(write)", err);
+		goto exit;
+	}
+
+	err = xnvme_buf_fill(write_buf, iosize, "anum");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill(write)", err);
+		goto exit;
+	}
+
+	ctx = xnvme_cmd_ctx_from_dev(dev);
+	err = xnvme_nvm_write(&ctx, nsid, 0, nlb, write_buf, NULL);
+	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		xnvme_cli_perr("xnvme_nvm_write()", err);
+		xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
+		err = err ? err : -EIO;
+		goto exit;
+	}
+
+	read_buf = xnvme_buf_alloc(alt_dev, iosize);
+	if (!read_buf) {
+		err = -errno;
+		xnvme_cli_perr("xnvme_buf_alloc(read)", err);
+		goto exit;
+	}
+
+	err = xnvme_buf_fill(read_buf, iosize, "zero");
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_fill(read)", err);
+		goto exit;
+	}
+
+	ctx = xnvme_cmd_ctx_from_dev(alt_dev);
+	err = xnvme_nvm_read(&ctx, nsid, 0, nlb, read_buf, NULL);
+	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		xnvme_cli_perr("xnvme_nvm_read()", err);
+		xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
+		err = err ? err : -EIO;
+		goto exit;
+	}
+
+	err = xnvme_buf_diff(write_buf, read_buf, iosize, &diff);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_diff()", err);
+		goto exit;
+	}
+
+	if (diff) {
+		fprintf(stderr, "FAIL: %zu/%u bytes differ\n", diff, iosize);
+		err = -EIO;
+	} else {
+		printf("PASS: %u bytes match\n", iosize);
+	}
+
+exit:
+	xnvme_buf_free(dev, write_buf);
+	xnvme_buf_free(alt_dev, read_buf);
+	xnvme_dev_close(alt_dev);
+
+	return err;
+}
+
+static int
+sub_idfy_cmp(struct xnvme_cli *cli)
+{
+	struct xnvme_dev *alt_dev, *dev = cli->args.dev;
+	struct xnvme_cmd_ctx ctx;
+	struct xnvme_spec_idfy *idfy = NULL, *alt_idfy = NULL;
+	size_t diff = 0;
+	int err;
+
+	err = open_alt(cli, &alt_dev);
+	if (err) {
+		return err;
+	}
+
+	idfy = xnvme_buf_alloc(dev, sizeof(*idfy));
+	if (!idfy) {
+		err = -errno;
+		xnvme_cli_perr("xnvme_buf_alloc(idfy)", err);
+		goto exit;
+	}
+	xnvme_buf_clear(idfy, sizeof(*idfy));
+
+	alt_idfy = xnvme_buf_alloc(alt_dev, sizeof(*alt_idfy));
+	if (!alt_idfy) {
+		err = -errno;
+		xnvme_cli_perr("xnvme_buf_alloc(alt_idfy)", err);
+		goto exit;
+	}
+	xnvme_buf_clear(alt_idfy, sizeof(*alt_idfy));
+
+	ctx = xnvme_cmd_ctx_from_dev(dev);
+	err = xnvme_adm_idfy_ctrlr(&ctx, idfy);
+	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		xnvme_cli_perr("xnvme_adm_idfy_ctrlr(--be)", err);
+		xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
+		err = err ? err : -EIO;
+		goto exit;
+	}
+
+	ctx = xnvme_cmd_ctx_from_dev(alt_dev);
+	err = xnvme_adm_idfy_ctrlr(&ctx, alt_idfy);
+	if (err || xnvme_cmd_ctx_cpl_status(&ctx)) {
+		xnvme_cli_perr("xnvme_adm_idfy_ctrlr(--alt-be)", err);
+		xnvme_cmd_ctx_pr(&ctx, XNVME_PR_DEF);
+		err = err ? err : -EIO;
+		goto exit;
+	}
+
+	err = xnvme_buf_diff(idfy, alt_idfy, sizeof(*idfy), &diff);
+	if (err) {
+		xnvme_cli_perr("xnvme_buf_diff()", err);
+		goto exit;
+	}
+
+	if (diff) {
+		fprintf(stderr, "FAIL: Identify responses differ by %zu bytes\n", diff);
+		err = -EIO;
+	} else {
+		printf("PASS: Identify Controller responses match (%zu bytes)\n", sizeof(*idfy));
+	}
+
+exit:
+	xnvme_buf_free(dev, idfy);
+	xnvme_buf_free(alt_dev, alt_idfy);
+	xnvme_dev_close(alt_dev);
+
+	return err;
+}
+
+static struct xnvme_cli_sub g_subs[] = {
+	{
+		"io-cmp",
+		"Write via --be, read back via --alt-be, compare",
+		"Write a known pattern to LBA 0 through the --be backend, read it back\n"
+		"through the --alt-be backend, and verify the data matches.\n"
+		"Both backends share the same NVMe controller on the same device URI.\n"
+		"NOTE: overwrites LBA 0; only use on a device where that is safe.",
+		sub_io_cmp,
+		{
+			{XNVME_CLI_OPT_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_URI, XNVME_CLI_POSA},
+			{XNVME_CLI_OPT_NON_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_BE, XNVME_CLI_LREQ},
+			{XNVME_CLI_OPT_ALT_BE, XNVME_CLI_LREQ},
+			{XNVME_CLI_OPT_DEV_NSID, XNVME_CLI_LREQ},
+		},
+	},
+	{
+		"idfy-cmp",
+		"Send Identify Controller via --be and --alt-be, compare responses",
+		"Issue an Identify Controller command through each of the two backends\n"
+		"sharing the same NVMe controller, then byte-compare the responses.\n"
+		"A mismatch indicates dual-backend operation returned inconsistent data.",
+		sub_idfy_cmp,
+		{
+			{XNVME_CLI_OPT_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_URI, XNVME_CLI_POSA},
+			{XNVME_CLI_OPT_NON_POSA_TITLE, XNVME_CLI_SKIP},
+			{XNVME_CLI_OPT_BE, XNVME_CLI_LREQ},
+			{XNVME_CLI_OPT_ALT_BE, XNVME_CLI_LREQ},
+			{XNVME_CLI_OPT_DEV_NSID, XNVME_CLI_LREQ},
+		},
+	},
+};
+
+static struct xnvme_cli g_cli = {
+	.title = "dual-be - Dual-backend operation tests",
+	.descr_short = "Test that two backends can share the same NVMe controller",
+	.descr_long = "",
+	.subs = g_subs,
+	.nsubs = sizeof g_subs / sizeof(*g_subs),
+};
+
+int
+main(int argc, char **argv)
+{
+	return xnvme_cli_run(&g_cli, argc, argv, XNVME_CLI_INIT_DEV_OPEN);
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -32,6 +32,7 @@ tests = {
   'delay_identification.c': [
     ['open', ['open', '1GB']]
   ],
+  'dual_be.c': [],
   'enum.c': [
     ['open', ['open', '--count', '4']],
     ['multi', ['multi', '--count', '4']],


### PR DESCRIPTION
This is #665 once more, since it was accidentally merged without running the maas tests.

-----

This series allows the `upcie` backend variants (`upcie` and `upcie-cuda`) to
share the same NVMe controller at the same time, enabling dual-backend use
cases such as opening a single device with both `upcie` and `upcie-cuda`
concurrently.

### Mechanism

Controller state in the `cref` table is keyed by backend name, so a second
backend config opening an already-open URI is normally rejected with `-EBUSY`.
This is relaxed for the `upcie` variants: because they share the same
underlying NVMe controller infrastructure, they accept each other's crefs
despite the inexact name match.

### Changes

- **`feat(be)`** — Relax the cref name-match check so `upcie` and `upcie-cuda`
  reuse the same controller for a given URI instead of conflicting.
- **`feat(upcie)`** — Move the CUDA runtime lifecycle (`_cuda_rte_init` /
  `_cuda_rte_term`) out of `ctrlr_init` / `ctrlr_term` and into `dev_open` /
  `dev_close`, so CUDA is initialised for every `upcie-cuda` handle regardless
  of which backend performed the primary controller open. The driver check
  (`uio_pci_generic` required, `vfio-pci` rejected) is kept in both
  `ctrlr_init` (primary path) and `dev_open` (secondary path, where
  `ctrlr_init` is skipped).
- **`feat(cli)`** — Add `XNVME_CLI_OPT_ALT_BE` / `--alt-be` (a second backend
  name independent of `--be`). This is purely a CLI/test concern, used so tests
  can open the same device with two different backends; there is no
  primary/secondary hierarchy and the order is irrelevant.
- **`test(dual-be)`** — New `dual-be` test tool with two subcommands:
  - `io-cmp`: write a known pattern via `--be`, read it back via `--alt-be`,
    and compare.
  - `idfy-cmp`: issue Identify Controller via both backends and byte-compare
    the responses.
- **`test(cijoe)`** — pytest-based integration tests:
  - `test_open_dev_twice`: opens the same device twice with identical backends
    to verify same-name cref reuse.
  - `test_io_cmp` / `test_idfy_cmp`: exercise the dual-backend path for
    `upcie` / `upcie-cuda` pairs (skipped for backends without an alternate).
- **`docs(upcie)`** — Document dual-backend operation for `upcie` and
  `upcie-cuda`.

### User-facing impact

Minimal and intentionally so. Today the only supported combination is mixing
`upcie` and `upcie-cuda`. Just as a device URI like `0000:01:00.0` can already
be opened multiple times with the same backend, it can now also be opened with
these two different backends at once. No new concepts are exposed to ordinary
users.