### PR TITLE
test(cijoe): enable uPCIe in IOMMU-enabled verify workflow

### DIFF
--- a/cijoe/workflows/test-debian-trixie-iommu_enabled-pcie.yaml
+++ b/cijoe/workflows/test-debian-trixie-iommu_enabled-pcie.yaml
@@ -45,5 +45,5 @@ steps:
 - name: test_pcie
   uses: core.testrunner
   with:
-    args: '-k "pcie and not upcie" tests'
+    args: '-k "pcie" tests'
     random_order: false


### PR DESCRIPTION
uPCIe gained vfio-pci support in #661. Under IOMMU the pcie-labelled devices are already bound to vfio-pci for the libvfn/spdk tests, so drop the "not upcie" exclusion to let the uPCIe backend run there too.

Closes #669