### PR TITLE
fix(be/spdk): use shm_id as trigger for multi-process mode

### DIFF
--- a/include/libxnvme_opts.h
+++ b/include/libxnvme_opts.h
@@ -40,8 +40,8 @@ struct xnvme_opts {
 	struct xnvme_opts_css css; ///< SPDK controller-setup: do command-set-selection
 	uint32_t use_cmb_sqs;      ///< SPDK controller-setup: use controller-memory-buffer for sq
 	uint32_t shm_id;           ///< SPDK multi-processing: shared-memory-id
-	uint32_t main_core;        ///< SPDK multi-processing: main-core
-	const char *core_mask;     ///< SPDK multi-processing: core-mask
+	uint32_t main_core;        ///< SPDK: main-core
+	const char *core_mask;     ///< SPDK: core-mask
 	const char *iova_mode;     ///< SPDK env-init: DPDK IOVA mode ("va" or "pa")
 	const char *adrfam;        ///< SPDK fabrics: address-family, IPv4/IPv6
 	const char *subnqn;        ///< SPDK fabrics: Subsystem NQN

--- a/lib/xnvme_be_spdk_dev.c
+++ b/lib/xnvme_be_spdk_dev.c
@@ -506,12 +506,23 @@ xnvme_be_spdk_ctrlr_init(struct xnvme_dev *dev)
 	int err;
 
 	xnvme_spdk_env_opts_init(&env_opts);
-	if (dev->opts.core_mask) {
+
+	// SPDK default for shm_id is -1, so don't overwrite unless given
+	if (dev->opts.shm_id) {
 		XNVME_DEBUG("INFO: multi-process setup");
 		env_opts.shm_id = dev->opts.shm_id;
+	}
+
+	// SPDK default for core_mask is 0x1, so don't overwrite unless given
+	if (dev->opts.core_mask) {
 		env_opts.core_mask = dev->opts.core_mask;
+	}
+
+	// SPDK default for main_core is -1, so don't overwrite unless given
+	if (dev->opts.main_core) {
 		env_opts.main_core = dev->opts.main_core;
 	}
+
 	/* DPDK's IOVA-mode auto-detection cannot see through nested vfio-pci */
 	/* pass-through to the inner guest's DMA mask; setups that hit "IOVA */
 	/* exceeding limits of current DMA mask" need iova_mode='pa'. Honour */


### PR DESCRIPTION
In SPDK, the shm_id option is the signal for using multi-process mode, and therefore it should be the same in our code. Before, we were using core_mask which was misleading, as this option is a signal of which CPU cores to use - not necessarily that the user wants multi-process mode.

Also, move the core_mask and main_core out of the if-statement, as these options are not necessarily tied to multi-process mode and can be given without the user needing multi-process mode. The doc-strings have been updated accordingly.