### PR TITLE
 Make FreeBSD contigmem buffer size configurable

### DIFF
--- a/cijoe/tests/conftest.py
+++ b/cijoe/tests/conftest.py
@@ -207,7 +207,13 @@ class XnvmeDriver(object):
     def kernel_detach(cijoe):
         """Detach from kernel"""
 
-        err, _ = cijoe.run("xnvme-driver")
+        # 64MB contigmem buffers avoid ENOMEM on FreeBSD's fragmented CI heap;
+        # see toolbox/xnvme-driver.sh.
+        cmd = "xnvme-driver"
+        if get_osname() == "freebsd":
+            cmd = "env CONTIGMEM_BUFSZ=64 " + cmd
+
+        err, _ = cijoe.run(cmd)
         if err:
             cijoe.run("dmesg | tail -n20")
 

--- a/cijoe/tests/logic/test_xnvme_tests_buf.py
+++ b/cijoe/tests/logic/test_xnvme_tests_buf.py
@@ -3,7 +3,11 @@ from ..conftest import xnvme_parametrize
 
 @xnvme_parametrize(["dev"], opts=["be"])
 def test_buf_alloc_free(cijoe, device, be_opts, cli_args):
-    err, _ = cijoe.run(f"xnvme_tests_buf buf_alloc_free {cli_args} --count 28")
+    # count=27 caps the largest allocation at 1<<26 (64MB). On FreeBSD a single
+    # DMA buffer cannot exceed one contigmem buffer, which the CI sizes at 64MB
+    # (CONTIGMEM_BUFSZ in conftest.py); the test only exercises functionality,
+    # not allocation limits, so keep it at/under that ceiling.
+    err, _ = cijoe.run(f"xnvme_tests_buf buf_alloc_free {cli_args} --count 27")
     assert not err
 
 

--- a/docs/background/platforms/freebsd/index.md
+++ b/docs/background/platforms/freebsd/index.md
@@ -10,6 +10,29 @@ FreeBSD is one of several supported platforms. **xNVMe** is likely to work on
 multiple versions of FreeBSD, however to ensure compatibility we recommend using
 a version listed in the {ref}`sec-toolchain` section.
 
+(sec-platforms-freebsd-contigmem)=
+
+### User-space DMA memory (`contigmem`)
+
+The `spdk` backend gets its DMA memory from the `contigmem` kernel module,
+which the `xnvme-driver` script loads. It pre-allocates a pool of
+physically-contiguous buffers, `CONTIGMEM_BUFSZ` MB each (`256` by default), up
+to a total of `HUGEMEM` MB (`2048` by default). The pool holds at most 64
+buffers, so `HUGEMEM / CONTIGMEM_BUFSZ` must not exceed 64.
+
+`CONTIGMEM_BUFSZ` is a hard upper bound on a single DMA allocation: a buffer
+cannot span multiple `contigmem` buffers, so `xnvme_buf_alloc()` cannot return
+more than `CONTIGMEM_BUFSZ` MB no matter how much of the pool is free.
+
+On a fragmented heap, a large physically-contiguous buffer can be impossible to
+place even when plenty of memory is free, and loading `contigmem` then fails
+with `contigmalloc failed for buffer N` in `dmesg`. Smaller buffers are easier
+to place, so lowering `CONTIGMEM_BUFSZ` avoids the failure:
+
+```bash
+CONTIGMEM_BUFSZ=64 xnvme-driver
+```
+
 (sec-platforms-freebsd-identification)=
 
 ## Device Identification

--- a/toolbox/xnvme-driver.sh
+++ b/toolbox/xnvme-driver.sh
@@ -219,6 +219,11 @@ function usage()
 	echo "                  For NUMA systems, the hugepages will be evenly distributed"
 	echo "                  between CPU nodes"
 	echo "NRHUGE            Number of hugepages to allocate. This variable overwrites HUGEMEM."
+	echo "CONTIGMEM_BUFSZ   FreeBSD only. Size of each contigmem buffer (in MB). 256 by default."
+	echo "                  Sets the ceiling for a single physically-contiguous DMA allocation."
+	echo "                  Smaller buffers are more reliable on a fragmented heap; larger ones"
+	echo "                  allow bigger single allocations. HUGEMEM/CONTIGMEM_BUFSZ must not"
+	echo "                  exceed RTE_CONTIGMEM_MAX_NUM_BUFS (64)."
 	echo "HUGENODE          Specific NUMA node to allocate hugepages on. To allocate"
 	echo "                  hugepages on multiple nodes run this script multiple times -"
 	echo "                  once for each node."
@@ -812,16 +817,24 @@ function configure_freebsd_pci {
 
 function configure_freebsd {
 	configure_freebsd_pci
+
+	# Assemble the contigmem pool from CONTIGMEM_BUFSZ-sized buffers. Smaller
+	# buffers are more reliable on a fragmented heap, where contigmalloc(9) can
+	# fail with ENOMEM for large physically-contiguous runs; the pool size
+	# (HUGEMEM) is unchanged. See usage() for CONTIGMEM_BUFSZ.
+	local bufsz_mb=$CONTIGMEM_BUFSZ
+	local num_buffers=$((HUGEMEM / bufsz_mb))
+
 	# If contigmem is already loaded but the HUGEMEM specified doesn't match the
 	#  previous value, unload contigmem so that we can reload with the new value.
 	if kldstat -q -m contigmem; then
-		if [ $(kenv hw.contigmem.num_buffers) -ne "$((HUGEMEM / 256))" ]; then
+		if [ $(kenv hw.contigmem.num_buffers) -ne "$num_buffers" ]; then
 			kldunload contigmem.ko
 		fi
 	fi
 	if ! kldstat -q -m contigmem; then
-		kenv hw.contigmem.num_buffers=$((HUGEMEM / 256))
-		kenv hw.contigmem.buffer_size=$((256 * 1024 * 1024))
+		kenv hw.contigmem.num_buffers=$num_buffers
+		kenv hw.contigmem.buffer_size=$((bufsz_mb * 1024 * 1024))
 		kldload contigmem.ko
 	fi
 }
@@ -838,6 +851,7 @@ if [ -z "$mode" ]; then
 fi
 
 : ${HUGEMEM:=2048}
+: ${CONTIGMEM_BUFSZ:=256}
 : ${PCI_WHITELIST:=""}
 : ${PCI_BLACKLIST:=""}
 


### PR DESCRIPTION
Loading `contigmem` intermittently failed on the FreeBSD CI with
`contigmalloc failed for buffer N` / `ENOMEM`, even though the VM had gigabytes
free. `contigmalloc(9)` cannot relocate wired pages, and the ~2GB of wired
DMA/kernel memory scattered across the heap (11 emulated NVMe controllers plus
the IOMMU) leaves too few regions large enough for a 256MB buffer.

This makes the size configurable so CI can use small buffers while other setups keep the larger default.