### PR TITLE
fix(readme): use correct URL for CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ SPDX-License-Identifier: BSD-3-Clause
 xNVMe: cross-platform libraries and tools for NVMe devices
 ==========================================================
 
-[![CI](https://github.com/xnvme/xnvme/workflows/linux-binaries-test/badge.svg)](https://github.com/xnvme/xnvme/actions/)
-[![CI](https://github.com/xnvme/xnvme/workflows/linux-build-test/badge.svg)](https://github.com/xnvme/xnvme/actions/)
-[![CI](https://github.com/xnvme/xnvme/workflows/style/badge.svg)](https://github.com/xnvme/xnvme/actions/)
+[![CI](https://github.com/xnvme/xnvme/workflows/verify/badge.svg)](https://github.com/xnvme/xnvme/actions/)
 [![Coverity](https://scan.coverity.com/projects/xNVMe/badge.svg)](https://scan.coverity.com/projects/xNVMe)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![REUSE status](https://api.reuse.software/badge/github.com/xnvme/xnvme)](https://api.reuse.software/info/github.com/xnvme/xnvme)


### PR DESCRIPTION
For a long time, we've only had a single Github Actions workflow running, so the badges in the readme has been broken. This should correctly reflect the state of our CI with the badge.

Before:
<img width="805" height="143" alt="image" src="https://github.com/user-attachments/assets/c9084916-ec19-404b-abf4-f03f44a285f3" />

After:
<img width="823" height="146" alt="image" src="https://github.com/user-attachments/assets/e4e9c817-e32b-4368-ae24-552ccd64c3a8" />
