### PR TITLE
test(kvs): fix test_list under NumPy 2.x and re-enable it on Debian Trixie

### DIFF
--- a/cijoe/workflows/test-debian-trixie-iommu_disabled-pcie.yaml
+++ b/cijoe/workflows/test-debian-trixie-iommu_disabled-pcie.yaml
@@ -19,7 +19,7 @@ steps:
   with:
     # Mirror trixie's python tests minus libvfn (needs vfio-pci).
     args: '{{ config.xnvme.repository.sync.remote_path }}/python/tests --timeout=60 --timeout-method=thread -k "not fabrics
-      and not libvfn and not test_list"'
+      and not libvfn"'
     run_local: false
     random_order: false
 

--- a/cijoe/workflows/test-debian-trixie-iommu_enabled-pcie.yaml
+++ b/cijoe/workflows/test-debian-trixie-iommu_enabled-pcie.yaml
@@ -26,7 +26,7 @@ steps:
   uses: core.testrunner
   with:
     args: '{{ config.xnvme.repository.sync.remote_path }}/python/tests --timeout=60 --timeout-method=thread -k "not fabrics
-      and not libvfn and not test_list"'
+      and not libvfn"'
     run_local: false
     random_order: false
 

--- a/python/tests/test_key_value.py
+++ b/python/tests/test_key_value.py
@@ -363,13 +363,13 @@ class TestKeyValue:
 
         def unpack_list_data(list_data):
             num_keys = int(
-                list_data[:4].view(np.uint32)
+                list_data[:4].view(np.uint32)[0]
             )  # First 32 bits define the number of keys
             key_data = list_data[4:]  # The initial key data
             read_keys = []
             for _ in range(num_keys):
                 # Extract key length from data
-                kbuf_nbytes = int(key_data[:2].view(np.uint16))
+                kbuf_nbytes = int(key_data[:2].view(np.uint16)[0])
                 assert kbuf_nbytes <= 16, "Invalid key length"
 
                 # Extract key name from data


### PR DESCRIPTION
Closes #631

## Summary

`test_list` in `python/tests/test_key_value.py` was disabled on the Debian Trixie
PCIe workflows (in #629) because it failed there. This fixes the actual cause —
a NumPy 2.x incompatibility — and re-enables the test.

## Root cause

`unpack_list_data()` decodes the KV List response by converting one-element
NumPy arrays to Python ints, e.g. `int(buf[:4].view(np.uint32))`. Debian Trixie
ships **NumPy 2.x** (with Python 3.12), which no longer converts a one-element
(1-D) array to a scalar implicitly and raises:

TypeError: only 0-dimensional arrays can be converted to Python scalars

NumPy 1.x accepted this, so it only shows up on Trixie. It is **backend-
independent** — the KV device and List command work correctly (the response
header decodes to 260 keys) — which is why it failed both before and after the
switch to `vfu_kvssd`, and matches the "Python 3.12+" environmental change noted
when the test was disabled.

## Fix

Index the single element before `int()`, e.g.
`int(buf[:4].view(np.uint32)[0])`, in the two conversions in
`unpack_list_data()`. This works on both NumPy 1.x and 2.x. No other test logic
changes.