### PR TITLE
fix(cref): use strcmp for URI comparison in cref lookup

### DIFF
--- a/lib/xnvme_be_cref.c
+++ b/lib/xnvme_be_cref.c
@@ -15,7 +15,7 @@ xnvme_be_cref_get(const char *uri)
 		if (!g_cref_table[i].ctrlr) {
 			continue;
 		}
-		if (strncmp(g_cref_table[i].uri, uri, XNVME_IDENT_URI_LEN)) {
+		if (strcmp(g_cref_table[i].uri, uri)) {
 			continue;
 		}
 		if (g_cref_table[i].refcount < 1) {


### PR DESCRIPTION
strncmp(..., XNVME_IDENT_URI_LEN) can treat two distinct URIs as equal when they share a common prefix of that length. URIs are null-terminated strings stored in fixed-size buffers, so strcmp is both simpler and semantically correct.

This is the last piece required for closing #624.