### PR TITLE
feat(upcie): configurable heap sizes with workload-aware sizing in xnvmeperf

### DIFF
--- a/include/libxnvme_opts.h
+++ b/include/libxnvme_opts.h
@@ -50,7 +50,7 @@ struct xnvme_opts {
 	uint32_t command_timeout;  ///< SPDK fabrics: enable io command timeout
 	uint32_t spdk_fabrics;     ///< Is assigned a value by backend if SPDK uses fabrics
 	uint32_t keep_alive_timeout_ms; ///< SPDK fabrics: set keep alive timeout
-	size_t host_heap_size;   ///< upcie: host DMA heap size in bytes (0 = default 256 MiB)
+	size_t host_heap_size;          ///< upcie: host DMA heap size in bytes (0 = default 1 GiB)
 	size_t device_heap_size; ///< upcie-cuda: GPU device heap size in bytes (0 = default 1 GiB)
 };
 

--- a/include/libxnvme_opts.h
+++ b/include/libxnvme_opts.h
@@ -50,6 +50,8 @@ struct xnvme_opts {
 	uint32_t command_timeout;  ///< SPDK fabrics: enable io command timeout
 	uint32_t spdk_fabrics;     ///< Is assigned a value by backend if SPDK uses fabrics
 	uint32_t keep_alive_timeout_ms; ///< SPDK fabrics: set keep alive timeout
+	size_t host_heap_size;   ///< upcie: host DMA heap size in bytes (0 = default 256 MiB)
+	size_t device_heap_size; ///< upcie-cuda: GPU device heap size in bytes (0 = default 1 GiB)
 };
 
 /**

--- a/lib/upcie/xnvme_be_upcie.h
+++ b/lib/upcie/xnvme_be_upcie.h
@@ -12,6 +12,12 @@
 #define _UPCIE_WITH_NVME
 #include <upcie/upcie.h>
 
+/**
+ * Default heap size used for the host DMA heap (upcie) and the GPU device heap
+ * (upcie-cuda) when xnvme_opts leaves the size unset (0)
+ */
+#define XNVME_BE_UPCIE_DEFAULT_HEAP_SIZE (1024ULL * 1024 * 1024)
+
 struct xnvme_queue_upcie {
 	struct xnvme_queue_base base;
 	struct nvme_qpair qpair;

--- a/lib/upcie/xnvme_be_upcie_cuda_dev.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_dev.c
@@ -36,7 +36,7 @@ _cuda_rte_init(size_t heap_size)
 	}
 
 	if (!heap_size) {
-		heap_size = 1024 * 1024 * 1024;
+		heap_size = XNVME_BE_UPCIE_DEFAULT_HEAP_SIZE;
 	}
 
 	err = cuInit(0);

--- a/lib/upcie/xnvme_be_upcie_cuda_dev.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_dev.c
@@ -26,13 +26,17 @@ _cuda_rte_term(void)
 }
 
 static int
-_cuda_rte_init(void)
+_cuda_rte_init(size_t heap_size)
 {
 	CUdevice cu_dev;
 	int err;
 
 	if (g_upcie_cuda_rte.is_initialized) {
 		return 0;
+	}
+
+	if (!heap_size) {
+		heap_size = 1024 * 1024 * 1024;
 	}
 
 	err = cuInit(0);
@@ -59,7 +63,12 @@ _cuda_rte_init(void)
 		return err;
 	}
 
-	err = cudamem_heap_init(&g_upcie_cuda_rte.cuda_heap, 1024 * 1024 * 1024,
+	// align to the dma-buf page granularity used by the cudamem heap
+	heap_size = ((heap_size + g_upcie_cuda_rte.cuda_config.device_pagesize - 1) /
+		     g_upcie_cuda_rte.cuda_config.device_pagesize) *
+		    g_upcie_cuda_rte.cuda_config.device_pagesize;
+
+	err = cudamem_heap_init(&g_upcie_cuda_rte.cuda_heap, heap_size,
 				&g_upcie_cuda_rte.cuda_config);
 	if (err) {
 		XNVME_DEBUG("FAILED: cudamem_heap_init(); err(%d)", err);
@@ -157,7 +166,7 @@ xnvme_be_upcie_cuda_dev_open(struct xnvme_dev *dev)
 		return err;
 	}
 
-	err = _cuda_rte_init();
+	err = _cuda_rte_init(dev->opts.device_heap_size);
 	if (err) {
 		XNVME_DEBUG("FAILED: _cuda_rte_init(); err(%d)", err);
 		return err;

--- a/lib/upcie/xnvme_be_upcie_dev.c
+++ b/lib/upcie/xnvme_be_upcie_dev.c
@@ -72,7 +72,7 @@ _rte_init(size_t heap_size)
 	}
 
 	if (!heap_size) {
-		heap_size = 256 * 1024 * 1024;
+		heap_size = XNVME_BE_UPCIE_DEFAULT_HEAP_SIZE;
 	}
 
 	err = hostmem_config_init(&g_upcie_rte.config);

--- a/lib/upcie/xnvme_be_upcie_dev.c
+++ b/lib/upcie/xnvme_be_upcie_dev.c
@@ -63,12 +63,16 @@ _rte_term(void)
  * already initialized, then it exits early.
  */
 static int
-_rte_init(void)
+_rte_init(size_t heap_size)
 {
 	int err;
 
 	if (g_upcie_rte.is_initialized) {
 		return 0;
+	}
+
+	if (!heap_size) {
+		heap_size = 256 * 1024 * 1024;
 	}
 
 	err = hostmem_config_init(&g_upcie_rte.config);
@@ -77,7 +81,11 @@ _rte_init(void)
 		return err;
 	}
 
-	err = hostmem_heap_init(&g_upcie_rte.heap, 256 * 1024 * 1024, &g_upcie_rte.config);
+	// hostmem_heap_init() requires a size that is a whole number of hugepages
+	heap_size = ((heap_size + g_upcie_rte.config.hugepgsz - 1) / g_upcie_rte.config.hugepgsz) *
+		    g_upcie_rte.config.hugepgsz;
+
+	err = hostmem_heap_init(&g_upcie_rte.heap, heap_size, &g_upcie_rte.config);
 	if (err) {
 		XNVME_DEBUG("FAILED: hostmem_heap_init(); err(%d)", err);
 		return err;
@@ -153,7 +161,7 @@ xnvme_be_upcie_ctrlr_init(struct xnvme_dev *dev)
 	char driver_name[sizeof(dev->ident.kernel_driver)] = {0};
 	int err;
 
-	err = _rte_init();
+	err = _rte_init(dev->opts.host_heap_size);
 	if (err) {
 		XNVME_DEBUG("FAILED: _rte_init()");
 		errno = -err;

--- a/lib/xnvme_opts.c
+++ b/lib/xnvme_opts.c
@@ -86,6 +86,10 @@ xnvme_opts_yaml(FILE *stream, const struct xnvme_opts *opts, int indent, const c
 	wrtn += fprintf(stream, "%*sspdk_fabrics: 0x%" PRIx32 "%s", indent, "", opts->spdk_fabrics,
 			sep);
 
+	wrtn += fprintf(stream, "%*shost_heap_size: %zu%s", indent, "", opts->host_heap_size, sep);
+	wrtn += fprintf(stream, "%*sdevice_heap_size: %zu%s", indent, "", opts->device_heap_size,
+			sep);
+
 	return wrtn;
 }
 

--- a/tools/xnvmeperf/xnvmeperf.c
+++ b/tools/xnvmeperf/xnvmeperf.c
@@ -10,6 +10,13 @@
 
 #include "xnvmeperf.h"
 
+/**
+ * Generous per-queue allowance for uPCIe control structures (PRP pools, SQ/CQ
+ * rings, and a share of the admin/sync qpairs). Sized to comfortably overshoot
+ * the real per-queue overhead so the heap math stays simple.
+ */
+#define XNVMEPERF_HEAP_QUEUE_OVERHEAD (16UL << 20)
+
 struct xnvmeperf_job {
 	struct xnvme_dev *dev;
 	struct xnvme_queue *queue;
@@ -1236,6 +1243,32 @@ parse_run_args(struct xnvme_cli *cli, struct xnvmeperf_args *args)
 	return err;
 }
 
+/**
+ * Derive uPCIe host/device heap sizes from the workload and write them into
+ * args->opts. Deliberately overshoots to keep the estimate simple: every queue
+ * gets a fixed control-structure slab, and data buffers land on the host heap
+ * for the host backends or on the device heap for the CUDA backend (qdepth
+ * buffers per queue vs one reused host buffer).
+ */
+static void
+derive_heap_sizes(struct xnvmeperf_args *args)
+{
+	int is_cuda = args->opts.be && strstr(args->opts.be, "cuda");
+	size_t nq = args->nqueues ? args->nqueues : 1;
+	size_t qd = args->qdepth ? args->qdepth : 1;
+	size_t queues = (size_t)args->ndevs * nq;
+	size_t control = queues * XNVMEPERF_HEAP_QUEUE_OVERHEAD;
+	size_t iosize = args->iosize;
+
+	args->opts.host_heap_size = control + (is_cuda ? 0 : queues * iosize);
+	printf("- host_heap_size: %zu bytes\n", args->opts.host_heap_size);
+
+	if (is_cuda) {
+		args->opts.device_heap_size = control + queues * qd * iosize;
+		printf("- device_heap_size: %zu bytes\n", args->opts.device_heap_size);
+	}
+}
+
 static int
 sub_run(struct xnvme_cli *cli)
 {
@@ -1254,6 +1287,7 @@ sub_run(struct xnvme_cli *cli)
 	}
 
 	print_run_args(&args, cli->args.iopattern);
+	derive_heap_sizes(&args);
 
 	err = xnvmeperf_run(&args);
 	free(args.cpus);
@@ -1281,6 +1315,8 @@ sub_verify(struct xnvme_cli *cli)
 	args.qdepth = 1;
 	args.pattern = IOPATTERN_VERIFY;
 
+	derive_heap_sizes(&args);
+
 	return xnvmeperf_verify(&args);
 }
 
@@ -1305,6 +1341,7 @@ sub_cuda_run(struct xnvme_cli *cli)
 	}
 
 	print_run_args(&args, cli->args.iopattern);
+	derive_heap_sizes(&args);
 
 	return xnvmeperf_cuda_run(&args);
 }
@@ -1337,6 +1374,8 @@ sub_cuda_verify(struct xnvme_cli *cli)
 	}
 
 	args.nqueues = cli->args.nqueues ? cli->args.nqueues : 1;
+
+	derive_heap_sizes(&args);
 
 	return xnvmeperf_cuda_verify(&args);
 }


### PR DESCRIPTION
Closes #642

------

 Make the uPCIe host/device heap sizes configurable, raise the host default,
  and have xnvmeperf size the heaps to its workload so large runs no longer
  run out of memory.

  ## Changes

  1. **Configurable heap sizes** (`feat(upcie): add host_heap_size and
     device_heap_size opts`). Adds `host_heap_size` (upcie host DMA heap) and
     `device_heap_size` (upcie-cuda GPU heap) to `struct xnvme_opts`, letting
     callers override the heap sizes. Both keep their existing behavior when left
     unset (`0`). The values are surfaced in `xnvme_opts_yaml()` for debugging.
     For upcie-cuda opened after upcie in the same process, host_heap_size has no 
     effect since the call to open upcie already initialized the host heap.

  2. **Raise the default host heap 256 MiB → 1 GiB** (`fix(upcie): increase
     default host heap from 256 MiB to 1 GiB`). The host heap backs both NVMe
     control structures and user IO buffers: each controller alone consumes
     ~8 MiB (admin and sync qpairs each carry a 4 MiB PRP pool plus two 64 KiB
     SQ/CQ buffers), and `xnvme_buf_alloc` draws from the same heap, so multiple
     devices with large buffers exhaust 256 MiB quickly. Introduces
     `XNVME_BE_UPCIE_DEFAULT_HEAP_SIZE` as the shared default for the host and
     device heaps.

  3. **Workload-aware sizing in xnvmeperf** (`feat(xnvmeperf): size uPCIe heaps
     to the workload`). Running many devices, many queues, or deep queues
     exhausts even the 1 GiB default. xnvmeperf now derives `host_heap_size` /
     `device_heap_size` from `ndevs`, `nqueues`, `qdepth`, and `iosize` before
     opening the devices. Each queue gets a generous fixed control slab; data
     buffers are sized onto the host heap (host backends) or the device heap
     (CUDA backend, scaled by qdepth). The estimate deliberately overshoots to
     keep the math simple.

  ## Notes

  - The new opts are programmatic-only (set via `struct xnvme_opts`); no CLI flag
    is added, since xnvmeperf derives the sizes itself.