### PR TITLE
fix(tests/map): unmap buffers and re-enable mem_map_unmap on Trixie

### DIFF
--- a/cijoe/workflows/test-debian-trixie-iommu_enabled-pcie.yaml
+++ b/cijoe/workflows/test-debian-trixie-iommu_enabled-pcie.yaml
@@ -45,5 +45,5 @@ steps:
 - name: test_pcie
   uses: core.testrunner
   with:
-    args: '-k "pcie and not upcie and not test_mem_map_unmap" tests'
+    args: '-k "pcie and not upcie" tests'
     random_order: false

--- a/tests/map.c
+++ b/tests/map.c
@@ -38,12 +38,20 @@ test_mem_map_unmap(struct xnvme_cli *cli)
 		if (err) {
 			xnvme_cli_perr("xnvme_mem_map()", -errno);
 			nerr += 1;
+			munmap(buf, buf_nbytes);
 			continue;
 		}
 
 		err = xnvme_mem_unmap(cli->args.dev, buf);
 		if (err) {
 			xnvme_cli_perr("xnvme_mem_unmap()", -errno);
+			nerr += 1;
+			munmap(buf, buf_nbytes);
+			continue;
+		}
+
+		if (munmap(buf, buf_nbytes)) {
+			xnvme_cli_perr("munmap()", -errno);
 			nerr += 1;
 			continue;
 		}


### PR DESCRIPTION
Fixes #630 by removing the hack that disabled `test_mem_map_unmap` on
Debian Trixie and addressing the underlying resource leak in the test.

Closes #630