### PR TITLE
doc(libxnvme_nvm): fix and standardize command descriptions

### DIFF
--- a/include/libxnvme_cmd.h
+++ b/include/libxnvme_cmd.h
@@ -102,6 +102,12 @@ xnvme_cmd_ctx_cpl_status(struct xnvme_cmd_ctx *ctx)
 /**
  * Pass an NVMe IO Command through to the device via the given ::xnvme_cmd_ctx
  *
+ * The mode of submission is determined by the command context: a context
+ * obtained via xnvme_cmd_ctx_from_dev() submits synchronously and returns once
+ * the command has completed, whereas a context obtained via
+ * xnvme_cmd_ctx_from_queue() submits asynchronously and returns once the command
+ * has been submitted; its completion is then processed via xnvme_queue_poke().
+ *
  * @param ctx Pointer to command context (::xnvme_cmd_ctx)
  * @param dbuf pointer to data-payload
  * @param dbuf_nbytes size of data-payload in bytes

--- a/include/libxnvme_nvm.h
+++ b/include/libxnvme_nvm.h
@@ -76,13 +76,16 @@ int
 xnvme_nvm_write_zeroes(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t slba, uint16_t nlb);
 
 /**
- * Submit, and optionally wait for completion of, a NVMe Write
+ * Prepare a NVMe command context for an I/O command
+ *
+ * This populates the command fields in the given context, it does not submit
+ * the command. Submit it with e.g. ::xnvme_cmd_pass.
  *
  * @param ctx Pointer to command context (::xnvme_cmd_ctx)
  * @param opcode Opcode for the NVMe command
  * @param nsid Namespace Identifier
- * @param slba The LBA to start the write at
- * @param nlb Number of LBAs to be written. NOTE: nlb is a zero-based value
+ * @param slba The LBA to start the operation at
+ * @param nlb Number of LBAs. NOTE: nlb is a zero-based value
  */
 void
 xnvme_prep_nvm(struct xnvme_cmd_ctx *ctx, uint8_t opcode, uint32_t nsid, uint64_t slba,

--- a/include/libxnvme_nvm.h
+++ b/include/libxnvme_nvm.h
@@ -16,7 +16,7 @@ extern "C" {
 #include <libxnvme.h>
 
 /**
- * Submit, and optionally wait for completion of, a NVMe Read
+ * Submit a NVMe Read command
  *
  * @param ctx Pointer to command context (::xnvme_cmd_ctx)
  * @param nsid Namespace Identifier
@@ -32,7 +32,7 @@ xnvme_nvm_read(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t slba, uint16_t
 	       void *mbuf);
 
 /**
- * Submit, and optionally wait for completion of, a NVMe Write
+ * Submit a NVMe Write command
  *
  * @param ctx Pointer to command context (::xnvme_cmd_ctx)
  * @param nsid Namespace Identifier
@@ -48,7 +48,7 @@ xnvme_nvm_write(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t slba, uint16_
 		const void *dbuf, const void *mbuf);
 
 /**
- * Submit a write uncorrected command
+ * Submit a NVMe Write Uncorrectable command
  *
  * @param ctx Pointer to command context (::xnvme_cmd_ctx)
  * @param nsid Namespace Identifier
@@ -60,7 +60,7 @@ xnvme_nvm_write_uncorrectable(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t
 			      uint16_t nlb);
 
 /**
- * Submit a write zeroes command
+ * Submit a NVMe Write Zeroes command
  *
  * @see xnvme_cmd_opts
  *
@@ -92,7 +92,7 @@ xnvme_prep_nvm(struct xnvme_cmd_ctx *ctx, uint8_t opcode, uint32_t nsid, uint64_
 	       uint16_t nlb);
 
 /**
- * Submit, and optionally wait for completion of a NVMe Simple-Copy-Command
+ * Submit a NVMe Simple-Copy command
  *
  * @see xnvme_cmd_opts
  *
@@ -112,7 +112,9 @@ xnvme_nvm_scopy(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint64_t sdlba,
 		enum xnvme_nvm_scopy_fmt copy_fmt);
 
 /**
- * Deallocate or hint at read/write usage of a range.
+ * Submit a NVMe Dataset Management command
+ *
+ * Deallocate or hint at read/write usage of the given ranges.
  *
  * @param ctx Pointer to command context (::xnvme_cmd_ctx)
  * @param nsid Namespace Identifier
@@ -129,7 +131,7 @@ xnvme_nvm_dsm(struct xnvme_cmd_ctx *ctx, uint32_t nsid, struct xnvme_spec_dsm_ra
 	      uint8_t nr, bool ad, bool idw, bool idr);
 
 /**
- * Submit, and wait for completion of a I/O management receive command
+ * Submit a NVMe I/O Management Receive command
  *
  * @see xnvme_cmd_opts
  *
@@ -147,7 +149,7 @@ xnvme_nvm_mgmt_recv(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t mo, uint16
 		    uint32_t dbuf_nbytes);
 
 /**
- * Submit, and wait for completion of a I/O management send command
+ * Submit a NVMe I/O Management Send command
  *
  * @see xnvme_cmd_opts
  *
@@ -165,7 +167,7 @@ xnvme_nvm_mgmt_send(struct xnvme_cmd_ctx *ctx, uint32_t nsid, uint8_t mo, uint16
 		    uint32_t dbuf_nbytes);
 
 /**
- * Submit, and optionally wait for completion of, a NVMe Compare
+ * Submit a NVMe Compare command
  *
  * @param ctx Pointer to command context (::xnvme_cmd_ctx)
  * @param nsid Namespace Identifier


### PR DESCRIPTION
Fixes the incorrect `xnvme_prep_nvm` documentation reported in #712 and
standardizes the surrounding command descriptions in `libxnvme_nvm.h`.

Closes #712 