### PR TITLE
doc: use @file instead of @headerfile in header doc-blocks

### DIFF
--- a/include/libxnvme_adm.h
+++ b/include/libxnvme_adm.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_adm.h
+ * @file libxnvme_adm.h
  */
 
 /**

--- a/include/libxnvme_be.h
+++ b/include/libxnvme_be.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_be.h
+ * @file libxnvme_be.h
  */
 
 /**

--- a/include/libxnvme_buf.h
+++ b/include/libxnvme_buf.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_buf.h
+ * @file libxnvme_buf.h
  */
 
 /**

--- a/include/libxnvme_cli.h
+++ b/include/libxnvme_cli.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_cli.h
+ * @file libxnvme_cli.h
  */
 
 #define XNVME_CLI_CORE_OPTS                                                                 \

--- a/include/libxnvme_cmd.h
+++ b/include/libxnvme_cmd.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_cmd.h
+ * @file libxnvme_cmd.h
  */
 
 /**

--- a/include/libxnvme_cuda.h
+++ b/include/libxnvme_cuda.h
@@ -10,7 +10,7 @@
  *
  * @note This API is experimental and may change without notice.
  *
- * @headerfile libxnvme_cuda.h
+ * @file libxnvme_cuda.h
  */
 
 #ifndef __LIBXNVME_CUDA_H

--- a/include/libxnvme_dev.h
+++ b/include/libxnvme_dev.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_dev.h
+ * @file libxnvme_dev.h
  */
 
 enum xnvme_enumerate_action {

--- a/include/libxnvme_file.h
+++ b/include/libxnvme_file.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_file.h
+ * @file libxnvme_file.h
  */
 
 /**

--- a/include/libxnvme_geo.h
+++ b/include/libxnvme_geo.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_geo.h
+ * @file libxnvme_geo.h
  */
 
 /**

--- a/include/libxnvme_ident.h
+++ b/include/libxnvme_ident.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_ident.h
+ * @file libxnvme_ident.h
  */
 
 #define XNVME_IDENT_URI_LEN 384

--- a/include/libxnvme_kvs.h
+++ b/include/libxnvme_kvs.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_kv.h
+ * @file libxnvme_kvs.h
  */
 
 /**

--- a/include/libxnvme_lba.h
+++ b/include/libxnvme_lba.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_lba.h
+ * @file libxnvme_lba.h
  */
 
 struct xnvme_lba_range_attr {

--- a/include/libxnvme_libconf.h
+++ b/include/libxnvme_libconf.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_libconf.h
+ * @file libxnvme_libconf.h
  */
 
 #ifndef __LIBXNVME_LIBCONF_H

--- a/include/libxnvme_mem.h
+++ b/include/libxnvme_mem.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_mem.h
+ * @file libxnvme_mem.h
  */
 
 /**

--- a/include/libxnvme_nvm.h
+++ b/include/libxnvme_nvm.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_nvm.h
+ * @file libxnvme_nvm.h
  */
 
 #ifndef __LIBXNVME_NVM_H

--- a/include/libxnvme_opts.h
+++ b/include/libxnvme_opts.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_adm.h
+ * @file libxnvme_opts.h
  */
 
 struct xnvme_opts_css {

--- a/include/libxnvme_pi.h
+++ b/include/libxnvme_pi.h
@@ -4,7 +4,7 @@
  * Copyright (C) Samsung Electronics Co., Ltd
  * All rights reserved.
  *
- * @headerfile libxnvme_pi.h
+ * @file libxnvme_pi.h
  */
 
 #ifndef __INTERNAL_XNVME_PI_H

--- a/include/libxnvme_pp.h
+++ b/include/libxnvme_pp.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_pp.h
+ * @file libxnvme_pp.h
  */
 
 /**

--- a/include/libxnvme_queue.h
+++ b/include/libxnvme_queue.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_adm.h
+ * @file libxnvme_queue.h
  */
 
 /**

--- a/include/libxnvme_scan.h
+++ b/include/libxnvme_scan.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_scan.h
+ * @file libxnvme_scan.h
  */
 
 /**

--- a/include/libxnvme_spec.h
+++ b/include/libxnvme_spec.h
@@ -33,7 +33,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_spec.h
+ * @file libxnvme_spec.h
  */
 
 /**

--- a/include/libxnvme_spec_fs.h
+++ b/include/libxnvme_spec_fs.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_spec_fs.h
+ * @file libxnvme_spec_fs.h
  */
 
 #ifndef __LIBXNVME_SPEC_FS_H

--- a/include/libxnvme_spec_pp.h
+++ b/include/libxnvme_spec_pp.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_spec_pp.h
+ * @file libxnvme_spec_pp.h
  */
 
 /**

--- a/include/libxnvme_topology.h
+++ b/include/libxnvme_topology.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_topology.h
+ * @file libxnvme_topology.h
  */
 
 struct xnvme_subsystem {

--- a/include/libxnvme_util.h
+++ b/include/libxnvme_util.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_util.h
+ * @file libxnvme_util.h
  */
 
 #define XNVME_UNIVERSAL_SECT_SH 9

--- a/include/libxnvme_ver.h
+++ b/include/libxnvme_ver.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_ver.h
+ * @file libxnvme_ver.h
  */
 
 /**

--- a/include/libxnvme_znd.h
+++ b/include/libxnvme_znd.h
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
- * @headerfile libxnvme_znd.h
+ * @file libxnvme_znd.h
  */
 
 #ifndef __LIBXNVME_ZND_H


### PR DESCRIPTION
The file-level doc-block in each public header used the Doxygen command @headerfile, which is meant for documenting which header a class is declared in - not for documenting a file. As a result Doxygen did not treat the block as file documentation and instead attached it to the first declaration in the file, leaking the SPDX license header into the docstring of e.g. xnvme_nvm_read.

Switch these blocks to @file, matching libxnvme.h which already did so. While here, correct the file names on the blocks that had been copy-pasted with the wrong name (opts/queue referenced libxnvme_adm.h, kvs referenced libxnvme_kv.h).

Closes #713