### PR TITLE
feat: add gpu_id option to select the GPU for upcie-cuda/upcie-hip

### DIFF
--- a/include/libxnvme_cli.h
+++ b/include/libxnvme_cli.h
@@ -122,6 +122,8 @@ struct xnvme_cli_args {
 	const char *core_mask;
 	const char *iova_mode;
 
+	uint32_t gpu_id; ///< upcie-cuda/upcie-hip: GPU ordinal to use
+
 	struct xnvme_opts_css css; ///< SPDK controller-setup: do command-set-selection
 
 	uint32_t use_cmb_sqs;
@@ -354,7 +356,9 @@ enum xnvme_cli_opt {
 
 	XNVME_CLI_OPT_ALT_BE = 130, ///< XNVME_CLI_OPT_ALT_BE
 
-	XNVME_CLI_OPT_END = 131, ///< XNVME_CLI_OPT_END
+	XNVME_CLI_OPT_GPU_ID = 131, ///< XNVME_CLI_OPT_GPU_ID
+
+	XNVME_CLI_OPT_END = 132, ///< XNVME_CLI_OPT_END
 };
 
 /**

--- a/include/libxnvme_opts.h
+++ b/include/libxnvme_opts.h
@@ -51,7 +51,8 @@ struct xnvme_opts {
 	uint32_t spdk_fabrics;     ///< Is assigned a value by backend if SPDK uses fabrics
 	uint32_t keep_alive_timeout_ms; ///< SPDK fabrics: set keep alive timeout
 	size_t host_heap_size;          ///< upcie: host DMA heap size in bytes (0 = default 1 GiB)
-	size_t device_heap_size; ///< upcie-cuda: GPU device heap size in bytes (0 = default 1 GiB)
+	size_t device_heap_size; ///< upcie-cuda/upcie-hip: GPU device heap size in bytes (0 =
+				 ///< default 1 GiB)
 };
 
 /**

--- a/include/libxnvme_opts.h
+++ b/include/libxnvme_opts.h
@@ -53,6 +53,7 @@ struct xnvme_opts {
 	size_t host_heap_size;          ///< upcie: host DMA heap size in bytes (0 = default 1 GiB)
 	size_t device_heap_size; ///< upcie-cuda/upcie-hip: GPU device heap size in bytes (0 =
 				 ///< default 1 GiB)
+	uint32_t gpu_id;         ///< upcie-cuda/upcie-hip: GPU ordinal to use (default 0)
 };
 
 /**

--- a/lib/upcie/xnvme_be_upcie_cuda_dev.c
+++ b/lib/upcie/xnvme_be_upcie_cuda_dev.c
@@ -26,7 +26,7 @@ _cuda_rte_term(void)
 }
 
 static int
-_cuda_rte_init(size_t heap_size)
+_cuda_rte_init(size_t heap_size, uint32_t gpu_id)
 {
 	CUdevice cu_dev;
 	int err;
@@ -45,7 +45,7 @@ _cuda_rte_init(size_t heap_size)
 		return -ENODEV;
 	}
 
-	err = cuDeviceGet(&cu_dev, 0); // GPU ID 0
+	err = cuDeviceGet(&cu_dev, gpu_id);
 	if (err) {
 		XNVME_DEBUG("FAILED: cuDeviceGet(); err(%d)", err);
 		return -ENODEV;
@@ -172,7 +172,7 @@ xnvme_be_upcie_cuda_dev_open(struct xnvme_dev *dev)
 		return err;
 	}
 
-	err = _cuda_rte_init(dev->opts.device_heap_size);
+	err = _cuda_rte_init(dev->opts.device_heap_size, dev->opts.gpu_id);
 	if (err) {
 		XNVME_DEBUG("FAILED: _cuda_rte_init(); err(%d)", err);
 		return err;

--- a/lib/upcie/xnvme_be_upcie_hip_dev.c
+++ b/lib/upcie/xnvme_be_upcie_hip_dev.c
@@ -25,7 +25,7 @@ _hip_rte_term(void)
 }
 
 static int
-_hip_rte_init(size_t heap_size)
+_hip_rte_init(size_t heap_size, uint32_t gpu_id)
 {
 	int err;
 
@@ -43,7 +43,7 @@ _hip_rte_init(size_t heap_size)
 		return -ENODEV;
 	}
 
-	err = hipSetDevice(0); // GPU ID 0
+	err = hipSetDevice(gpu_id);
 	if (err) {
 		XNVME_DEBUG("FAILED: hipSetDevice(); err(%d)", err);
 		return -ENODEV;
@@ -158,7 +158,7 @@ xnvme_be_upcie_hip_dev_open(struct xnvme_dev *dev)
 		return err;
 	}
 
-	err = _hip_rte_init(dev->opts.device_heap_size);
+	err = _hip_rte_init(dev->opts.device_heap_size, dev->opts.gpu_id);
 	if (err) {
 		XNVME_DEBUG("FAILED: _hip_rte_init(); err(%d)", err);
 		return err;

--- a/lib/xnvme_cli.c
+++ b/lib/xnvme_cli.c
@@ -636,6 +636,12 @@ static struct xnvme_cli_opt_attr xnvme_cli_opts[] = {
 		.descr = "For be=spdk, DPDK IOVA mode ('va' or 'pa')",
 	},
 	{
+		.opt = XNVME_CLI_OPT_GPU_ID,
+		.vtype = XNVME_CLI_OPT_VTYPE_NUM,
+		.name = "gpu_id",
+		.descr = "For be=upcie-cuda/upcie-hip, GPU ordinal to use",
+	},
+	{
 		.opt = XNVME_CLI_OPT_USE_CMB_SQS,
 		.vtype = XNVME_CLI_OPT_VTYPE_NUM,
 		.name = "use_cmb_sqs",
@@ -1446,6 +1452,9 @@ xnvme_cli_assign_arg(struct xnvme_cli *cli, struct xnvme_cli_opt_attr *opt_attr,
 	case XNVME_CLI_OPT_IOVA_MODE:
 		args->iova_mode = arg ? arg : "INVALID_INPUT";
 		break;
+	case XNVME_CLI_OPT_GPU_ID:
+		args->gpu_id = num;
+		break;
 	case XNVME_CLI_OPT_USE_CMB_SQS:
 		args->use_cmb_sqs = arg ? num : 0;
 		break;
@@ -2032,6 +2041,7 @@ xnvme_cli_to_opts(const struct xnvme_cli *cli, struct xnvme_opts *opts)
 		cli->given[XNVME_CLI_OPT_CORE_MASK] ? cli->args.core_mask : opts->core_mask;
 	opts->iova_mode =
 		cli->given[XNVME_CLI_OPT_IOVA_MODE] ? cli->args.iova_mode : opts->iova_mode;
+	opts->gpu_id = cli->given[XNVME_CLI_OPT_GPU_ID] ? cli->args.gpu_id : opts->gpu_id;
 	opts->adrfam = cli->given[XNVME_CLI_OPT_ADRFAM] ? cli->args.adrfam : opts->adrfam;
 	opts->subnqn = cli->given[XNVME_CLI_OPT_SUBNQN] ? cli->args.subnqn : opts->subnqn;
 	opts->hostnqn = cli->given[XNVME_CLI_OPT_HOSTNQN] ? cli->args.hostnqn : opts->hostnqn;

--- a/lib/xnvme_opts.c
+++ b/lib/xnvme_opts.c
@@ -89,6 +89,7 @@ xnvme_opts_yaml(FILE *stream, const struct xnvme_opts *opts, int indent, const c
 	wrtn += fprintf(stream, "%*shost_heap_size: %zu%s", indent, "", opts->host_heap_size, sep);
 	wrtn += fprintf(stream, "%*sdevice_heap_size: %zu%s", indent, "", opts->device_heap_size,
 			sep);
+	wrtn += fprintf(stream, "%*sgpu_id: %" PRIu32 "%s", indent, "", opts->gpu_id, sep);
 
 	return wrtn;
 }

--- a/tools/xnvmeperf/xnvmeperf.c
+++ b/tools/xnvmeperf/xnvmeperf.c
@@ -1409,6 +1409,7 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_DIRECT, XNVME_CLI_LFLG},
 			{XNVME_CLI_OPT_POLL_IO, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_POLL_SQ, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_GPU_ID, XNVME_CLI_LOPT},
 		},
 	},
 	{
@@ -1429,6 +1430,7 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_DIRECT, XNVME_CLI_LFLG},
 			{XNVME_CLI_OPT_POLL_IO, XNVME_CLI_LOPT},
 			{XNVME_CLI_OPT_POLL_SQ, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_GPU_ID, XNVME_CLI_LOPT},
 		},
 	},
 	{
@@ -1449,6 +1451,7 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_RUNTIME, XNVME_CLI_LREQ},
 			{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP},
 			{XNVME_CLI_OPT_BE, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_GPU_ID, XNVME_CLI_LOPT},
 		},
 	},
 	{
@@ -1467,6 +1470,7 @@ static struct xnvme_cli_sub g_subs[] = {
 			{XNVME_CLI_OPT_QDEPTH, XNVME_CLI_LREQ},
 			{XNVME_CLI_OPT_ORCH_TITLE, XNVME_CLI_SKIP},
 			{XNVME_CLI_OPT_BE, XNVME_CLI_LOPT},
+			{XNVME_CLI_OPT_GPU_ID, XNVME_CLI_LOPT},
 		},
 	},
 };


### PR DESCRIPTION
The `upcie-cuda` and `upcie-hip` P2P backends previously hardcoded GPU
ordinal 0 (`cuDeviceGet(&cu_dev, 0)` / `hipSetDevice(0)`), so there was no
way to target a specific GPU on a multi-GPU host. This adds a `gpu_id`
option that flows from `xnvme_opts` through the CLI framework down into
both backends.

The default is `0`, so existing behavior is unchanged.

### Naming: why `gpu_id` and not `device_id`

At first I wanted to name it `device_id`, since it plays nicely with the
existing `device_heap_size` option (both use "device" to mean the GPU).
However, I decided to avoid it because "device" is heavily overloaded in xNVMe. 
It almost always refers to the NVMe device (`struct xnvme_dev`, `--dev`, `dev_nsid`,
etc.), so `device_id` would be easy to misread as an NVMe device selector.
